### PR TITLE
Use explicit single quotes for result_id

### DIFF
--- a/treebeard/templatetags/admin_tree.py
+++ b/treebeard/templatetags/admin_tree.py
@@ -166,7 +166,7 @@ def items_for_result(cl, result, form):
             else:
                 attr = pk
             value = result.serializable_value(attr)
-            result_id = repr(force_str(value))[1:]
+            result_id = "'%s'" % force_str(value)
             onclickstr = (
                 ' onclick="opener.dismissRelatedLookupPopup(window, %s);'
                 ' return false;"')


### PR DESCRIPTION
- `repr` will produce different strings on PY2/3
- Proper JSON encoding doesn't work because string needs to be single quoted due in
double quoted html attribute

Fixes #72 