### PR TITLE
allow working with custom ids

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,4 +36,4 @@ setenv =
     postgres: DATABASE_ENGINE=psql
     mysql: DATABASE_ENGINE=mysql
     mssql: DATABASE_ENGINE=mssql
-commands = pytest
+commands = pytest {posargs}

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 
 [tox]
 envlist =
-    {py27,py35,py36,py37}-{dj111,dj20,dj21,dj22}-{sqlite,postgres,mysql,mssql}
+    {py27,py35,py36,py37,py38,py39}-{dj111,dj20,dj21,dj22}-{sqlite,postgres,mysql,mssql}
 
 [testenv:docs]
 basepython = python

--- a/treebeard/al_tree.py
+++ b/treebeard/al_tree.py
@@ -55,7 +55,7 @@ class AL_Node(Node):
         if len(kwargs) == 1 and 'instance' in kwargs:
             # adding the passed (unsaved) instance to the tree
             newobj = kwargs['instance']
-            if newobj.pk:
+            if not newobj._state.adding:
                 raise NodeAlreadySaved("Attempted to add a tree node that is "\
                     "already in the database")
         else:
@@ -210,7 +210,7 @@ class AL_Node(Node):
         if len(kwargs) == 1 and 'instance' in kwargs:
             # adding the passed (unsaved) instance to the tree
             newobj = kwargs['instance']
-            if newobj.pk:
+            if not newobj._state.adding:
                 raise NodeAlreadySaved("Attempted to add a tree node that is "\
                     "already in the database")
         else:
@@ -285,7 +285,7 @@ class AL_Node(Node):
         if len(kwargs) == 1 and 'instance' in kwargs:
             # adding the passed (unsaved) instance to the tree
             newobj = kwargs['instance']
-            if newobj.pk:
+            if not newobj._state.adding:
                 raise NodeAlreadySaved("Attempted to add a tree node that is "\
                     "already in the database")
         else:

--- a/treebeard/forms.py
+++ b/treebeard/forms.py
@@ -59,7 +59,6 @@ class MoveNodeForm(forms.ModelForm):
                                           coerce=int,
                                           label=_("Relative to"))
 
-
     def _get_position_ref_node(self, instance):
         if self.is_sorted:
             position = 'sorted-child'
@@ -100,9 +99,10 @@ class MoveNodeForm(forms.ModelForm):
         # update the '_ref_node_id' choices
         choices = self.mk_dropdown_tree(opts.model, for_node=instance)
         self.declared_fields['_ref_node_id'].choices = choices
+        # use the formfield `to_python` method to coerse the field for custom ids
         idFormField = opts.model._meta.get_field('id').formfield()
-        if idFormField:
-            self.declared_fields['_ref_node_id'].coerse = idFormField.to_python
+        self.declared_fields['_ref_node_id'].coerce = idFormField.to_python if idFormField else int
+
 
         # put initial data for these fields into a map, update the map with
         # initial data, and pass this new map to the parent constructor as

--- a/treebeard/forms.py
+++ b/treebeard/forms.py
@@ -123,7 +123,7 @@ class MoveNodeForm(forms.ModelForm):
 
     def _clean_cleaned_data(self):
         """ delete auxilary fields not belonging to node model """
-        reference_node_id = 0
+        reference_node_id = None
 
         if '_ref_node_id' in self.cleaned_data:
             reference_node_id = self.cleaned_data['_ref_node_id']
@@ -192,7 +192,7 @@ class MoveNodeForm(forms.ModelForm):
     def mk_dropdown_tree(cls, model, for_node=None):
         """ Creates a tree-like list of choices """
 
-        options = [(0, _('-- root --'))]
+        options = [(None, _('-- root --'))]
         for node in model.get_root_nodes():
             cls.add_subtree(for_node, node, options)
         return options

--- a/treebeard/forms.py
+++ b/treebeard/forms.py
@@ -133,7 +133,7 @@ class MoveNodeForm(forms.ModelForm):
     def save(self, commit=True):
         position_type, reference_node_id = self._clean_cleaned_data()
 
