### PR TITLE
fix: check for change permission in TreeAdmin move node view

### DIFF
--- a/treebeard/static/treebeard/treebeard-admin.js
+++ b/treebeard/static/treebeard/treebeard-admin.js
@@ -97,8 +97,8 @@
             }
         });
 
-        // Don't activate drag or collapse if GET filters are set on the page
-        if ($('#has-filters').val() === "1") {
+        // Don't activate drag or collapse if GET filters are set on the page, or if user has no change permission
+        if ($('#has-filters').val() === "1" || $('#has-change-permission').val() === "0") {
             return;
         }
 

--- a/treebeard/templates/admin/tree_change_list_results.html
+++ b/treebeard/templates/admin/tree_change_list_results.html
@@ -32,6 +32,7 @@
             </tbody>
         </table>
         <input type="hidden" id="has-filters" value="{{ filtered|yesno:"1,0" }}"/>
+        <input type="hidden" id="has-change-permission" value="{{ has_change_permission|yesno:"1,0" }}"/>
     </div>
 {% endif %}
 

--- a/treebeard/templatetags/admin_tree.py
+++ b/treebeard/templatetags/admin_tree.py
@@ -208,6 +208,7 @@ def result_tree(context, cl, request):
         'class_attrib': mark_safe(' class="oder-grabber"')
     })
     return {
+        'has_change_permission': context['has_change_permission'],
         'filtered': not check_empty_dict(request.GET),
         'result_hidden_fields': list(result_hidden_fields(cl)),
         'result_headers': headers,


### PR DESCRIPTION
Check for change permissions before allowing moving a node via TreeAdmin. This PR:

- Adds a permission check to the `move` endpoint, raising `PermissionDenied` if the user has no permission (this is consistent with what other admin views do);
- Adds context to the list view to indicate whether the user has permission;
- Disables the drag handlers if user has no permission.

Fixes #267