### PR TITLE
Prepare version 4.4

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,13 @@
+Release 4.4 (Oct 26, 2020)
+----------------------------
+
+* Implement a non-destructive path-fixing algorithm for ``MP_Node.fix_tree``.
+* Ensure ``post_save`` is triggered *after* the parent node is updated in ``MP_AddChildHandler``.
+* Fix static URL generation to use ``static`` template tag instead of constructing the URL manually.
+* Declare support for Django 2.2, 3.0 and 3.1.
+* Drop support for Django 2.1 and lower.
+* Drop support for Python 2.7 and Python 3.5.
+
 Release 4.3.1 (Dec 25, 2019)
 ----------------------------
 
@@ -221,7 +231,7 @@ New features added
   - script to build documentation
 
   - updated numconv.py
-  
+
 
 Bugs fixed
 ~~~~~~~~~~
@@ -230,7 +240,7 @@ Bugs fixed
   Solves bug in postgres when the table isn't created by syncdb.
 
 * Removing unused method NS_Node._find_next_node
-  
+
 * Fixed MP_Node.get_tree to include the given parent when given a leaf node
 
 

--- a/treebeard/__init__.py
+++ b/treebeard/__init__.py
@@ -10,10 +10,13 @@ Release logic:
  5. git push
  6. assure that all tests pass on https://travis-ci.org/django-treebeard/django-treebeard/builds/
  7. git push --tags
- 8. python setup.py sdist upload
- 9. bump the version, append ".dev0" to __version__
-10. git add treebeard/__init__.py
-11. git commit -m 'Start with <version>'
-12. git push
+ 8. pip install --upgrade pip wheel twine
+ 9. python setup.py clean --all
+ 9. python setup.py sdist bdist_wheel
+10. twine upload dist/*
+11. bump the version, append ".dev0" to __version__
+12. git add treebeard/__init__.py
+13. git commit -m 'Start with <version>'
+14. git push
 """
-__version__ = '4.3.1'
+__version__ = '4.4.0'


### PR DESCRIPTION
Preparing a 4.4 release which declares support for Django 2.2 and higher, and drops support for Django 2.1 and lower, and Python 3.5 and lower.

Also fixes #169.