### PR TITLE
Update supported Django versions in docs

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,7 +3,7 @@ django-treebeard
 
 `django-treebeard <https://tabo.pe/projects/django-treebeard/>`_
 is a library that implements efficient tree implementations for the
-`Django Web Framework 1.7+ <http://www.djangoproject.com/>`_, written by
+`Django Web Framework 1.8+ <http://www.djangoproject.com/>`_, written by
 `Gustavo Picón <https://tabo.pe>`_ and licensed under the Apache License 2.0.
 
 ``django-treebeard`` is:

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -6,7 +6,7 @@ Prerequisites
 -------------
 
 ``django-treebeard`` needs at least **Python 2.7/3.4** to run, and
-**Django 1.7 or better**.
+**Django 1.8 or better**.
 
 
 Installing
@@ -86,4 +86,3 @@ settings file.
    http://pypi.python.org/pypi/django-treebeard
 .. _`treebeard download page`:
    https://tabo.pe/projects/django-treebeard/download/
-


### PR DESCRIPTION
Support for Django 1.7 was removed in version 4.1.0 (Nov 24, 2016). Update the docs to mention 1.8+ is supported.