### PR TITLE
Add back CI tests for MSSQL.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,9 @@ Status
 .. image:: https://travis-ci.org/django-treebeard/django-treebeard.svg?branch=master
     :target: https://travis-ci.org/django-treebeard/django-treebeard
 
+.. image:: https://ci.appveyor.com/api/projects/status/mwbf062v68lhw05c?svg=true
+    :target: https://ci.appveyor.com/project/mvantellingen/django-treebeard
+
 .. image:: https://img.shields.io/pypi/v/django-treebeard.svg
     :target: https://pypi.org/project/django-treebeard/
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,25 @@
-# Do a dummy build so that AppVeyor doesn't fail
-# while we're waiting for it to be disconnected altogether
+services:
+  - mssql2016
 
-branches:
-  only: []
+environment:
+  matrix:
+    - TOXENV: py36-dj22-mssql
+    - TOXENV: py37-dj22-mssql
+    - TOXENV: py38-dj22-mssql
+    - TOXENV: py36-dj30-mssql
+    - TOXENV: py37-dj30-mssql
+    - TOXENV: py38-dj30-mssql
+    - TOXENV: py36-dj31-mssql
+    - TOXENV: py37-dj31-mssql
+    - TOXENV: py38-dj31-mssql
 
-build: false  # i.e. do nut run msbuild
+matrix:
+  fast_finish: true
+
+install:
+  - C:\Python36\python -m pip install tox
+
+build: false  # Not a C# project
+
+test_script:
+  - C:\Python36\scripts\tox

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@
 
 [tox]
 envlist =
-    py{36,37,38}-dj{22,30,31}-{sqlite,postgres,mysql}
+    py{36,37,38}-dj{22,30,31}-{sqlite,postgres,mysql,mssql}
 
 [testenv:docs]
 basepython = python
@@ -25,9 +25,11 @@ deps =
     dj31: Django>=3.1,<3.2
     postgres: psycopg2>=2.6
     mysql: mysqlclient>=1.3.9
+    mssql: django-mssql-backend>=2.8.1
 
 setenv =
     sqlite: DATABASE_ENGINE=sqlite
     postgres: DATABASE_ENGINE=psql
     mysql: DATABASE_ENGINE=mysql
+    mssql: DATABASE_ENGINE=mssql
 commands = pytest

--- a/treebeard/tests/settings.py
+++ b/treebeard/tests/settings.py
@@ -36,6 +36,19 @@ def get_db_conf():
             'HOST': '127.0.0.1',
             'PORT': '',
         }
+    elif database_engine == "mssql":
+        return {
+            'ENGINE': 'sql_server.pyodbc',
+            'NAME': 'master',
+            'USER': 'sa',
+            'PASSWORD': 'Password12!',
+            'HOST': '(local)\\SQL2016',
+            'PORT': '',
+            'OPTIONS': {
+                'driver': 'SQL Server Native Client 11.0',
+                'MARS_Connection': 'True',
+            },
+        }
 
 DATABASES = {'default': get_db_conf()}
 SECRET_KEY = '7r33b34rd'


### PR DESCRIPTION
https://github.com/ESSolutions/django-mssql-backend is a fork of `django-pyodbc-azure` which supports newer versions of Django, and should let us reinstate the CI tests for MSSQL.