### PR TITLE
Fix compatibility with jQuery 1.8+.

### DIFF
--- a/treebeard/static/treebeard/treebeard-admin.js
+++ b/treebeard/static/treebeard/treebeard-admin.js
@@ -72,7 +72,7 @@
 
         // begin csrf token code
         // Taken from http://docs.djangoproject.com/en/dev/ref/contrib/csrf/#ajax
-        $('html').ajaxSend(function (event, xhr, settings) {
+        $(document).ajaxSend(function (event, xhr, settings) {
             function getCookie(name) {
                 var cookieValue = null;
                 if (document.cookie && document.cookie != '') {
@@ -301,7 +301,7 @@
     function c(g, e) {
         var f;
         do {
-            f = d.curCSS(g, e);
+            f = d.css(g, e);
             if (f != "" && f != "transparent" || d.nodeName(g, "body")) {
                 break
             }


### PR DESCRIPTION
Django 1.6 uses a newer jQuery, and a couple things in treebeard-admin.js were not compatible with newer jQuery. This pull request fixes those; the fixes are backwards compatible at least as far as jQuery 1.3, and Django 1.3 already used jQuery 1.4.2, so there should be no back-compat issues here.
