### PR TITLE
Ensure post_save is triggered after parent is updated in add_child

### DIFF
--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -385,15 +385,17 @@ class MP_AddChildHandler(MP_AddHandler):
         else:
             # adding the new child as the last one
             newobj.path = self.node.get_last_child()._inc_path()
-        # saving the instance before returning it
-        newobj.save()
-        newobj._cached_parent_obj = self.node
 
         get_result_class(self.node_cls).objects.filter(
             path=self.node.path).update(numchild=F('numchild')+1)
 
         # we increase the numchild value of the object in memory
         self.node.numchild += 1
+
+        # saving the instance before returning it
+        newobj._cached_parent_obj = self.node
+        newobj.save()
+
         return newobj
 
 

--- a/treebeard/tests/test_treebeard.py
+++ b/treebeard/tests/test_treebeard.py
@@ -726,7 +726,6 @@ class TestAddChild(TestNonEmptyTree):
         with pytest.raises(NodeAlreadySaved):
             model.objects.get(desc='2').add_child(instance=child)
 
-    @pytest.mark.xfail(reason="Child post_save triggered before parent numchild updated")
     def test_add_child_post_save(self, model):
         try:
             @receiver(post_save, dispatch_uid='test_add_child_post_save')


### PR DESCRIPTION
This avoids strange behaviours in post_save receivers
since if the parent is in an inconsistent state many types
of queries depending on numchild does not work correctly