### PR TITLE
Implement a non-destructive path-fixing algorithm for MP_Node.fix_tree

### DIFF
--- a/treebeard/tests/models.py
+++ b/treebeard/tests/models.py
@@ -201,7 +201,7 @@ class MP_TestNodeSortedAutoNow(MP_Node):
 
 class MP_TestNodeShortPath(MP_Node):
     steplen = 1
-    alphabet = '01234'
+    alphabet = '012345678'
     desc = models.CharField(max_length=255)
 
     def __str__(self):  # pragma: no cover
@@ -231,7 +231,7 @@ class AL_TestNode_Proxy(AL_TestNode):
 
 class MP_TestSortedNodeShortPath(MP_Node):
     steplen = 1
-    alphabet = '01234'
+    alphabet = '012345678'
     desc = models.CharField(max_length=255)
 
     node_order_by = ['desc']

--- a/treebeard/tests/test_treebeard.py
+++ b/treebeard/tests/test_treebeard.py
@@ -2073,6 +2073,14 @@ class TestMP_TreeFix(TestTreeBase):
         assert got == expected
         mpshort_model.find_problems()
 
+    def test_fix_tree_with_fix_paths(self, mpshort_model):
+        self.add_broken_test_data(mpshort_model)
+        mpshort_model.fix_tree(fix_paths=True)
+        got = self.got(mpshort_model)
+        expected = self.expected_no_holes[mpshort_model]
+        assert got == expected
+        mpshort_model.find_problems()
+
 
 class TestIssues(TestTreeBase):
     # test for http://code.google.com/p/django-treebeard/issues/detail?id=14


### PR DESCRIPTION
From [the `MP_Node.fix_tree` docs](https://django-treebeard.readthedocs.io/en/latest/mp_tree.html#treebeard.mp_tree.MP_Node.fix_tree):

> That needs complex in-place tree reordering, not available at the moment (hint: patches are welcome).

It might have taken 11 years, but I took the hint. :-)

This replaces `MP_Node.fix_tree(destructive=True)` with an implementation that non-destructively fixes 'holes' in paths and applies `node_order_by` ordering. It runs after the old `fix_tree` code has fixed up the `depth` and `numchild` values, and works pretty much as you'd expect:

* for each non-leaf node in the tree, fetch the child nodes in `node_order_by` order if specified, or `path` order if not; enumerating this queryset gives us the desired final path positions
* build a lookup table of the nodes' current path positions
* for each node in the queryset:
  * if the node is already in its desired final position, do nothing
  * if the desired slot is vacant, update the path of that node and its descendants to move it into that slot
  * if the desired slot is occupied by another node, move that node to one greater than the previous max position (updating the lookup table accordingly) and move the correct node into the slot

(note: I took the liberty of increasing the alphabet length on the test models. Fixing a tree in-place with no spare characters isn't really a fair challenge!)
