### PR TITLE
Improve compatibility with 3rd-party database backend

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+un-Released 4.7.x (??? ??, 2023)
+----------------------------
+
+* Improve compatibility with 3rd-party database backends not supported officially.
+
 Release 4.7 (Apr 7, 2023)
 ----------------------------
 


### PR DESCRIPTION
We ran into an issue updating `depth` field of `MP_Node` model when working with [database backend other than officially supported](https://docs.djangoproject.com/en/4.2/ref/databases/#using-a-3rd-party-database-backend) by Django and/or  `django-treebeard`. In particular we are on PostgreSQL-like backend – [CockroachDB](https://pypi.org/project/django-cockroachdb/). Whenever there is required an update of the `depth` field we get error "**django.db.utils.DataError: unsupported binary operator: &lt;int&gt; / &lt;int&gt; (desired &lt;int&gt;)**".

Doing some research, I found that `django-treebeard` heavily uses raw and hardcoded SQL to perform some operations, and in this particular case the part of SQL UPDATE statement, that triggers that error, is this `depth` update expression: '_UPDATE … SET path=…, **depth=LENGTH(%s||SUBSTR(path, %s))/%s** WHERE …_'. What happens here is that `depth` is declared as `django.db.models.PositiveIntegerField()`, but division **int** by **int** might not always be an integer. Most databases will do implicit cast to integer here, but some databases are stricter and require explicit cast here.

So, in this PR I propose to introduce an explicit CAST here, by re-writing this update expression like this:  
`depth=CAST(LENGTH(%s||SUBSTR(path, %s))/%s AS <db-specific-type-name>)`, where _&lt;db-specific-type-name&gt;_ is database data type name that implements `PositiveIntegerField()` on a given database backend.

CAST function is supported on all the officially supported database back-ends, so it should not introduce any breaking impact. 
