### PR TITLE
fix drag/drop order not working

### DIFF
--- a/treebeard/templates/admin/tree_change_list_results.html
+++ b/treebeard/templates/admin/tree_change_list_results.html
@@ -17,7 +17,7 @@
             </tr>
             </thead>
             <tbody>
-            {% for node_id, parent_id, node_level, has_children, result in results %}
+            {% for node_id, parent_id, node_level, children_num, result in results %}
                 <tr id="node-{{ node_id }}-id" class="{% cycle 'row1' 'row2' %}"
                     level="{{ node_level }}" children-num="{{ children_num }}"
                     parent="{{ parent_id }}" node="{{ node_id }}">


### PR DESCRIPTION
variable named incorrectly, drag and drop does not work in admin in current treebeard versions