### PR TITLE
Alternative pk field name

### DIFF
--- a/treebeard/al_tree.py
+++ b/treebeard/al_tree.py
@@ -161,7 +161,7 @@ class AL_Node(Node):
         return self.pk in [obj.pk for obj in node.get_descendants()]
 
     @classmethod
-    def dump_bulk(cls, parent=None, keep_ids=True):
+    def dump_bulk(cls, parent=None, keep_pks=True):
         """Dumps a tree branch to a python data structure."""
 
         serializable_cls = cls._get_serializable_model()
@@ -175,6 +175,7 @@ class AL_Node(Node):
         objs = serializable_cls.get_tree(parent)
 
         ret, lnk = [], {}
+        pk_field = cls._meta.pk.attname
         for node, pyobj in zip(objs, serializers.serialize('python', objs)):
             depth = node.get_depth()
             # django's serializer stores the attributes in 'fields'
@@ -185,12 +186,12 @@ class AL_Node(Node):
             if 'sib_order' in fields:
                 del fields['sib_order']
 
-            if 'id' in fields:
-                del fields['id']
+            if pk_field in fields:
+                del fields[pk_field]
 
             newobj = {'data': fields}
-            if keep_ids:
-                newobj['id'] = pyobj['pk']
+            if keep_pks:
+                newobj[pk_field] = pyobj['pk']
 
             if (not parent and depth == 1) or\
                (parent and depth == parent.get_depth()):

--- a/treebeard/al_tree.py
+++ b/treebeard/al_tree.py
@@ -161,7 +161,7 @@ class AL_Node(Node):
         return self.pk in [obj.pk for obj in node.get_descendants()]
 
     @classmethod
-    def dump_bulk(cls, parent=None, keep_pks=True):
+    def dump_bulk(cls, parent=None, keep_ids=True):
         """Dumps a tree branch to a python data structure."""
 
         serializable_cls = cls._get_serializable_model()
@@ -190,7 +190,7 @@ class AL_Node(Node):
                 del fields[pk_field]
 
             newobj = {'data': fields}
-            if keep_pks:
+            if keep_ids:
                 newobj[pk_field] = pyobj['pk']
 
             if (not parent and depth == 1) or\

--- a/treebeard/forms.py
+++ b/treebeard/forms.py
@@ -98,8 +98,8 @@ class MoveNodeForm(forms.ModelForm):
         choices = self.mk_dropdown_tree(opts.model, for_node=instance)
         self.declared_fields['_ref_node_id'].choices = choices
         # use the formfield `to_python` method to coerse the field for custom ids
-        idFormField = opts.model._meta.get_field('id').formfield()
-        self.declared_fields['_ref_node_id'].coerce = idFormField.to_python if idFormField else int
+        pkFormField = opts.model._meta.pk.formfield()
+        self.declared_fields['_ref_node_id'].coerce = pkFormField.to_python if pkFormField else int
 
         # put initial data for these fields into a map, update the map with
         # initial data, and pass this new map to the parent constructor as

--- a/treebeard/models.py
+++ b/treebeard/models.py
@@ -61,7 +61,7 @@ class Node(models.Model):
                     pk=node_data[key])
 
     @classmethod
-    def load_bulk(cls, bulk_data, parent=None, keep_ids=False):
+    def load_bulk(cls, bulk_data, parent=None, keep_pks=False):
         """
         Loads a list/dictionary structure to the tree.
 
@@ -85,11 +85,11 @@ class Node(models.Model):
             nodes
 
 
-        :param keep_ids:
+        :param keep_pks:
 
-            If enabled, loads the nodes with the same id that are given in the
-            structure. Will error if there are nodes without id info or if the
-            ids are already used.
+            If enabled, loads the nodes with the same pk that are given in the
+            structure. Will error if there are nodes without pk info or if the
+            pks are already used.
 
 
         :returns: A list of the added node ids.
@@ -100,14 +100,15 @@ class Node(models.Model):
         # stack of nodes to analyze
         stack = [(parent, node) for node in bulk_data[::-1]]
         foreign_keys = cls.get_foreign_keys()
+        pk_field = cls._meta.pk.attname
 
         while stack:
             parent, node_struct = stack.pop()
             # shallow copy of the data structure so it doesn't persist...
             node_data = node_struct['data'].copy()
             cls._process_foreign_keys(foreign_keys, node_data)
-            if keep_ids:
-                node_data['id'] = node_struct['id']
+            if keep_pks:
+                node_data[pk_field] = node_struct[pk_field]
             if parent:
                 node_obj = parent.add_child(**node_data)
             else:
@@ -123,7 +124,7 @@ class Node(models.Model):
         return added
 
     @classmethod
-    def dump_bulk(cls, parent=None, keep_ids=True):  # pragma: no cover
+    def dump_bulk(cls, parent=None, keep_pks=True):  # pragma: no cover
         """
         Dumps a tree branch to a python data structure.
 
