### PR TITLE
Fix KeyError in MP_Node.dump_bulk if ordering differs from depth, path.

### DIFF
--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -79,7 +79,7 @@ class MP_NodeQuerySet(models.query.QuerySet):
         Custom delete method, will remove all descendant nodes to ensure a
         consistent tree (no orphans)
 
-        :returns: tuple of the number of objects deleted and a dictionary 
+        :returns: tuple of the number of objects deleted and a dictionary
                   with the number of deletions per object type
         """
         # we'll have to manually run through all the nodes that are going
@@ -631,7 +631,7 @@ class MP_Node(Node):
         # Because of fix_tree, this method assumes that the depth
         # and numchild properties in the nodes can be incorrect,
         # so no helper methods are used
-        qset = cls._get_serializable_model().objects.all()
+        qset = cls._get_serializable_model().objects.all().order_by("depth", "path")
         if parent:
             qset = qset.filter(path__startswith=parent.path)
         ret, lnk = [], {}


### PR DESCRIPTION
Fixes #219.

The qset needed to be ordered to ensure parents are serialized before the children.  Otherwise a child might come first and the `lnk` would not have the parent and raise a KeyError, like:

```
Traceback (...):
  ...
  File "tree/models/level.py", line 309, in dump_bulk
    result = super().dump_bulk(parent, keep_ids=keep_ids)
  File "treebeard/mp_tree.py", line 661, in dump_bulk
    parentobj = lnk[parentpath]
KeyError: '00IW'
```