### PR TITLE
Include static assets in dist tarball.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include CHANGES LICENSE NOTICE README.rst UPDATING MANIFEST.in
 recursive-include docs Makefile README.rst *.py *.rst
-recursive-include treebeard *.py *.html
+recursive-include treebeard *.py *.html *.js *.css *.png


### PR DESCRIPTION
Previously `python setup.py sdist` resulted in a bad sdist tarball, missing the static assets. This fixes `MANIFEST.in` so that those files are included in the sdist.
