### PR TITLE
Python 3.12 and Django 5.0 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,11 +15,15 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.8, 3.9, "3.10", 3.11]
-        django-version: [32, 41, 42]
+        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
+        django-version: [32, 41, 42, 50]
         exclude:
           - django-version: 32
             python-version: 3.11
+          - django-version: 50
+            python-version: 3.8
+          - django-version: 50
+            python-version: 3.9
     services:
       postgres:
         image: postgres:13

--- a/README.md
+++ b/README.md
@@ -38,6 +38,6 @@ You can find the documentation in
 
 **django-treebeard** officially supports
 
--   Django 3.2, 4.1, 4.2
--   Python 3.8 - 3.11
+-   Django 3.2, 4.1, 4.2, 5.0
+-   Python 3.8 - 3.12
 -   PostgreSQL, MySQL, MSSQL, SQLite database back-ends.

--- a/setup.py
+++ b/setup.py
@@ -37,11 +37,13 @@ setup_args = dict(
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.1',
         'Framework :: Django :: 4.2',
+        'Framework :: Django :: 5.0',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Operating System :: OS Independent',
         'Topic :: Software Development :: Libraries',
         'Topic :: Utilities'])

--- a/tox.ini
+++ b/tox.ini
@@ -8,6 +8,7 @@
 envlist =
     py{38,39,310}-dj{32}-{sqlite,postgres,mysql,mssql}
     py{38,39,310,311}-dj{40,41}-{sqlite,postgres,mysql,mssql}
+    py{310,311,312}-dj{50}-{sqlite,postgres,mysql,mssql}
 
 [testenv:docs]
 basepython = python
@@ -26,6 +27,7 @@ deps =
     dj32: Django>=3.2,<3.3
     dj41: Django>=4.1,<4.2
     dj42: Django>=4.2,<4.3
+    dj50: Django>=5.0,<5.1
     postgres: psycopg2-binary>=2.9
     mysql: mysqlclient>=2.1.1
     mssql: mssql-django>=1.2


### PR DESCRIPTION
Tests pass on Python 3.12 and Django 5.0