### PR TITLE
fix collapsible for parent or node id 999

### DIFF
--- a/treebeard/templates/admin/tree_change_list_results.html
+++ b/treebeard/templates/admin/tree_change_list_results.html
@@ -20,7 +20,7 @@
             {% for node_id, parent_id, node_level, children_num, result in results %}
                 <tr id="node-{{ node_id|stringformat:'s' }}-id" class="{% cycle 'row1' 'row2' %}"
                     level="{{ node_level }}" children-num="{{ children_num }}"
-                    parent="{{ parent_id }}" node="{{ node_id|stringformat:'s' }}">
+                    parent="{{ parent_id|stringformat:'s' }}" node="{{ node_id|stringformat:'s' }}">
                     {% for item in result %}
                         {% if forloop.counter == 1 %}
                             {% for spacer in item.depth %}<span class="grab">&nbsp;

--- a/treebeard/templates/admin/tree_change_list_results.html
+++ b/treebeard/templates/admin/tree_change_list_results.html
@@ -18,9 +18,9 @@
             </thead>
             <tbody>
             {% for node_id, parent_id, node_level, children_num, result in results %}
-                <tr id="node-{{ node_id }}-id" class="{% cycle 'row1' 'row2' %}"
+                <tr id="node-{{ node_id|stringformat:'s' }}-id" class="{% cycle 'row1' 'row2' %}"
                     level="{{ node_level }}" children-num="{{ children_num }}"
-                    parent="{{ parent_id }}" node="{{ node_id }}">
+                    parent="{{ parent_id }}" node="{{ node_id|stringformat:'s' }}">
                     {% for item in result %}
                         {% if forloop.counter == 1 %}
                             {% for spacer in item.depth %}<span class="grab">&nbsp;


### PR DESCRIPTION
fixes #314 by converting `node_id` and `parent_id` to string so that `1.234` is interpreted properly as integer `1234` and not as decimal `1.234`

Bug description: in listview user is not able to collapse parent if a child had id > 999 and I assume same for `parent_id`
