### PR TITLE
Update test infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,43 +4,100 @@ sudo: false
 
 language: python
 
-python:
-    - 2.7
-    - 3.4
-    - 3.5
-
-env:
-    - DJANGO="Django>=1.8,<1.9" DATABASE_ENGINE="sqlite"
-    - DJANGO="Django>=1.9,<1.10" DATABASE_ENGINE="sqlite"
-    - DJANGO="Django>=1.10,<1.11" DATABASE_ENGINE="sqlite"
-
-    - DJANGO="Django>=1.8,<1.9" DATABASE_ENGINE="psql"
-    - DJANGO="Django>=1.9,<1.10" DATABASE_ENGINE="psql"
-    - DJANGO="Django>=1.10,<1.11" DATABASE_ENGINE="psql"
-
-    - DJANGO="Django>=1.8,<1.9" DATABASE_ENGINE="mysql"
-    - DJANGO="Django>=1.9,<1.10" DATABASE_ENGINE="mysql"
-    - DJANGO="Django>=1.10,<1.11" DATABASE_ENGINE="mysql"
-
-install:
-    - pip install $DJANGO
-    - pip install -r requirements_test.txt
-    # Add project to Python path
-    - pip install -e .
-    # Useful for debugging
-    - pip freeze
-
 addons:
   # Newest available version currently
   postgresql: "9.4"
+
+
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV=py27-dj18-sqlite
+    - python: 2.7
+      env: TOXENV=py27-dj19-sqlite
+    - python: 2.7
+      env: TOXENV=py27-dj110-sqlite
+    - python: 3.4
+      env: TOXENV=py34-dj18-sqlite
+    - python: 3.4
+      env: TOXENV=py34-dj19-sqlite
+    - python: 3.4
+      env: TOXENV=py34-dj110-sqlite
+    - python: 3.5
+      env: TOXENV=py35-dj18-sqlite
+    - python: 3.5
+      env: TOXENV=py35-dj19-sqlite
+    - python: 3.5
+      env: TOXENV=py35-dj110-sqlite
+    - python: 3.6
+      env: TOXENV=py36-dj18-sqlite
+    - python: 3.6
+      env: TOXENV=py36-dj19-sqlite
+    - python: 3.6
+      env: TOXENV=py36-dj110-sqlite
+
+    - python: 2.7
+      env: TOXENV=py27-dj18-postgres
+    - python: 2.7
+      env: TOXENV=py27-dj19-postgres
+    - python: 2.7
+      env: TOXENV=py27-dj110-postgres
+    - python: 3.4
+      env: TOXENV=py34-dj18-postgres
+    - python: 3.4
+      env: TOXENV=py34-dj19-postgres
+    - python: 3.4
+      env: TOXENV=py34-dj110-postgres
+    - python: 3.5
+      env: TOXENV=py35-dj18-postgres
+    - python: 3.5
+      env: TOXENV=py35-dj19-postgres
+    - python: 3.5
+      env: TOXENV=py35-dj110-postgres
+    - python: 3.6
+      env: TOXENV=py36-dj18-postgres
+    - python: 3.6
+      env: TOXENV=py36-dj19-postgres
+    - python: 3.6
+      env: TOXENV=py36-dj110-postgres
+
+    - python: 2.7
+      env: TOXENV=py27-dj18-mysql
+    - python: 2.7
+      env: TOXENV=py27-dj19-mysql
+    - python: 2.7
+      env: TOXENV=py27-dj110-mysql
+    - python: 3.4
+      env: TOXENV=py34-dj18-mysql
+    - python: 3.4
+      env: TOXENV=py34-dj19-mysql
+    - python: 3.4
+      env: TOXENV=py34-dj110-mysql
+    - python: 3.5
+      env: TOXENV=py35-dj18-mysql
+    - python: 3.5
+      env: TOXENV=py35-dj19-mysql
+    - python: 3.5
+      env: TOXENV=py35-dj110-mysql
+    - python: 3.6
+      env: TOXENV=py36-dj18-mysql
+    - python: 3.6
+      env: TOXENV=py36-dj19-mysql
+    - python: 3.6
+      env: TOXENV=py36-dj110-mysql
+
+
+install:
+  - pip install tox codecov
+
 
 # Create MySQL and Postgres databases
 before_script:
   - psql -c 'create database travis_ci_test;' -U postgres
   - mysql -e 'CREATE DATABASE IF NOT EXISTS travis_ci_test;' -uroot
 
-script: pytest
+script: tox
 
 # Can discuss again if somebody wants them.
 notifications:
-    email: false
+  email: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,17 +1,13 @@
+services:
+  - mssql2016
+
 environment:
   matrix:
-    - TOXENV: py27-dj18-sqlite
-    - TOXENV: py34-dj18-sqlite
-    - TOXENV: py35-dj18-sqlite
-    - TOXENV: py36-dj18-sqlite
-    - TOXENV: py27-dj19-sqlite
-    - TOXENV: py34-dj19-sqlite
-    - TOXENV: py35-dj19-sqlite
-    - TOXENV: py36-dj19-sqlite
-    - TOXENV: py27-dj110-sqlite
-    - TOXENV: py34-dj110-sqlite
-    - TOXENV: py35-dj110-sqlite
-    - TOXENV: py36-dj110-sqlite
+    - TOXENV: py27-dj18-mssql
+    - TOXENV: py27-dj19-mssql
+    - TOXENV: py27-dj110-mssql
+    - TOXENV: py35-dj19-mssql
+    - TOXENV: py36-dj110-mssql
 
 matrix:
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,27 +1,22 @@
 environment:
   matrix:
