### PR TITLE
Update node delete() methods to match Django's delete API.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,18 @@
+Release 4.6 (in development)
+----------------------------
+
+* Drop support for Django 3.1 and lower.
+* Add support for Django 4.0 and 4.1.
+* Drop support for Python 3.7 and lower.
+* Add support for Python 3.10 and Python 3.11.
+* Change the return value of `delete()` for all node classes to be consistent with Django,
+  and return a tuple of the number of objects deleted and a dictionary with the number of 
+  deletions per object type.
+* Change the `delete()` methods for all node classes to accept arbitrary positional and 
+  keyword arguments which are passed to the parent method.
+* Set `alters_data` and `queryset_only` attributes on the `delete()` methods for all node classes
+  to prevent them being used in an unwanted context (e.g., in Django templates).
+
 Release 4.5.1 (Feb 22, 2021)
 ----------------------------
 

--- a/treebeard/models.py
+++ b/treebeard/models.py
@@ -499,9 +499,12 @@ class Node(models.Model):
         """
         raise NotImplementedError
 
-    def delete(self):
+    def delete(self, *args, **kwargs):
         """Removes a node and all it's descendants."""
-        self.__class__.objects.filter(pk=self.pk).delete()
+        return self.__class__.objects.filter(pk=self.pk).delete(*args, **kwargs)
+
+    delete.alters_data = True
+    delete.queryset_only = True
 
     def _prepare_pos_var(self, pos, method_name, valid_pos, valid_sorted_pos):
         if pos is None:


### PR DESCRIPTION
- Return the number of objects deleted and a dictionary with the number of deletions per object type, consistent with what Django does.
- Accept aribitrary arguments to the delete() method to support overridden models and Django's own `using` and `keep_parents` arguments.
- Set `alters_data` and `queryset_only` attributes on delete methods, to prevent them being used in an unwanted context.

I wonder whether this is enough of an API change that we need to do a major release rather than minor - open to input on this.

Fixes #197, fixes #61, fixes #160.