### PR TITLE
Don't cache db connections on a model class.

### DIFF
--- a/treebeard/models.py
+++ b/treebeard/models.py
@@ -590,12 +590,10 @@ class Node(models.Model):
 
     @classmethod
     def _get_database_connection(cls, action):
-        if cls._db_connection is None:
-            cls._db_connection = {
-                'read': connections[router.db_for_read(cls)],
-                'write': connections[router.db_for_write(cls)]
-            }
-        return cls._db_connection[action]
+        return {
+            'read': connections[router.db_for_read(cls)],
+            'write': connections[router.db_for_write(cls)]
+            }[action]
 
     @classmethod
     def get_database_vendor(cls, action):


### PR DESCRIPTION
Django 1.6 ensures thread-safe use of database connections by only allowing a database connection to be used in the thread that created it (https://github.com/django/django/blob/master/django/db/backends/__init__.py#L447). Treebeard's caching of db connections on the `Node` class means that sometimes connections will be used in the wrong thread, causing intermittent `DatabaseError`s under a threaded webserver (such as `runserver`). This pull request fixes that by simply removing the caching of connections and getting them from the router each time they are needed.

If this is a significant slowdown (I doubt it, but haven't benchmarked), the caching could be reintroduced, but needs to be keyed by thread ID.
