### PR TITLE
fix mp tree move method

### DIFF
--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -552,7 +552,9 @@ class MP_MoveHandler(MP_ComplexAddMoveHandler):
                 self.pos = 'first-sibling'
                 siblings = get_result_class(self.node_cls).objects.none()
             else:
-                self.target = self.target.get_last_child()
+                target_last_child = self.target.get_last_child()
+                if target_last_child is not None:
+                    self.target = target_last_child
                 self.pos = {
                     'first-child': 'first-sibling',
                     'last-child': 'last-sibling',


### PR DESCRIPTION
  In the current implementation, when a user attempts to move a node to a parent node that has no children, they encounter an `AttributeError: 'NoneType' object has no attribute is_descendant_of'`. This error arises because currently, the parent node is replaced with its last child, which is `None` if it doesn't have any children: `self.target = self.target.get_last_child()`.

This pull request aims to rectify this issue by adding a check to see if the `get_last_child()` is `None` before replacing `self.target`. This condition ensures that `self.target` is only reassigned if `self.target.get_last_child() is not None`, thereby eliminating the `AttributeError`.