### PR TITLE
Fix indentation in docstring of `get_sorted_pos_queryset`

### DIFF
--- a/treebeard/models.py
+++ b/treebeard/models.py
@@ -544,8 +544,10 @@ class Node(models.Model):
 
     def get_sorted_pos_queryset(self, siblings, newobj):
         """
-        :returns: A queryset of the nodes that must be moved
-        to the right. Called only for Node models with :attr:`node_order_by`
+        :returns:
+
+            A queryset of the nodes that must be moved to the right.
+            Called only for Node models with :attr:`node_order_by`
 
         This function is based on _insertion_target_filters from django-mptt
         (BSD licensed) by Jonathan Buchanan:


### PR DESCRIPTION
When I build the documentation of my model which inherits from `Node` with sphinx and the `:inherited-members:` included, I get the following warning:

```
/path/to/django/models/tree_node_model.py:docstring of treebeard.models.Node.get_sorted_pos_queryset:2:
WARNING: Field list ends without a blank line; unexpected unindent.
```

and it is rendered as follows:

![Screenshot 2022-01-10 at 20-47-25 Languages — integreat-cms 2021 12 0-beta documentation](https://user-images.githubusercontent.com/16021269/148829681-b2802b24-a61a-454d-aab3-255bc510b823.png)

While with my patch, the warning is gone and the documentation looks like this:

![Screenshot 2022-01-10 at 20-45-45 Languages — integreat-cms 2021 12 0-beta documentation](https://user-images.githubusercontent.com/16021269/148829741-7d36d1e3-b11a-4009-abf4-df1ecb4eefc6.png)

Since this is such a minor problem and trivial fix, I didn't open an issue for it, but I can do so if you prefer.
Thanks in advance for your feedback!