### PR TITLE
Adding back requirements_test.txt removed in 2a0e8fb

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,5 @@
+# Dependencies needed for individual (tox, Travis) test runs
+
+pytest>3.0
+psycopg2>2.6
+mysqlclient>=1.3.9


### PR DESCRIPTION
The `requirements_test.txt` file was removed in 2a0e8fb but it is still being used in the main `requirements.txt` file.