-    - TOXENV: py27-dj18
-      DATABASE_ENGINE: sqlite
-    - TOXENV: py34-dj18
-      DATABASE_ENGINE: sqlite
-    - TOXENV: py35-dj18
-      DATABASE_ENGINE: sqlite
-    - TOXENV: py36-dj18
-      DATABASE_ENGINE: sqlite
-    - TOXENV: py27-dj10
-      DATABASE_ENGINE: sqlite
-    - TOXENV: py34-dj10
-      DATABASE_ENGINE: sqlite
-    - TOXENV: py35-dj10
-      DATABASE_ENGINE: sqlite
-    - TOXENV: py36-dj10
-      DATABASE_ENGINE: sqlite
+    - TOXENV: py27-dj18-sqlite
+    - TOXENV: py34-dj18-sqlite
+    - TOXENV: py35-dj18-sqlite
+    - TOXENV: py36-dj18-sqlite
+    - TOXENV: py27-dj19-sqlite
+    - TOXENV: py34-dj19-sqlite
+    - TOXENV: py35-dj19-sqlite
+    - TOXENV: py36-dj19-sqlite
+    - TOXENV: py27-dj110-sqlite
+    - TOXENV: py34-dj110-sqlite
+    - TOXENV: py35-dj110-sqlite
+    - TOXENV: py36-dj110-sqlite
 
 matrix:
   fast_finish: true
 
 install:
-  - echo.pytest > requirements_test.txt
   - C:\Python36\python -m pip install tox
 
 build: false  # Not a C# project

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,5 +1,0 @@
-# Dependencies needed for individual (tox, Travis) test runs
-
-pytest>3.0
-psycopg2>2.6
-mysqlclient>=1.3.9

--- a/tox.ini
+++ b/tox.ini
@@ -6,10 +6,10 @@
 
 [tox]
 envlist =
-    {py27,py34,py35,py36}-{dj18,dj19,dj110}-{sqlite,postgres,mysql}
+    {py27,py34,py35,py36}-{dj18,dj19,dj110}-{sqlite,postgres,mysql,mssql}
 
 [testenv:docs]
-basepython=python
+basepython = python
 changedir = docs
 deps =
     Sphinx
@@ -25,9 +25,13 @@ deps =
     dj110: Django>=1.10,<1.11
     postgres: psycopg2>=2.6
     mysql: mysqlclient>=1.3.9
+    dj18-mssql: django-pyodbc-azure==1.8.13.0
+    dj19-mssql: django-pyodbc-azure==1.9.6.0
+    dj110-mssql: django-pyodbc-azure==1.10.4.0
 
 setenv = 
     sqlite: DATABASE_ENGINE=sqlite
     postgres: DATABASE_ENGINE=psql
     mysql: DATABASE_ENGINE=mysql
+    mssql: DATABASE_ENGINE=mssql
 commands = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 
 [tox]
 envlist =
-    {py27,py34,py35}-{dj18,dj19,dj10}
+    {py27,py34,py35,py36}-{dj18,dj19,dj110}-{sqlite,postgres,mysql}
 
 [testenv:docs]
 basepython=python
@@ -19,8 +19,15 @@ commands =
 
 [testenv]
 deps =
-    -rrequirements_test.txt
+    pytest>=3.0
     dj18: Django>=1.8,<1.9
     dj19: Django>=1.9,<1.10
     dj110: Django>=1.10,<1.11
+    postgres: psycopg2>=2.6
+    mysql: mysqlclient>=1.3.9
+
+setenv = 
+    sqlite: DATABASE_ENGINE=sqlite
+    postgres: DATABASE_ENGINE=psql
+    mysql: DATABASE_ENGINE=mysql
 commands = pytest

--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -881,14 +881,16 @@ class MP_Node(Node):
             params = []
             extrand = ''
 
+        subpath = sql_substr("path", "1", "%(subpathlen)s", vendor=vendor)
+
         sql = (
             'SELECT * FROM %(table)s AS t1 INNER JOIN '
             ' (SELECT '
-            '   ' + sql_substr("path", "1", "%(subpathlen)s", vendor=vendor) + ' AS subpath, '
+            '   ' + subpath + ' AS subpath, '
             '   COUNT(1)-1 AS count '
             '   FROM %(table)s '
             '   WHERE depth >= %(depth)s %(extrand)s'
-            '   GROUP BY subpath) AS t2 '
+            '   GROUP BY '+ subpath + ') AS t2 '
             ' ON t1.path=t2.subpath '
             ' ORDER BY t1.path'
         ) % {

--- a/treebeard/tests/settings.py
+++ b/treebeard/tests/settings.py
@@ -36,6 +36,19 @@ def get_db_conf():
             'HOST': '127.0.0.1',
             'PORT': '',
         }
+    elif database_engine == "mssql":
+        return {
+            'ENGINE': 'sql_server.pyodbc',
+            'NAME': 'master',
+            'USER': 'sa',
+            'PASSWORD': 'Password12!',
+            'HOST': '(local)\SQL2016',
+            'PORT': '',
+            'OPTIONS': {
+                'driver': 'SQL Server Native Client 11.0',
+                'MARS_Connection': 'True',
+            },
+        }
 
 DATABASES = {'default': get_db_conf()}
 SECRET_KEY = '7r33b34rd'


### PR DESCRIPTION
This PR updates the way the tests are run on tox, travis and appveyor.

The database engine is now part of the tox environment string, and the database drivers are now installed via tox so that only the required ones are installed. This is required since installing some drivers on appveyor don't work.

Also the mssql engine is added and the changes from #54 so that the mssql tests now pass.

See https://ci.appveyor.com/project/mvantellingen/django-treebeard/build/1.0.41