### PR TITLE
docs: Fix a few typos

### DIFF
--- a/treebeard/exceptions.py
+++ b/treebeard/exceptions.py
@@ -6,7 +6,7 @@ class InvalidPosition(Exception):
 
 
 class InvalidMoveToDescendant(Exception):
-    """Raised when attemping to move a node to one of it's descendants."""
+    """Raised when attempting to move a node to one of it's descendants."""
 
 
 class NodeAlreadySaved(Exception):

--- a/treebeard/ns_tree.py
+++ b/treebeard/ns_tree.py
@@ -494,13 +494,13 @@ class NS_Node(Node):
             parent_id = parent.pk
         else:
             parent_id = None
-        # stack of nodes to analize
+        # stack of nodes to analyze
         stack = [(parent_id, node) for node in bulk_data[::-1]]
         foreign_keys = cls.get_foreign_keys()
         pk_field = cls._meta.pk.attname
         while stack:
             parent_id, node_struct = stack.pop()
-            # shallow copy of the data strucure so it doesn't persist...
+            # shallow copy of the data structure so it doesn't persist...
             node_data = node_struct['data'].copy()
             cls._process_foreign_keys(foreign_keys, node_data)
             if keep_ids:

--- a/treebeard/static/treebeard/treebeard-admin.js
+++ b/treebeard/static/treebeard/treebeard-admin.js
@@ -36,7 +36,7 @@
                 return $('tr[parent=' + node_id + ']');
             },
             collapse: function () {
-                // For each children, hide it's childrens and so on...
+                // For each children, hide it's children and so on...
                 $.each(this.children(),function () {
                     var node = new Node(this);
                     node.collapse();
@@ -144,7 +144,7 @@
                 $('tr', node.$elem.parent()).each(function (index, element) {
                     $row = $(element);
                     rtop = $row.offset().top;
-                    // The tooltop will display whether I'm droping the element as
+                    // The tooltip will display whether I'm dropping the element as
                     // child or sibling
                     $tooltip = $drag_line.find('span');
                     $tooltip.css({

--- a/treebeard/templatetags/admin_tree.py
+++ b/treebeard/templatetags/admin_tree.py
@@ -177,7 +177,7 @@ def results(cl):
 
 def check_empty_dict(GET_dict):
     """
-    Returns True if the GET querstring contains on values, but it can contain
+    Returns True if the GET query string contains on values, but it can contain
     empty keys.
     This is better than doing not bool(request.GET) as an empty key will return
     True

--- a/treebeard/tests/test_treebeard.py
+++ b/treebeard/tests/test_treebeard.py
@@ -345,7 +345,7 @@ class TestClassMethods(TestNonEmptyTree):
         model.load_bulk(exp, None, True)
         got = model.dump_bulk(keep_ids=True)
         assert got == exp
-        # do we really have an unchaged tree after the dump/delete/load?
+        # do we really have an unchanged tree after the dump/delete/load?
         got = [
             (o.desc, o.get_depth(), o.get_children_count()) for o in model.get_tree()
         ]


### PR DESCRIPTION
There are small typos in:
- treebeard/exceptions.py
- treebeard/ns_tree.py
- treebeard/static/treebeard/treebeard-admin.js
- treebeard/templatetags/admin_tree.py
- treebeard/tests/test_treebeard.py

Fixes:
- Should read `unchanged` rather than `unchaged`.
- Should read `tooltip` rather than `tooltop`.
- Should read `structure` rather than `strucure`.
- Should read `query string` rather than `querstring`.
- Should read `dropping` rather than `droping`.
- Should read `children` rather than `childrens`.
- Should read `attempting` rather than `attemping`.
- Should read `analyze` rather than `analize`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md