-        if self.instance.pk is None:
+        if self.instance._state.adding:
             cl_data = {}
             for field in self.cleaned_data:
                 if not isinstance(self.cleaned_data[field], (list, QuerySet)):

--- a/treebeard/forms.py
+++ b/treebeard/forms.py
@@ -59,6 +59,7 @@ class MoveNodeForm(forms.ModelForm):
                                           coerce=int,
                                           label=_("Relative to"))
 
+
     def _get_position_ref_node(self, instance):
         if self.is_sorted:
             position = 'sorted-child'
@@ -99,6 +100,9 @@ class MoveNodeForm(forms.ModelForm):
         # update the '_ref_node_id' choices
         choices = self.mk_dropdown_tree(opts.model, for_node=instance)
         self.declared_fields['_ref_node_id'].choices = choices
+        idFormField = opts.model._meta.get_field('id').formfield()
+        if idFormField:
+            self.declared_fields['_ref_node_id'].coerse = idFormField.to_python
 
         # put initial data for these fields into a map, update the map with
         # initial data, and pass this new map to the parent constructor as

--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -332,7 +332,7 @@ class MP_AddRootHandler(MP_AddHandler):
         if len(self.kwargs) == 1 and 'instance' in self.kwargs:
             # adding the passed (unsaved) instance to the tree
             newobj = self.kwargs['instance']
-            if newobj.pk:
+            if not newobj._state.adding:
                 raise NodeAlreadySaved("Attempted to add a tree node that is "\
                     "already in the database")
         else:
@@ -364,7 +364,7 @@ class MP_AddChildHandler(MP_AddHandler):
         if len(self.kwargs) == 1 and 'instance' in self.kwargs:
             # adding the passed (unsaved) instance to the tree
             newobj = self.kwargs['instance']
-            if newobj.pk:
+            if not newobj._state.adding:
                 raise NodeAlreadySaved("Attempted to add a tree node that is "\
                     "already in the database")
         else:
@@ -411,7 +411,7 @@ class MP_AddSiblingHandler(MP_ComplexAddMoveHandler):
         if len(self.kwargs) == 1 and 'instance' in self.kwargs:
             # adding the passed (unsaved) instance to the tree
             newobj = self.kwargs['instance']
-            if newobj.pk:
+            if not newobj._state.adding:
                 raise NodeAlreadySaved("Attempted to add a tree node that is "\
                     "already in the database")
         else:

--- a/treebeard/ns_tree.py
+++ b/treebeard/ns_tree.py
@@ -142,7 +142,7 @@ class NS_Node(Node):
         if len(kwargs) == 1 and 'instance' in kwargs:
             # adding the passed (unsaved) instance to the tree
             newobj = kwargs['instance']
-            if newobj.pk:
+            if not newobj._state.adding:
                 raise NodeAlreadySaved("Attempted to add a tree node that is "\
                     "already in the database")
         else:
@@ -209,7 +209,7 @@ class NS_Node(Node):
         if len(kwargs) == 1 and 'instance' in kwargs:
             # adding the passed (unsaved) instance to the tree
             newobj = kwargs['instance']
-            if newobj.pk:
+            if not newobj._state.adding:
                 raise NodeAlreadySaved("Attempted to add a tree node that is "\
                     "already in the database")
         else:
@@ -242,7 +242,7 @@ class NS_Node(Node):
         if len(kwargs) == 1 and 'instance' in kwargs:
             # adding the passed (unsaved) instance to the tree
             newobj = kwargs['instance']
-            if newobj.pk:
+            if not newobj._state.adding:
                 raise NodeAlreadySaved("Attempted to add a tree node that is "\
                     "already in the database")
         else:

--- a/treebeard/tests/models.py
+++ b/treebeard/tests/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.contrib.auth.models import User
+import uuid
 
 from treebeard.mp_tree import MP_Node
 from treebeard.al_tree import AL_Node
