### PR TITLE
Code cleanups for Python 3 and Django > 2.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup_args = dict(
     include_package_data=True,
     description='Efficient tree implementations for Django',
     long_description=codecs.open(os.path.join(root_dir(), 'README.rst'), encoding='utf-8').read(),
+    python_requires='>=3.6',
     install_requires=['Django>=2.2'],
     tests_require=['pytest'],
     classifiers=[

--- a/treebeard/admin.py
+++ b/treebeard/admin.py
@@ -26,7 +26,7 @@ class TreeAdmin(admin.ModelAdmin):
             # AL Trees return a list instead of a QuerySet for .get_tree()
             # So we're returning the regular .get_queryset cause we will use
             # the old admin
-            return super(TreeAdmin, self).get_queryset(request)
+            return super().get_queryset(request)
         else:
             return self.model.get_tree()
 
@@ -48,13 +48,13 @@ class TreeAdmin(admin.ModelAdmin):
         lacks_request = ('request' not in extra_context and not request_context)
         if lacks_request:
             extra_context['request'] = request
-        return super(TreeAdmin, self).changelist_view(request, extra_context)
+        return super().changelist_view(request, extra_context)
 
     def get_urls(self):
         """
         Adds a url to move nodes to this admin
         """
-        urls = super(TreeAdmin, self).get_urls()
+        urls = super().get_urls()
         from django.views.i18n import JavaScriptCatalog
 
         jsi18n_url = url(r'^jsi18n/$',

--- a/treebeard/admin.py
+++ b/treebeard/admin.py
@@ -3,11 +3,10 @@
 import sys
 
 from django.conf import settings
-from django.conf.urls import url
-
 from django.contrib import admin, messages
 from django.contrib.admin.options import TO_FIELD_VAR
 from django.http import HttpResponse, HttpResponseBadRequest
+from django.urls import path
 from django.utils.translation import gettext_lazy as _
 from django.utils.encoding import force_str
 
@@ -57,13 +56,13 @@ class TreeAdmin(admin.ModelAdmin):
         urls = super().get_urls()
         from django.views.i18n import JavaScriptCatalog
 
-        jsi18n_url = url(r'^jsi18n/$',
+        jsi18n_url = path('jsi18n/',
             JavaScriptCatalog.as_view(packages=['treebeard']),
             name='javascript-catalog'
         )
 
         new_urls = [
-            url('^move/$', self.admin_site.admin_view(self.move_node), ),
+            path('move/', self.admin_site.admin_view(self.move_node), ),
             jsi18n_url,
         ]
         return new_urls + urls

--- a/treebeard/al_tree.py
+++ b/treebeard/al_tree.py
@@ -39,7 +39,7 @@ class AL_NodeManager(models.Manager):
             order_by = ['parent'] + list(self.model.node_order_by)
         else:
             order_by = ['parent', 'sib_order']
-        return super(AL_NodeManager, self).get_queryset().order_by(*order_by)
+        return super().get_queryset().order_by(*order_by)
 
 
 class AL_Node(Node):

--- a/treebeard/forms.py
+++ b/treebeard/forms.py
@@ -111,10 +111,10 @@ class MoveNodeForm(forms.ModelForm):
         if initial is not None:
             initial_.update(initial)
 
-        super(MoveNodeForm, self).__init__(
-            data=data, files=files, auto_id=auto_id, prefix=prefix, 
-            initial=initial_, error_class=error_class, 
-            label_suffix=label_suffix, empty_permitted=empty_permitted, 
+        super().__init__(
+            data=data, files=files, auto_id=auto_id, prefix=prefix,
+            initial=initial_, error_class=error_class,
+            label_suffix=label_suffix, empty_permitted=empty_permitted,
             instance=instance, **kwargs)
 
     def _clean_cleaned_data(self):
@@ -159,7 +159,7 @@ class MoveNodeForm(forms.ModelForm):
                 self.instance.move(self._meta.model.get_first_root_node(), pos)
         # Reload the instance
         self.instance = self._meta.model.objects.get(pk=self.instance.pk)
-        super(MoveNodeForm, self).save(commit=commit)
+        super().save(commit=commit)
         return self.instance
 
     @staticmethod

--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -306,7 +306,7 @@ class MP_ComplexAddMoveHandler(MP_AddHandler):
 
 class MP_AddRootHandler(MP_AddHandler):
     def __init__(self, cls, **kwargs):
-        super(MP_AddRootHandler, self).__init__()
+        super().__init__()
         self.cls = cls
         self.kwargs = kwargs
 
@@ -346,7 +346,7 @@ class MP_AddRootHandler(MP_AddHandler):
 
 class MP_AddChildHandler(MP_AddHandler):
     def __init__(self, node, **kwargs):
-        super(MP_AddChildHandler, self).__init__()
+        super().__init__()
         self.node = node
         self.node_cls = node.__class__
         self.kwargs = kwargs
@@ -399,7 +399,7 @@ class MP_AddChildHandler(MP_AddHandler):
 
 class MP_AddSiblingHandler(MP_ComplexAddMoveHandler):
     def __init__(self, node, pos, **kwargs):
-        super(MP_AddSiblingHandler, self).__init__()
+        super().__init__()
         self.node = node
         self.node_cls = node.__class__
         self.pos = pos
@@ -452,7 +452,7 @@ class MP_AddSiblingHandler(MP_ComplexAddMoveHandler):
 
 class MP_MoveHandler(MP_ComplexAddMoveHandler):
     def __init__(self, node, target, pos=None):
-        super(MP_MoveHandler, self).__init__()
+        super().__init__()
         self.node = node
         self.node_cls = node.__class__
         self.target = target

--- a/treebeard/ns_tree.py
+++ b/treebeard/ns_tree.py
@@ -55,7 +55,7 @@ class NS_NodeQuerySet(models.query.QuerySet):
             # we already know the children, let's call the default django
             # delete method and let it handle the removal of the user's
             # foreign keys...
-            super(NS_NodeQuerySet, self).delete()
+            super().delete()
             cursor = model._get_database_cursor('write')
 
             # Now closing the gap (Celko's trees book, page 62)

--- a/treebeard/tests/urls.py
+++ b/treebeard/tests/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import include, url
 from django.contrib import admin
+from django.urls import include, path
 
 admin.autodiscover()
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
+    path('admin/', admin.site.urls),
 ]


### PR DESCRIPTION
- Use simplified `super()` calls now that we've dropped Python 2 support.
- Replace use of deprecated `django.conf.urls.url` with `django.urls.path`.