### PR TITLE
Updating delete method to respect return value from django

### DIFF
--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -123,7 +123,9 @@ class MP_NodeQuerySet(models.query.QuerySet):
         # ids, and will deal with removing related objects
         if toremove:
             qset = get_result_class(self.model).objects.filter(reduce(operator.or_, toremove))
-            super(MP_NodeQuerySet, qset).delete()
+        else:
+            qset = get_result_class(self.model).objects.none()
+        return super(MP_NodeQuerySet, qset).delete()
 
 
 class MP_NodeManager(models.Manager):


### PR DESCRIPTION
Currently the delete() method always returns `None`. This does not support the default Django delete() method default behavior. From the [Django documentation](https://docs.djangoproject.com/en/2.1/ref/models/querysets/#delete), it will
> Performs an SQL delete query on all rows in the QuerySet and returns the number of objects deleted and a dictionary with the number of deletions per object type.

This change, essentially, returns the expected Django result when calling the delete() method, even when there is nothing to delete.