### PR TITLE
Update all pypi.python.org URLs to pypi.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ Status
     :target: https://ci.appveyor.com/project/mvantellingen/django-treebeard
 
 .. image:: https://img.shields.io/pypi/v/django-treebeard.svg
-    :target: https://pypi.python.org/pypi/django-treebeard/
+    :target: https://pypi.org/project/django-treebeard/
 
 Features
 --------

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -83,5 +83,5 @@ settings file.
 
 
 .. _`django-treebeard's PyPI page`:
-   http://pypi.python.org/pypi/django-treebeard
+   https://pypi.org/project/django-treebeard/
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -107,4 +107,4 @@ Read the :class:`treebeard.models.Node` API reference for detailed info.
 .. _`treebeard mercurial repository`:
    http://code.tabo.pe/django-treebeard
 .. _`latest treebeard version from PyPi`:
-   http://pypi.python.org/pypi/django-treebeard/
+   https://pypi.org/project/django-treebeard/


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html