### PR TITLE
Fix pytest installation instructions

### DIFF
--- a/docs/source/tests.rst
+++ b/docs/source/tests.rst
@@ -7,12 +7,11 @@ recommended that you run and update the test suite when you send patches.
 py.test
 -------
 
-You will need `pytest`_ to run the test suite. It's included with the
-development dependencies:
+You will need `pytest`_ to run the test suite:
 
 .. code-block:: console
 
-    $ pip install -r requirements.txt
+    $ pip install pytest
 
 Then just run the test suite:
 


### PR DESCRIPTION
Since the removal of requirements_test.txt (in 2a0e8fb756d7c9dfce5f66e2b3cf68274dbc96d5 and 63610e0fd83d2fbb4126963bbe22b5b0a76f6104) it is no longer the case that `pip install -r requirements.txt` will install pytest.