@@ -132,9 +133,9 @@ class Node(models.Model):
             The node whose descendants will be dumped. The node itself will be
             included in the dump. If not given, the entire tree will be dumped.
 
-        :param keep_ids:
+        :param keep_pks:
 
-            Stores the id value (primary key) of every node. Enabled by
+            Stores the pk value (primary key) of every node. Enabled by
             default.
 
         :returns: A python data structure, described with detail in

--- a/treebeard/models.py
+++ b/treebeard/models.py
@@ -61,7 +61,7 @@ class Node(models.Model):
                     pk=node_data[key])
 
     @classmethod
-    def load_bulk(cls, bulk_data, parent=None, keep_pks=False):
+    def load_bulk(cls, bulk_data, parent=None, keep_ids=False):
         """
         Loads a list/dictionary structure to the tree.
 
@@ -85,11 +85,11 @@ class Node(models.Model):
             nodes
 
 
-        :param keep_pks:
+        :param keep_ids:
 
-            If enabled, loads the nodes with the same pk that are given in the
-            structure. Will error if there are nodes without pk info or if the
-            pks are already used.
+            If enabled, loads the nodes with the same primary keys that are
+            given in the structure. Will error if there are nodes without
+            primary key info or if the primary keys are already used.
 
 
         :returns: A list of the added node ids.
@@ -107,7 +107,7 @@ class Node(models.Model):
             # shallow copy of the data structure so it doesn't persist...
             node_data = node_struct['data'].copy()
             cls._process_foreign_keys(foreign_keys, node_data)
-            if keep_pks:
+            if keep_ids:
                 node_data[pk_field] = node_struct[pk_field]
             if parent:
                 node_obj = parent.add_child(**node_data)
@@ -124,7 +124,7 @@ class Node(models.Model):
         return added
 
     @classmethod
-    def dump_bulk(cls, parent=None, keep_pks=True):  # pragma: no cover
+    def dump_bulk(cls, parent=None, keep_ids=True):  # pragma: no cover
         """
         Dumps a tree branch to a python data structure.
 
@@ -133,7 +133,7 @@ class Node(models.Model):
             The node whose descendants will be dumped. The node itself will be
             included in the dump. If not given, the entire tree will be dumped.
 
-        :param keep_pks:
+        :param keep_ids:
 
             Stores the pk value (primary key) of every node. Enabled by
             default.

--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -625,7 +625,7 @@ class MP_Node(Node):
         return MP_AddRootHandler(cls, **kwargs).process()
 
     @classmethod
-    def dump_bulk(cls, parent=None, keep_ids=True):
+    def dump_bulk(cls, parent=None, keep_pks=True):
         """Dumps a tree branch to a python data structure."""
 
         cls = get_result_class(cls)
@@ -637,6 +637,7 @@ class MP_Node(Node):
         if parent:
             qset = qset.filter(path__startswith=parent.path)
         ret, lnk = [], {}
+        pk_field = cls._meta.pk.attname
         for pyobj in serializers.serialize('python', qset):
             # django's serializer stores the attributes in 'fields'
             fields = pyobj['fields']
@@ -646,13 +647,13 @@ class MP_Node(Node):
             del fields['depth']
             del fields['path']
             del fields['numchild']
-            if 'id' in fields:
+            if pk_field in fields:
                 # this happens immediately after a load_bulk
-                del fields['id']
+                del fields[pk_field]
 
             newobj = {'data': fields}
