### PR TITLE
Stop MP_Node.get_descendants from querying the db on leaf nodes

### DIFF
--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -1027,6 +1027,8 @@ class MP_Node(Node):
         :returns: A queryset of all the node's descendants as DFS, doesn't
             include the node itself
         """
+        if self.is_leaf():
+            return get_result_class(self.__class__).objects.none()
         return self.__class__.get_tree(self).exclude(pk=self.pk)
 
     def get_prev_sibling(self):

--- a/treebeard/tests/test_treebeard.py
+++ b/treebeard/tests/test_treebeard.py
@@ -3044,3 +3044,24 @@ class TestMPFormPerformance(object):
         form = form_class()
         with django_assert_num_queries(len(model.get_root_nodes()) + 1):
             form.mk_dropdown_tree(model)
+
+
+@pytest.mark.django_db
+class TestMP_TreeDescendantsPerformance(TestTreeBase):
+    def test_get_descendants_no_of_queries(self, django_assert_num_queries):
+        model = models.MP_TestNode
+        model.load_bulk(BASE_DATA)
+
+        data = [
+            ("2", 1),
+            ("23", 1),
+            ("231", 0),
+            ("1", 0),
+            ("4", 1),
+        ]
+
+        for desc, expected in data:
+            node = model.objects.get(desc=desc)
+            with django_assert_num_queries(expected):
+                # converting to list to force queryset evaluation
+                list(node.get_descendants())


### PR DESCRIPTION
Fixes https://github.com/django-treebeard/django-treebeard/issues/268 and adds a test case.