### PR TITLE
Clear cached attributes on refresh_from_db()

### DIFF
--- a/treebeard/al_tree.py
+++ b/treebeard/al_tree.py
@@ -48,6 +48,11 @@ class AL_Node(Node):
     objects = AL_NodeManager()
     node_order_by = None
 
+    _cached_attributes = (
+        *Node._cached_attributes,
+        "_cached_depth",
+    )
+
     @classmethod
     def add_root(cls, **kwargs):
         """Adds a root node to the tree."""

--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -592,6 +592,11 @@ class MP_Node(Node):
 
     numconv_obj_ = None
 
+    _cached_attributes = (
+        *Node._cached_attributes,
+        "_cached_parent_obj",
+    )
+
     @classmethod
     def _int2str(cls, num):
         return cls.numconv_obj().int2str(num)

--- a/treebeard/ns_tree.py
+++ b/treebeard/ns_tree.py
@@ -138,6 +138,11 @@ class NS_Node(Node):
 
     objects = NS_NodeManager()
 
+    _cached_attributes = (
+        *Node._cached_attributes,
+        "_cached_parent_obj",
+    )
+
     @classmethod
     def add_root(cls, **kwargs):
         """Adds a root node to the tree."""

--- a/treebeard/tests/test_treebeard.py
+++ b/treebeard/tests/test_treebeard.py
@@ -3128,3 +3128,23 @@ class TestRegression:
             models.MP_RegressionIssue219.dump_bulk()
         except KeyError:
             pytest.fail("It should not have raised an KeyError")
+
+
+@pytest.mark.django_db
+class TestRefreshFromDb:
+    def test_get_parent(self, model):
+        parent1 = model.objects.get(desc=2)
+        parent2 = model.objects.get(desc=4)
+        node = model.objects.get(desc=21)
+        assert node.get_parent() == parent1
+        node.move(parent2, pos="last-child")
+        node.refresh_from_db()
+        assert node.get_parent() == parent2
+
+    def test_get_depth(self, model):
+        node = model.objects.get(desc=1)
+        new_parent = model.objects.get(desc=2)
+        assert node.get_depth() == 1
+        node.move(new_parent, pos="last-child")
+        node.refresh_from_db()
+        assert node.get_depth() == 2


### PR DESCRIPTION
When working with Wagtail (which uses treebeard's `MP_Node` quite extensively) I got annoyed that Django's builtin `refresh_from_db()` didn't always work: sometimes, `get_parent()` would report the wrong parent for a model instance, even after that instance had been refreshed.

I dug a little in the codebase and found that it wasn't too hard to fix so here's a PR. Let me know if you'd like me to open an issue also.

Thanks!