### PR TITLE
Prevent unnecessary database query for get_ancestors() on MP_Tree if the node is a root node

### DIFF
--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -1054,6 +1054,9 @@ class MP_Node(Node):
         :returns: A queryset containing the current node object's ancestors,
             starting by the root node and descending to the parent.
         """
+        if self.is_root():
+            return get_result_class(self.__class__).objects.none()
+
         paths = [
             self.path[0:pos]
             for pos in range(0, len(self.path), self.steplen)[1:]


### PR DESCRIPTION
Hi! We noticed that calling `get_ancestors()` on a root node will trigger a database query even though the node cannot have ancestors. 

This change makes the behaviour consistent with what [NS_Tree](https://github.com/django-treebeard/django-treebeard/blob/ad44d91d0459750278694c49ed8e9525ff3089ee/treebeard/ns_tree.py#L631-L632) does, and skips the database query if the node is a root node.