### PR TITLE
Include documentation in source tarball.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ recursive-include treebeard *.py
 recursive-include treebeard/static *
 recursive-include treebeard/templates *
 recursive-include treebeard/locale *
+recursive-include docs Makefile README.md make.bat *.py *.png *.rst


### PR DESCRIPTION
This makes the tarballs on PyPi suitable for distribution packages again. The
Debian package would otherwise not be able to provide a documentation package.