### PR TITLE
Add `include_self=False` to `get_descendants()` in `al_tree.py`, `mp_tree.py` and `ns_tree.py`

### DIFF
--- a/treebeard/al_tree.py
+++ b/treebeard/al_tree.py
@@ -258,11 +258,13 @@ class AL_Node(Node):
         cls._get_tree_recursively(results, parent, depth)
         return results
 
-    def get_descendants(self):
+    def get_descendants(self, include_self=False):
         """
         :returns: A *list* of all the node's descendants, doesn't
-            include the node itself
+            include the node itself if `include_self` is False
         """
+        if include_self:
+            return self.__class__.get_tree(self)
         return self.__class__.get_tree(parent=self)[1:]
 
     def get_descendant_count(self):

--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -1022,11 +1022,13 @@ class MP_Node(Node):
         except IndexError:
             return None
 
-    def get_descendants(self):
+    def get_descendants(self, include_self=False):
         """
         :returns: A queryset of all the node's descendants as DFS, doesn't
-            include the node itself
+            include the node itself if `include_self` is False
         """
+        if include_self:
+            return self.__class__.get_tree(self)
         if self.is_leaf():
             return get_result_class(self.__class__).objects.none()
         return self.__class__.get_tree(self).exclude(pk=self.pk)

--- a/treebeard/ns_tree.py
+++ b/treebeard/ns_tree.py
@@ -628,11 +628,13 @@ class NS_Node(Node):
             tree_id=parent.tree_id,
             lft__range=(parent.lft, parent.rgt - 1))
 
-    def get_descendants(self):
+    def get_descendants(self, include_self=False):
         """
         :returns: A queryset of all the node's descendants as DFS, doesn't
-            include the node itself
+            include the node itself if `include_self` is `False`
         """
+        if include_self:
+            return self.__class__.get_tree(self)
         if self.is_leaf():
             return get_result_class(self.__class__).objects.none()
         return self.__class__.get_tree(self).exclude(pk=self.pk)


### PR DESCRIPTION
I added `include_self=False` to `get_descendants()` as the 2nd argument so that we can choose to include the node itself or not. *I switched from Django-mptt to Django-treebeard because Django-mptt is currently unmaintained but Django-treebeard doesn't have `include_self=False` in `get_descendants()` which Django-mptt has. `include_self=False` is really useful.
