### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+# Use the faster container-based infrastructure
+# https://docs.travis-ci.com/user/ci-environment/
+sudo: false
+
+language: python
+
+python:
+    - 2.7
+    - 3.4
+    - 3.5
+
+env:
+    - DJANGO="Django>=1.7,<1.8"
+    - DJANGO="Django>=1.8,<1.9"
+    - DJANGO="Django>=1.9,<1.10"
+    - DJANGO="Django>=1.10,<1.11"
+
+matrix:
+    exclude:
+        # Python 3.5 is not supported by Django 1.7
+        - python: 3.5
+          env: 'DJANGO="Django>=1.7,<1.8"'
+
+install:
+    - pip install $DJANGO "pytest>3.0"
+    # Useful for debugging
+    - pip freeze
+
+script: pytest

--- a/README.rst
+++ b/README.rst
@@ -21,10 +21,18 @@ django-treebeard is:
 - **Clean**: Testable and well tested code base. Code/branch test coverage is above
   96%. Tests are available in Jenkins:
 
-  - Test suite running on different versions of Python, Django and database
-    engine: https://tabo.pe/jenkins/job/django-treebeard/
-  - Code quality: https://tabo.pe/jenkins/job/django-treebeard-quality/
+  - Test suite running on different versions of Python and Django:
+    https://travis-ci.org/django-treebeard/django-treebeard/
 
 You can find the documentation in
 
     http://django-treebeard.readthedocs.io/en/latest/
+
+Supported versions
+==================
+
+**django-treebeard** supports
+
+* Django 1.7 - 1.10
+* Python 2.7, 3.4, 3.5
+* PostgreSQL, MySQL, SQLite database back-ends (others are untested)


### PR DESCRIPTION
This PR implements basic Travis support. It tests against the documented versions of Django and Python.

We're not yet testing against Postgres and MySQL, and we're not checking coverage. I'll have a fiddle with that another time. 

I also want to update the tox.ini, but am tempted to drop testing against different database backends there. That would make tox 3 times faster, and I sort of feel right now it's almost useless because it's too slow for me to care. Also, it's a bit of a hassle to get MySQL and PostgreSQL configured appropriately, so I doubt people will care enough.