### PR TITLE
Added .order_by() to get_root_nodes

### DIFF
--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -340,7 +340,7 @@ class MP_Node(Node):
     @classmethod
     def get_root_nodes(cls):
         ":returns: A queryset containing the root nodes in the tree."
-        return cls.objects.filter(depth=1)
+        return cls.objects.filter(depth=1).order_by("path")
 
     @classmethod
     def get_descendants_group_count(cls, parent=None):


### PR DESCRIPTION
Treebeard works great unless you're working off of an database import that inserted the records out of sequential order, then suddenly `cls.objects.filter(depth=1)` doesn't return a list of paths with the most recent one on the end... something you need when you're trying to get the `last_root`.

Without this patch, projects with the aforementioned database import will often suffer from `duplicate key value violates unique constraint` complaints during .add_root(), as Treebeard unintentionally attempts to add a new root where one already exists.
