### PR TITLE
Fix "ImportError: cannot import name '__version__'"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,10 @@ from __future__ import unicode_literals
 
 import os
 from setuptools import setup, find_packages
-from treebeard import __version__
+try:
+    from treebeard import __version__
+except ImportError as err:
+    __version__="<unknown: %s>" % err
 import codecs
 
 


### PR DESCRIPTION
Install as editable raised into this:
```
  Running setup.py develop for django-treebeard
    Complete output from command .../bin/python3 -c "import setuptools, tokenize;__file__='.../src/django-treebeard/setup.py';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" develop --no-deps:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File ".../src/django-treebeard/setup.py", line 7, in <module>
        from treebeard import __version__
    ImportError: cannot import name '__version__'
```