### PR TITLE
Fix error when loading jsi18n in admin interface

### DIFF
--- a/treebeard/templatetags/admin_tree.py
+++ b/treebeard/templatetags/admin_tree.py
@@ -298,4 +298,4 @@ def treebeard_js():
         '</script>'
         '<script type="text/javascript" src="{}"></script>')
     return format_html(
-        TEMPLATE, "jsi18n", mark_safe(js_file), mark_safe(jquery_ui))
+        TEMPLATE, "/jsi18n", mark_safe(js_file), mark_safe(jquery_ui))


### PR DESCRIPTION
I don't know if this is the correct solution seeing as the modified code has been there since 2015 but recently I had django treebeard loading jsi18n without a slash which was causing a 500 error. The issue went deep into https://github.com/django/django/blob/master/django/views/i18n.py where this line was failing

```
 packages = packages.split('+') if packages else self.packages
```

Because the the jsi18n wasn't loaded properly the resolution of a url was coming back with the wrong kwargs

```
In [7]: a.resolve('/admin/multimenus/menuitem/jsi18n/')
Out[7]: ResolverMatch(func=django.views.i18n.JavaScriptCatalog, args=(), kwargs={'packages': ('treebeard',)}, url_name=None, app_names=['admin'], namespaces=['admin'])
```

I noticed in the template code that there was a call to jsi18n that was missing a slash.

```
<script src="jsi18n" type="text/javascript"></script>
```

So I added the slash to the template tag code and it fixed my issue. I don't know if this is masking a different issue but hopefully it sheds light onto something.