### PR TITLE
Fix for `object has no attribute 'rel'` in django 2.0

### DIFF
--- a/treebeard/templatetags/admin_tree.py
+++ b/treebeard/templatetags/admin_tree.py
@@ -83,7 +83,7 @@ def get_result_and_row_class(cl, field_name, result):
             if isinstance(value, (datetime.date, datetime.time)):
                 row_classes.append('nowrap')
         else:
-            if isinstance(f.rel, models.ManyToOneRel):
+            if hasattr(f, 'rel') and isinstance(f.rel, models.ManyToOneRel):
                 field_val = getattr(result, f.name)
                 if field_val is None:
                     result_repr = empty_value_display


### PR DESCRIPTION
In django 2.0 admin area for treebeard-enabled model got broken  because of exception in `result_tree` tag.

The fix was rather simple, however