### PR TITLE
fix typos in get_annotated_list

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -376,12 +376,12 @@ API
      .. code-block:: python
 
             [
-                (a,     {'open':True,  'close':[],    'level': 0})
-                (ab,    {'open':True,  'close':[],    'level': 1})
-                (aba,   {'open':True,  'close':[],    'level': 2})
-                (abb,   {'open':False, 'close':[],    'level': 2})
-                (abc,   {'open':False, 'close':[0,1], 'level': 2})
-                (ac,    {'open':False, 'close':[0],   'level': 1})
+                ('a',     {'open':True,  'close':[],    'level': 0}),
+                ('ab',    {'open':True,  'close':[],    'level': 1}),
+                ('aba',   {'open':True,  'close':[],    'level': 2}),
+                ('abb',   {'open':False, 'close':[],    'level': 2}),
+                ('abc',   {'open':False, 'close':[0], 'level': 2}),
+                ('ac',    {'open':False, 'close':[0,1],   'level': 1}),
             ]
 
      This can be used with a template like:


### PR DESCRIPTION
I've tried to generate the html list (`<ul>` / `<li>`) using the template here: https://django-treebeard.readthedocs.io/en/latest/api.html#treebeard.models.Node.get_annotated_list and it doesn't match the tree here: https://django-treebeard.readthedocs.io/en/latest/_images/graphviz-e7e37dc8512ab2c6748e55df49b011e14f28a879.png.

Maybe something like this would be better?