### PR TITLE
removed adminmedia reference from template

### DIFF
--- a/treebeard/templates/admin/tree_change_list.html
+++ b/treebeard/templates/admin/tree_change_list.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_list.html" %}
-{% load adminmedia admin_list admin_tree i18n %}
+{% load admin_list admin_tree i18n %}
 
 {% block extrastyle %}
 {{block.super}}


### PR DESCRIPTION
The adminmedia tag was removed in django 1.5 which was causing an error when using TreeAdmin. It looks like it was not actually used here, just leftover.
