### PR TITLE
Declare support for Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -114,7 +114,7 @@ before_install:
   - sudo service postgresql restart 11
 
 install:
-  - pip install tox codecov
+  - pip install tox
 
 script: tox
 

--- a/docs/source/tests.rst
+++ b/docs/source/tests.rst
@@ -24,12 +24,13 @@ You can use all the features and plugins of pytest this way.
 By default the test suite will run using a sqlite3 database in RAM, but you can
 change this setting environment variables:
 
-.. option:: DATABASE_ENGINE
-.. option:: DATABASE_NAME
 .. option:: DATABASE_USER
 .. option:: DATABASE_PASSWORD
 .. option:: DATABASE_HOST
-.. option:: DATABASE_PORT
+.. option:: DATABASE_USER_POSTGRES
+.. option:: DATABASE_PORT_POSTGRES
+.. option:: DATABASE_USER_MYSQL
+.. option:: DATABASE_PORT_MYSQL
 
    Sets the database settings to be used by the test suite. Useful if you
    want to test the same database engine/version you use in production.
@@ -41,9 +42,9 @@ tox
 ``django-treebeard`` uses `tox`_ to run the test suite in all the supported
 environments - permutations of:
 
-  - Python 3.6, 3.7 and 3.8
+  - Python 3.6, 3.7, 3.8 and 3.9
   - Django 2.2, 3.0 and 3.1
-  - Sqlite, MySQL and PostgreSQL
+  - Sqlite, MySQL, PostgreSQL and MSSQL
 
 This means that the test suite will run 24 times to test every
 environment supported by ``django-treebeard``. This takes a long time.
@@ -52,9 +53,8 @@ option in `tox`_, like:
 
 .. code-block:: console
 
-    $ tox -e py36-dj22-pgsql
+    $ tox -e py36-dj22-postgres
 
 
 .. _pytest: http://pytest.org/
-.. _coverage: http://nedbatchelder.com/code/coverage/
-.. _tox: http://codespeak.net/tox/
+.. _tox: https://tox.readthedocs.io/en/latest/index.html

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup_args = dict(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Operating System :: OS Independent',
         'Topic :: Software Development :: Libraries',
         'Topic :: Utilities'])


### PR DESCRIPTION
- Add Python 3.9 to the supported Python versions in setup.py (this is needed to make the package available for that version of Python from PyPi).
- Fix up documentation for running tests.