### PR TITLE
Fix: Allow usage of CSRF_COOKIE_HTTPONLY

### DIFF
--- a/treebeard/static/treebeard/treebeard-admin.js
+++ b/treebeard/static/treebeard/treebeard-admin.js
@@ -10,6 +10,8 @@
 
     RECENTLY_FADE_DURATION = 2000;
 
+    CSRF_TOKEN = document.currentScript.dataset.csrftoken;
+
     // Add jQuery util for disabling selection
     // Originally taken from jquery-ui (where it is deprecated)
     // https://api.jqueryui.com/disableSelection/
@@ -88,33 +90,12 @@
     };
 
     $(document).ready(function () {
-
-        // begin csrf token code
-        // Taken from http://docs.djangoproject.com/en/dev/ref/contrib/csrf/#ajax
         $(document).ajaxSend(function (event, xhr, settings) {
-            function getCookie(name) {
-                var cookieValue = null;
-                if (document.cookie && document.cookie != '') {
-                    var cookies = document.cookie.split(';');
-                    for (var i = 0; i < cookies.length; i++) {
-                        var cookie = $.trim(cookies[i]);
-                        // Does this cookie string begin with the name we want?
-                        if (cookie.substring(0, name.length + 1) == (name + '=')) {
-                            cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
-                            break;
-                        }
-                    }
-                }
-                return cookieValue;
-            }
-
             if (!(/^http:.*/.test(settings.url) || /^https:.*/.test(settings.url))) {
                 // Only send the token to relative URLs i.e. locally.
-                xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
+                xhr.setRequestHeader("X-CSRFToken", CSRF_TOKEN);
             }
         });
-        // end csrf token code
-
 
         // Don't activate drag or collapse if GET filters are set on the page
         if ($('#has-filters').val() === "1") {

--- a/treebeard/templates/admin/tree_change_list.html
+++ b/treebeard/templates/admin/tree_change_list.html
@@ -10,7 +10,7 @@
 {% block extrahead %}
     {{ block.super }}
     <script src="{% url 'admin:jsi18n' %}"></script>
-    <script src="{% static 'treebeard/treebeard-admin.js' %}"></script>
+    <script data-csrftoken="{{ csrf_token }}" src="{% static 'treebeard/treebeard-admin.js' %}"></script>
 {% endblock %}
 
 {% block result_list %}


### PR DESCRIPTION
This removes the cookie parsing snippet in favor of fetching the CSRF token from the `currentScript` node to allow usage of `CSRF_COOKIE_HTTPONLY = True`

See also: #92