### PR TITLE
fix: raise exception if attempting to make a node its own child

### DIFF
--- a/tests/test_treebeard.py
+++ b/tests/test_treebeard.py
@@ -1150,6 +1150,18 @@ class TestMoveErrors(TestNonEmptyTree):
         with pytest.raises(InvalidMoveToDescendant):
             node.move(target, "first-sibling")
 
+    @pytest.mark.parametrize("pos", ("first-child", "last-child"))
+    def test_cannot_move_node_to_its_own_child(self, pos, model):
+        # Test for non-leaf node
+        node = model.objects.get(desc="22")
+        with pytest.raises(InvalidMoveToDescendant, match="move node to itself"):
+            node.move(node, pos)
+
+        # Test for leaf node
+        node = model.objects.get(desc="231")
+        with pytest.raises(InvalidMoveToDescendant, match="move node to itself"):
+            node.move(node, pos)
+
     def test_move_missing_nodeorderby(self, model):
         node = model.objects.get(desc="231")
         with pytest.raises(MissingNodeOrderBy):

--- a/treebeard/al_tree.py
+++ b/treebeard/al_tree.py
@@ -353,6 +353,9 @@ class AL_Node(Node):
         parent = None
 
         if pos in ("first-child", "last-child", "sorted-child"):
+            if self == target:
+                raise InvalidMoveToDescendant(_("Can't move node to itself."))
+
             # moving to a child
             if not target.is_leaf():
                 target = target.get_last_child()

--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -494,6 +494,9 @@ class MP_MoveHandler(MP_ComplexAddMoveHandler):
         newpos = None
         siblings = []
         if self.pos in ("first-child", "last-child", "sorted-child"):
+            if self.target == self.node:
+                raise InvalidMoveToDescendant(_("Can't move node to itself."))
+
             # moving to a child
             parent = self.target
             newdepth += 1

--- a/treebeard/ns_tree.py
+++ b/treebeard/ns_tree.py
@@ -354,6 +354,9 @@ class NS_Node(Node):
         parent = None
 
         if pos in ("first-child", "last-child", "sorted-child"):
+            if self == target:
+                raise InvalidMoveToDescendant(_("Can't move node to itself."))
+
             # moving to a child
             if target.is_leaf():
                 parent = target


### PR DESCRIPTION
This edge case is not currently handled consistently, with different results depending on whether the node is a leaf or not. The case described in #281 results in nodes having invalid paths, e.g., `00020002`.

Fixes #281