-            if keep_ids:
-                newobj['id'] = pyobj['pk']
+            if keep_pks:
+                newobj[pk_field] = pyobj['pk']
 
             if (not parent and depth == 1) or\
                (parent and len(path) == len(parent.path)):

--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -625,7 +625,7 @@ class MP_Node(Node):
         return MP_AddRootHandler(cls, **kwargs).process()
 
     @classmethod
-    def dump_bulk(cls, parent=None, keep_pks=True):
+    def dump_bulk(cls, parent=None, keep_ids=True):
         """Dumps a tree branch to a python data structure."""
 
         cls = get_result_class(cls)
@@ -652,7 +652,7 @@ class MP_Node(Node):
                 del fields[pk_field]
 
             newobj = {'data': fields}
-            if keep_pks:
+            if keep_ids:
                 newobj[pk_field] = pyobj['pk']
 
             if (not parent and depth == 1) or\

--- a/treebeard/ns_tree.py
+++ b/treebeard/ns_tree.py
@@ -483,7 +483,7 @@ class NS_Node(Node):
         return sql, []
 
     @classmethod
-    def load_bulk(cls, bulk_data, parent=None, keep_ids=False):
+    def load_bulk(cls, bulk_data, parent=None, keep_pks=False):
         """Loads a list/dictionary structure to the tree."""
 
         cls = get_result_class(cls)
@@ -497,13 +497,14 @@ class NS_Node(Node):
         # stack of nodes to analize
         stack = [(parent_id, node) for node in bulk_data[::-1]]
         foreign_keys = cls.get_foreign_keys()
+        pk_field = cls._meta.pk.attname
         while stack:
             parent_id, node_struct = stack.pop()
             # shallow copy of the data strucure so it doesn't persist...
             node_data = node_struct['data'].copy()
             cls._process_foreign_keys(foreign_keys, node_data)
-            if keep_ids:
-                node_data['id'] = node_struct['id']
+            if keep_pks:
+                node_data[pk_field] = node_struct[pk_field]
             if parent_id:
                 parent = cls.objects.get(pk=parent_id)
                 node_obj = parent.add_child(**node_data)
@@ -552,10 +553,11 @@ class NS_Node(Node):
         return self.get_parent(True).get_children()
 
     @classmethod
-    def dump_bulk(cls, parent=None, keep_ids=True):
+    def dump_bulk(cls, parent=None, keep_pks=True):
         """Dumps a tree branch to a python data structure."""
         qset = cls._get_serializable_model().get_tree(parent)
         ret, lnk = [], {}
+        pk_field = cls._meta.pk.attname
         for pyobj in qset:
             serobj = serializers.serialize('python', [pyobj])[0]
             # django's serializer stores the attributes in 'fields'
@@ -566,13 +568,13 @@ class NS_Node(Node):
             del fields['rgt']
             del fields['depth']
             del fields['tree_id']
-            if 'id' in fields:
+            if pk_field in fields:
                 # this happens immediately after a load_bulk
-                del fields['id']
+                del fields[pk_field]
 
             newobj = {'data': fields}
-            if keep_ids:
-                newobj['id'] = serobj['pk']
+            if keep_pks:
+                newobj[pk_field] = serobj['pk']
 
             if (not parent and depth == 1) or\
                (parent and depth == parent.depth):

--- a/treebeard/ns_tree.py
+++ b/treebeard/ns_tree.py
@@ -483,7 +483,7 @@ class NS_Node(Node):
         return sql, []
 
     @classmethod
-    def load_bulk(cls, bulk_data, parent=None, keep_pks=False):
+    def load_bulk(cls, bulk_data, parent=None, keep_ids=False):
         """Loads a list/dictionary structure to the tree."""
 
         cls = get_result_class(cls)
@@ -503,7 +503,7 @@ class NS_Node(Node):
             # shallow copy of the data strucure so it doesn't persist...
             node_data = node_struct['data'].copy()
             cls._process_foreign_keys(foreign_keys, node_data)
-            if keep_pks:
+            if keep_ids:
                 node_data[pk_field] = node_struct[pk_field]
             if parent_id:
                 parent = cls.objects.get(pk=parent_id)
