### PR TITLE
Bugfix issues #90 admin change list view and jsi18n load for Django-1.11

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,3 +18,4 @@ Contributions made by:
     * moberley
     * czare1
     * Fernando Gutierrez (xbito) 
+    * Jens Diemer

--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+Release *dev*
+----------------------------
+
+* Bugfix issues #90: admin change list view and jsi18n load for Django-1.11
+
 Release 4.2.0 (Dec 8, 2017)
 ----------------------------
 

--- a/treebeard/admin.py
+++ b/treebeard/admin.py
@@ -67,16 +67,22 @@ class TreeAdmin(admin.ModelAdmin):
         """
         Adds a url to move nodes to this admin
         """
+        urls = super(TreeAdmin, self).get_urls()
+
         if django.VERSION < (1, 10):
             from django.views.i18n import javascript_catalog
+            jsi18n_url = url(r'^jsi18n/$', javascript_catalog, {'packages': ('treebeard',)})
         else:
             from django.views.i18n import JavaScriptCatalog
-            javascript_catalog = JavaScriptCatalog.as_view()
 
-        urls = super(TreeAdmin, self).get_urls()
+            jsi18n_url = url(r'^jsi18n/$',
+                JavaScriptCatalog.as_view(packages=['treebeard']),
+                name='javascript-catalog'
+            )
+
         new_urls = [
             url('^move/$', self.admin_site.admin_view(self.move_node), ),
-            url(r'^jsi18n/$', javascript_catalog, {'packages': ('treebeard',)}),
+            jsi18n_url,
         ]
         return new_urls + urls
 


### PR DESCRIPTION
Bugfix for "jsi18n" loading in admin change list view.

See:

* https://github.com/django-treebeard/django-treebeard/issues/90
* https://github.com/django-treebeard/django-treebeard/pull/88