### PR TITLE
Fix KeyError in MP_Node.dump_bulk if ordering differs from depth, path

### DIFF
--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -79,7 +79,7 @@ class MP_NodeQuerySet(models.query.QuerySet):
         Custom delete method, will remove all descendant nodes to ensure a
         consistent tree (no orphans)
 
-        :returns: tuple of the number of objects deleted and a dictionary 
+        :returns: tuple of the number of objects deleted and a dictionary
                   with the number of deletions per object type
         """
         # we'll have to manually run through all the nodes that are going
@@ -631,7 +631,7 @@ class MP_Node(Node):
         # Because of fix_tree, this method assumes that the depth
         # and numchild properties in the nodes can be incorrect,
         # so no helper methods are used
-        qset = cls._get_serializable_model().objects.all()
+        qset = cls._get_serializable_model().objects.all().order_by("depth", "path")
         if parent:
             qset = qset.filter(path__startswith=parent.path)
         ret, lnk = [], {}

--- a/treebeard/tests/migrations/0001_initial.py
+++ b/treebeard/tests/migrations/0001_initial.py
@@ -378,4 +378,22 @@ class Migration(migrations.Migration):
             },
             bases=('tests.ns_testnode',),
         ),
+        migrations.CreateModel(
+            name="MP_RegressionIssue219",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("path", models.CharField(max_length=255, unique=True)),
+                ("depth", models.PositiveIntegerField()),
+                ("numchild", models.PositiveIntegerField(default=0)),
+                ("name", models.CharField(max_length=255)),
+            ],
+        ),
     ]

--- a/treebeard/tests/models.py
+++ b/treebeard/tests/models.py
@@ -1,9 +1,11 @@
+import random
+import string
 import uuid
 
 from django.db import models
 from django.contrib.auth.models import User
 
-from treebeard.mp_tree import MP_Node
+from treebeard.mp_tree import MP_Node, MP_NodeQuerySet
 from treebeard.al_tree import AL_Node
 from treebeard.ns_tree import NS_Node
 
@@ -276,6 +278,22 @@ MP_TestSortedNodeShortPath._meta.get_field("path").max_length = 4
 class MP_TestManyToManyWithUser(MP_Node):
     name = models.CharField(max_length=255)
     users = models.ManyToManyField(User)
+
+
+class MP_RegressionIssue219QuerySet(MP_NodeQuerySet):
+    pass
+
+
+class MP_RegressionIssue219(MP_Node):
+    # Model to reproduce https://github.com/django-treebeard/django-treebeard/issues/219
+    steplen = 3
+
+    name = models.CharField(max_length=255)
+
+    def __str__(self):  # pragma: no cover
+        return "Node %d" % self.name
+
+    objects = MP_RegressionIssue219QuerySet.as_manager()
 
 
 BASE_MODELS = (

--- a/treebeard/tests/test_treebeard.py
+++ b/treebeard/tests/test_treebeard.py
@@ -3100,3 +3100,31 @@ class TestMP_TreeDescendantsPerformance(TestTreeBase):
             with django_assert_num_queries(expected):
                 # converting to list to force queryset evaluation
                 list(node.get_descendants())
+
+
+@pytest.mark.django_db
+class TestRegression:
+    def test_dump_bulk_regression_issue_219(self):
+        data = [
+            {
+                "data": {"name": "A"},
+                "children": [
+                    {"data": {"name": "X1"}},
+                    {"data": {"name": "X2"}},
+                    {
+                        "data": {"name": "X3"},
+                        "children": [
+                            # We need to create a large number of nodes to
+                            # to try the DB gives them in an arbitrary order
+                            {"data": {"name": f"Z{index}"}} for index in range(10000)
+                        ],
+                    },
+                    {"data": {"name": "X4"}},
+                ],
+            },
+        ]
+        models.MP_RegressionIssue219.load_bulk(data)
+        try:
+            models.MP_RegressionIssue219.dump_bulk()
+        except KeyError:
+            pytest.fail("It should not have raised an KeyError")


### PR DESCRIPTION
Fixes https://github.com/django-treebeard/django-treebeard/issues/219.

The qset needed to be ordered to ensure parents are serialized before the children. Otherwise a child might come first and the lnk would not have the parent and raise a KeyError, like:

```
Traceback (...):
  ...
  File "tree/models/level.py", line 309, in dump_bulk
    result = super().dump_bulk(parent, keep_ids=keep_ids)
  File "treebeard/mp_tree.py", line 661, in dump_bulk
    parentobj = lnk[parentpath]
KeyError: '00IW'
```

---

This was initially https://github.com/django-treebeard/django-treebeard/pull/302