@@ -50,6 +51,16 @@ class MP_TestNodeRelated(MP_Node):
 
 class MP_TestNodeInherited(MP_TestNode):
     extra_desc = models.CharField(max_length=255)
+
+
+class MP_TestNodeCustomId(MP_Node):
+    steplen = 3
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    desc = models.CharField(max_length=255)
+
+    def __str__(self):  # pragma: no cover
+        return 'Node %d' % self.pk
 
 
 class NS_TestNode(NS_Node):

--- a/treebeard/tests/models.py
+++ b/treebeard/tests/models.py
@@ -259,7 +259,7 @@ class MP_TestManyToManyWithUser(MP_Node):
     users = models.ManyToManyField(User)
 
 
-BASE_MODELS = AL_TestNode, MP_TestNode, NS_TestNode
+BASE_MODELS = AL_TestNode, MP_TestNode, NS_TestNode, MP_TestNodeCustomId
 PROXY_MODELS = AL_TestNode_Proxy, MP_TestNode_Proxy, NS_TestNode_Proxy
 SORTED_MODELS = AL_TestNodeSorted, MP_TestNodeSorted, NS_TestNodeSorted
 DEP_MODELS = AL_TestNodeSomeDep, MP_TestNodeSomeDep, NS_TestNodeSomeDep

--- a/treebeard/tests/test_treebeard.py
+++ b/treebeard/tests/test_treebeard.py
@@ -2115,7 +2115,7 @@ class TestMoveNodeForm(TestNonEmptyTree):
 
     def _assert_nodes_in_choices(self, form, nodes):
         choices = form.fields['_ref_node_id'].choices
-        assert 0 == choices.pop(0)[0]
+        assert None == choices.pop(0)[0]
         assert nodes == [(choice[0], choice[1]) for choice in choices]
 
     def _move_node_helper(self, node, safe_parent_nodes):

--- a/treebeard/tests/test_treebeard.py
+++ b/treebeard/tests/test_treebeard.py
@@ -2513,8 +2513,7 @@ class TestAdminTreeList(TestNonEmptyTree):
         context = Context({'cl': cl,
                            'request': request})
         table_output = self.template.render(context)
-
-        output_template = '<li><a href="%i/" >Node %i</a>'
+        output_template = '<li><a href="%s/" >Node %i</a>'
         for object in model.objects.all():
             expected_output = output_template % (object.pk, object.pk)
             assert expected_output in table_output
@@ -2538,8 +2537,8 @@ class TestAdminTreeList(TestNonEmptyTree):
                            'action_form': True})
         table_output = self.template.render(context)
         output_template = ('<input type="checkbox" class="action-select" '
-                           'value="%i" name="_selected_action" />'
-                           '<a href="%i/" >Node %i</a>')
+                           'value="%s" name="_selected_action" />'
+                           '<a href="%s/" >Node %i</a>')
 
         for object in model.objects.all():
             expected_output = output_template % (object.pk, object.pk,
@@ -2566,7 +2565,7 @@ class TestAdminTreeList(TestNonEmptyTree):
         context = Context({'cl': cl,
                            'request': request})
         table_output = self.template.render(context)
-        output_template = "opener.dismissRelatedLookupPopup(window, '%i');"
+        output_template = "opener.dismissRelatedLookupPopup(window, '%s');"
         for object in model.objects.all():
             expected_output = output_template % object.pk
             assert expected_output in table_output


### PR DESCRIPTION
treebeard was expecting the primary key for models to be integer serials

fixed two problems
1) detection of insertion was checking if the pk was None, but with custom ids with default values (as with uuids) the pk is never None as the default is set at model init. changed all checks to use more reliable `model._state.adding` instead.
2) the forms forced the use of integer as reference id, so it triggered an error when sending an uuid. I used the model field's formfield `to_python` as coerce function if applicable.

I also added tests but let me know if I should add more tests.