### PR TITLE
Update to link to 2nd edition of SQL for Smarties

### DIFF
--- a/docs/source/ns_tree.rst
+++ b/docs/source/ns_tree.rst
@@ -78,4 +78,4 @@ write/delete operations.
 
 .. _`Joe Celko`: http://en.wikipedia.org/wiki/Joe_Celko
 .. _`Trees and Hierarchies in SQL for Smarties`:
-  http://www.elsevier.com/wps/product/cws_home/702605
+  https://shop.elsevier.com/books/joe-celkos-trees-and-hierarchies-in-sql-for-smarties/celko/978-0-12-387733-8


### PR DESCRIPTION
This just updates the link to refer to the 2nd edition of the book.

Searched here: https://www.elsevier.com/search-results?query=trees%20and%20hierarchies

1st edition: https://shop.elsevier.com/books/joe-celkos-trees-and-hierarchies-in-sql-for-smarties/celko/978-1-55860-920-4

2nd edition: https://shop.elsevier.com/books/joe-celkos-trees-and-hierarchies-in-sql-for-smarties/celko/978-0-12-387733-8