### PR TITLE
Fix warnings about too short underlines

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,11 +1,11 @@
 Release 4.1.2 (Jun 22, 2017)
----------------------------
+----------------------------
 
 * Fixed MANIFEST.in for Debian packaging.
 
 
 Release 4.1.1 (May 24, 2017)
----------------------------
+----------------------------
 
 * Removed deprecated templatetag inclusion
 * Added support for Python-3.6
@@ -13,7 +13,7 @@ Release 4.1.1 (May 24, 2017)
 
 
 Release 4.1.0 (Nov 24, 2016)
----------------------------
+----------------------------
 
 * Add support for Django-1.10
 * Drop support for Django-1.7


### PR DESCRIPTION
sphinx complains when a title underline is shorter than the text above it. This
fixes the "WARNING: Title underline too short." messages when building the
documentation.