@@ -553,7 +553,7 @@ class NS_Node(Node):
         return self.get_parent(True).get_children()
 
     @classmethod
-    def dump_bulk(cls, parent=None, keep_pks=True):
+    def dump_bulk(cls, parent=None, keep_ids=True):
         """Dumps a tree branch to a python data structure."""
         qset = cls._get_serializable_model().get_tree(parent)
         ret, lnk = [], {}
@@ -573,7 +573,7 @@ class NS_Node(Node):
                 del fields[pk_field]
 
             newobj = {'data': fields}
-            if keep_pks:
+            if keep_ids:
                 newobj[pk_field] = serobj['pk']
 
             if (not parent and depth == 1) or\

--- a/treebeard/templatetags/admin_tree_list.py
+++ b/treebeard/templatetags/admin_tree_list.py
@@ -12,7 +12,8 @@ CHECKBOX_TMPL = ('<input type="checkbox" class="action-select" value="{}" '
 
 
 def _line(context, node, request):
-    if TO_FIELD_VAR in request.GET and request.GET[TO_FIELD_VAR] == 'id':
+    pk_field = node._meta.model._meta.pk.attname
+    if TO_FIELD_VAR in request.GET and request.GET[TO_FIELD_VAR] == pk_field:
         raw_id_fields = format_html("""
         onclick="opener.dismissRelatedLookupPopup(window, '{}'); return false;"
         """, mark_safe(node.pk))

--- a/treebeard/tests/models.py
+++ b/treebeard/tests/models.py
@@ -222,7 +222,11 @@ class MP_TestNodeShortPath(MP_Node):
 
 class MP_TestNodeUuid(MP_Node):
     steplen = 1
-    id = models.UUIDField(primary_key=True, default=uuid.uuid1, editable=False)
+    custom_id = models.UUIDField(
+        primary_key=True,
+        default=uuid.uuid1,
+        editable=False
+    )
 
     desc = models.CharField(max_length=255)
 

--- a/treebeard/tests/test_treebeard.py
+++ b/treebeard/tests/test_treebeard.py
@@ -163,7 +163,7 @@ class TestEmptyTree(TestTreeBase):
     def test_load_bulk_empty(self, model):
         ids = model.load_bulk(BASE_DATA)
         got_descs = [obj.desc
-                     for obj in model.objects.filter(id__in=ids)]
+                     for obj in model.objects.filter(pk__in=ids)]
         expected_descs = [x[0] for x in UNCHANGED]
         assert sorted(got_descs) == sorted(expected_descs)
         assert self.got(model) == UNCHANGED
@@ -238,7 +238,7 @@ class TestClassMethods(TestNonEmptyTree):
                     ('41', 2, 0)]
         expected_descs = ['1', '2', '21', '22', '23', '231', '24',
                           '3', '4', '41']
-        got_descs = [obj.desc for obj in model.objects.filter(id__in=ids)]
+        got_descs = [obj.desc for obj in model.objects.filter(pk__in=ids)]
         assert sorted(got_descs) == sorted(expected_descs)
         assert self.got(model) == expected
 
@@ -1981,7 +1981,7 @@ class TestMP_TreeFindProblems(TestTreeBase):
 
         def got(ids):
             return [o.path for o in
-                    mpalphabet_model.objects.filter(id__in=ids)]
+                    mpalphabet_model.objects.filter(pk__in=ids)]
 
         (evil_chars, bad_steplen, orphans, wrong_depth, wrong_numchild) = (
             mpalphabet_model.find_problems())

--- a/treebeard/tests/test_treebeard.py
+++ b/treebeard/tests/test_treebeard.py
@@ -250,7 +250,7 @@ class TestClassMethods(TestNonEmptyTree):
         assert all([type(o) == model for o in nodes])
 
     def test_dump_bulk_all(self, model):
-        assert model.dump_bulk(keep_ids=False) == BASE_DATA
+        assert model.dump_bulk(keep_pks=False) == BASE_DATA
 
     def test_get_tree_node(self, model):
         node = model.objects.get(desc='231')
