### PR TITLE
JavaScriptCatalog CBV supported

### DIFF
--- a/treebeard/admin.py
+++ b/treebeard/admin.py
@@ -69,14 +69,15 @@ class TreeAdmin(admin.ModelAdmin):
         """
         if django.VERSION < (1, 10):
             from django.views.i18n import javascript_catalog
+            javascript_catalog_url = url(r'^jsi18n/$', javascript_catalog, {'packages': ('treebeard',)})
         else:
             from django.views.i18n import JavaScriptCatalog
-            javascript_catalog = JavaScriptCatalog.as_view()
+            javascript_catalog_url = url(r'^jsi18n/$', JavaScriptCatalog.as_view(packages=['treebeard',]))
 
         urls = super(TreeAdmin, self).get_urls()
         new_urls = [
             url('^move/$', self.admin_site.admin_view(self.move_node), ),
-            url(r'^jsi18n/$', javascript_catalog, {'packages': ('treebeard',)}),
+            javascript_catalog_url,
         ]
         return new_urls + urls
 


### PR DESCRIPTION
Hello,

I thought it seemd that it worked fine, but I encountered the following error:

```
  File "/Users/mairoo/.pyenv/versions/rakmai/lib/python3.6/site-packages/django/views/i18n.py", line 229, in get
    packages = packages.split('+') if packages else self.packages
AttributeError: 'tuple' object has no attribute 'split'
```

It occurred because the way of passing parameters is dfferent betwen FBV(javascript_catalog) and CBV(JavaScriptCatalog).

https://docs.djangoproject.com/en/1.11/topics/i18n/translation/#module-django.views.i18n

https://docs.djangoproject.com/en/1.11/topics/i18n/translation/#the-javascript-catalog-view

Thank you.