### PR TITLE
Correct capitalization of PyPI

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -106,5 +106,5 @@ Read the :class:`treebeard.models.Node` API reference for detailed info.
 
 .. _`treebeard mercurial repository`:
    http://code.tabo.pe/django-treebeard
-.. _`latest treebeard version from PyPi`:
+.. _`latest treebeard version from PyPI`:
    https://pypi.org/project/django-treebeard/


### PR DESCRIPTION
As spelled on https://pypi.org/.