@@ -319,10 +319,10 @@ class TestClassMethods(TestNonEmptyTree):
         assert got == expected
 
     def test_load_and_dump_bulk_keeping_ids(self, model):
-        exp = model.dump_bulk(keep_ids=True)
+        exp = model.dump_bulk(keep_pks=True)
         model.objects.all().delete()
         model.load_bulk(exp, None, True)
-        got = model.dump_bulk(keep_ids=True)
+        got = model.dump_bulk(keep_pks=True)
         assert got == exp
         # do we really have an unchaged tree after the dump/delete/load?
         got = [(o.desc, o.get_depth(), o.get_children_count())
@@ -350,7 +350,7 @@ class TestClassMethods(TestNonEmptyTree):
                 {'data': {'desc': '41', 'related': related.pk}},
             ]}]
         related_model.load_bulk(related_data)
-        got = related_model.dump_bulk(keep_ids=False)
+        got = related_model.dump_bulk(keep_pks=False)
         assert got == related_data
 
     def test_get_root_nodes(self, model):

--- a/treebeard/tests/test_treebeard.py
+++ b/treebeard/tests/test_treebeard.py
@@ -250,7 +250,7 @@ class TestClassMethods(TestNonEmptyTree):
         assert all([type(o) == model for o in nodes])
 
     def test_dump_bulk_all(self, model):
-        assert model.dump_bulk(keep_pks=False) == BASE_DATA
+        assert model.dump_bulk(keep_ids=False) == BASE_DATA
 
     def test_get_tree_node(self, model):
         node = model.objects.get(desc='231')
@@ -319,10 +319,10 @@ class TestClassMethods(TestNonEmptyTree):
         assert got == expected
 
     def test_load_and_dump_bulk_keeping_ids(self, model):
-        exp = model.dump_bulk(keep_pks=True)
+        exp = model.dump_bulk(keep_ids=True)
         model.objects.all().delete()
         model.load_bulk(exp, None, True)
-        got = model.dump_bulk(keep_pks=True)
+        got = model.dump_bulk(keep_ids=True)
         assert got == exp
         # do we really have an unchaged tree after the dump/delete/load?
         got = [(o.desc, o.get_depth(), o.get_children_count())
@@ -350,7 +350,7 @@ class TestClassMethods(TestNonEmptyTree):
                 {'data': {'desc': '41', 'related': related.pk}},
             ]}]
         related_model.load_bulk(related_data)
-        got = related_model.dump_bulk(keep_pks=False)
+        got = related_model.dump_bulk(keep_ids=False)
         assert got == related_data
 
     def test_get_root_nodes(self, model):

--- a/treebeard/tests/test_treebeard.py
+++ b/treebeard/tests/test_treebeard.py
@@ -731,7 +731,7 @@ class TestAddChild(TestNonEmptyTree):
         If the model is using a natural primary key then it will be
         already set when the instance is inserted.
         """
-        child = model(id=999999, desc='natural key')
+        child = model(pk=999999, desc='natural key')
         result = model.objects.get(desc='2').add_child(instance=child)
         assert result == child
 
@@ -963,7 +963,7 @@ class TestAddSibling(TestNonEmptyTree):
         If the model is using a natural primary key then it will be
         already set when the instance is inserted.
         """
-        child = model(id=999999, desc='natural key')
+        child = model(pk=999999, desc='natural key')
         result = model.objects.get(desc='2').add_child(instance=child)
         assert result == child
 

--- a/treebeard/tests/test_treebeard.py
+++ b/treebeard/tests/test_treebeard.py
@@ -2608,9 +2608,10 @@ class TestAdminTreeList(TestNonEmptyTree):
 
     def test_result_tree_list_with_get(self, model_without_proxy):
         model = model_without_proxy
+        pk_field = model._meta.pk.attname
         # Test t GET parameter with value id
         request = RequestFactory().get(
-            '/admin/tree/?{0}=id'.format(TO_FIELD_VAR))
+            '/admin/tree/?{0}={1}'.format(TO_FIELD_VAR, pk_field))
         request.user = AnonymousUser()
         site = AdminSite()
         admin_register_all(site)


### PR DESCRIPTION
Models don't always have their pk in a column labeled 'id'. This addition allows for alternative pk column names.