### PR TITLE
Add migrations with path COLLATE for databases they provides it.

### DIFF
--- a/treebeard/migrations/0001_treebeard_path.py
+++ b/treebeard/migrations/0001_treebeard_path.py
@@ -1,0 +1,16 @@
+from django.conf import settings
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    operations = []
+    if settings.DATABASES['default']['ENGINE'] in (
+            'django.db.backends.postgresql_psycopg2', 'django.db.backends.postgresql'):
+        operations.append(migrations.RunSQL(
+            'ALTER TABLE cms_treenode ALTER COLUMN path SET DATA TYPE varchar(255) COLLATE "C"'))
+    elif settings.DATABASES['default']['ENGINE'] == 'django.db.backends.mysql':
+        operations.append(migrations.RunSQL(
+            'ALTER TABLE cms_treenode MODIFY path VARCHAR(255) COLLATE ascii_general_ci'))
+    elif settings.DATABASES['default']['ENGINE'] == 'django.db.backends.oracle':
+        operations.append(migrations.RunSQL(
+            'ALTER TABLE cms_treenode MODIFY (path VARCHAR2(255) COLLATE BINARY_CI)'))


### PR DESCRIPTION
Values in `path` must be sorted by ascii alphabetical order, otherwise module doesn't find the tail and creates duplicate path. Some databases have default collations that sorts in different way. It is necessary to set a proper collation to the column `path`.

 * https://www.postgresql.org/docs/9.1/collation.html
 * https://oracle-base.com/articles/12c/column-level-collation-and-case-insensitive-database-12cr2
 * https://dev.mysql.com/doc/refman/8.0/en/charset-collate.html
