### PR TITLE
remove MP_Node.gap ClassVar

### DIFF
--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -587,7 +587,6 @@ class MP_Node(Node):
     path = models.CharField(max_length=255, unique=True)
     depth = models.PositiveIntegerField()
     numchild = models.PositiveIntegerField(default=0)
-    gap = 1
 
     objects = MP_NodeManager()
 


### PR DESCRIPTION
There was an integer ClassVar on MP_Node called `gap`. It doesn't do anything and is completely undocumented, from what I can tell.

Perhaps there was some intention to leaves gaps in the materialized path so that efficient insertions could be done without rewriting the tree?