### PR TITLE
Fix for 'id' vs 'pk' in MP_Node

### DIFF
--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -447,7 +447,7 @@ class MP_Node(Node):
         :returns: A queryset of all the node's descendants as DFS, doesn't
             include the node itself
         """
-        return self.__class__.get_tree(self).exclude(pk=self.id)
+        return self.__class__.get_tree(self).exclude(pk=self.pk)
 
     def get_prev_sibling(self):
         """


### PR DESCRIPTION
This is just a quick fix for MP_Node.get_descendants, to allow for models that have a primary key named something other than 'id'.

Cheers,

Kerin
