### PR TITLE
Save already constructed instance in MoveNodeForm

### DIFF
--- a/treebeard/forms.py
+++ b/treebeard/forms.py
@@ -138,17 +138,13 @@ class MoveNodeForm(forms.ModelForm):
         position_type, reference_node_id = self._clean_cleaned_data()
 
         if self.instance._state.adding:
-            cl_data = {}
-            for field in self.cleaned_data:
-                if not isinstance(self.cleaned_data[field], (list, QuerySet)):
-                    cl_data[field] = self.cleaned_data[field]
             if reference_node_id:
                 reference_node = self._meta.model.objects.get(
                     pk=reference_node_id)
-                self.instance = reference_node.add_child(**cl_data)
+                self.instance = reference_node.add_child(instance=self.instance)
                 self.instance.move(reference_node, pos=position_type)
             else:
-                self.instance = self._meta.model.add_root(**cl_data)
+                self.instance = self._meta.model.add_root(instance=self.instance)
         else:
             self.instance.save()
             if reference_node_id:

--- a/treebeard/tests/test_treebeard.py
+++ b/treebeard/tests/test_treebeard.py
@@ -2553,6 +2553,14 @@ class TestForm(TestNonEmptyTree):
         assert form.save() is not None
         assert original_count < model.objects.all().count()
 
+    def test_save_instance(self, model):
+        form_class = movenodeform_factory(model)
+        form = form_class(data={'_position': 'first-child', 'desc': 'Test Instance'})
+        assert form.is_valid()
+        form.instance.desc = "Modified Instance"
+        instance = form.save()
+        assert instance.desc == "Modified Instance"
+
 
 class TestAdminTreeTemplateTags(TestCase):
     def test_treebeard_css(self):


### PR DESCRIPTION
Since there weren't any updates on #177 for exactly one year now, I decided to contribute the requested changes to that PR (see https://github.com/django-treebeard/django-treebeard/pull/177#issuecomment-761757727).
The new test case should fail on the current master branch and succeed after the patch has been applied.

Since there wasn't an "unreleased" section or similar in the [CHANGES.md](https://github.com/django-treebeard/django-treebeard/blob/master/CHANGES.md), I didn't know whether to include a notice there. But if you want, I can of course add this.

Thanks in advance for your feedback!

Fixes: #176, closes #177.