### PR TITLE
CSP compatibility: don't use inline scripts

### DIFF
--- a/treebeard/static/treebeard/treebeard-admin.js
+++ b/treebeard/static/treebeard/treebeard-admin.js
@@ -6,6 +6,7 @@
     RECENTLY_MOVED_FADEOUT = '#FFFFFF';
     ABORT_COLOR = '#EECCCC';
     DRAG_LINE_COLOR = '#AA00AA';
+    MOVE_NODE_ENDPOINT = 'move/';
 
     RECENTLY_FADE_DURATION = 2000;
 
@@ -226,7 +227,7 @@
                             // Call $.ajax so we can handle the error
                             // On Drop, make an XHR call to perform the node move
                             $.ajax({
-                                url: window.MOVE_NODE_ENDPOINT,
+                                url: MOVE_NODE_ENDPOINT,
                                 type: 'POST',
                                 data: {
                                     node_id: node.node_id,

--- a/treebeard/templates/admin/tree_change_list_results.html
+++ b/treebeard/templates/admin/tree_change_list_results.html
@@ -32,9 +32,6 @@
             </tbody>
         </table>
         <input type="hidden" id="has-filters" value="{{ filtered|yesno:"1,0" }}"/>
-        <script>
-            var MOVE_NODE_ENDPOINT = 'move/';
-        </script>
     </div>
 {% endif %}
 


### PR DESCRIPTION
It's not clear why this needed to be inline in the first place. Inline scripts can't be used with a strong CSP policy.