### PR TITLE
Add stub github action, to which we'll move CI tests.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        tox-python-version: [39]
+        django-version: [3.1]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2


### PR DESCRIPTION
This adds a Github Actions workflow that (currently) does nothing - in order to get actions working for the repo. Once this is merged I'll work on moving the CI tests from Travis (see #214), which will need a bit of trial and error to get working.