### PR TITLE
[WIP] Async Support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
 test = [
     "pytest-django>=4.0,<5.0",
     "pytest-pythonpath>=0.7,<1.0",
+    "pytest-asyncio>=1.3.0",
 ]
 
 [tool.ruff]

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,8 @@
 DJANGO_SETTINGS_MODULE = tests.settings
 python_files = tests.py test_*.py *_tests.py
 django_find_project = false
+
+asyncio_mode = auto
+asyncio_debug = true
+asyncio_default_test_loop_scope = session
+asyncio_default_fixture_loop_scope = session

--- a/tests/test_treebeard.py
+++ b/tests/test_treebeard.py
@@ -1,4 +1,7 @@
 """Unit/Functional tests"""
+from hmac import trans_36
+from django.contrib.gis.measure import A
+import asyncio
 
 import datetime
 import os
@@ -78,6 +81,10 @@ def model(request):
     request.param.load_bulk(BASE_DATA)
     return request.param
 
+@pytest.fixture(scope="function", params=models.BASE_MODELS + models.PROXY_MODELS)
+async def model_async(request):
+    await request.param.aload_bulk(BASE_DATA)
+    return request.param
 
 @pytest.fixture(scope="function", params=models.BASE_MODELS + models.PROXY_MODELS)
 def model_without_data(request):
@@ -87,6 +94,11 @@ def model_without_data(request):
 @pytest.fixture(scope="function", params=models.BASE_MODELS)
 def model_without_proxy(request):
     request.param.load_bulk(BASE_DATA)
+    return request.param
+
+@pytest.fixture(scope="function", params=models.BASE_MODELS)
+async def model_without_proxy_async(request):
+    await request.param.aload_bulk(BASE_DATA)
     return request.param
 
 
@@ -163,14 +175,39 @@ class TestTreeBase:
 
         return [(o.desc, o.get_depth(), o.get_children_count()) for o in model.get_tree()]
 
+    async def agot(self, model):
+        if model in [models.NS_TestNode, models.NS_TestNode_Proxy]:
+            # this slows down nested sets tests quite a bit, but it has the
+            # advantage that we'll check the node edges are correct
+            d = {}
+            # Bug: values_list("tree_id", "lft", "rgt") does not work with aiterator
+            async for node in model.objects.aiterator():
+                tree_id = node.tree_id
+                lft = node.lft
+                rgt = node.rgt
+                d.setdefault(tree_id, []).extend([lft, rgt])
+            for tree_id, got_edges in d.items():
+                assert len(got_edges) == max(got_edges)
+                good_edges = list(range(1, len(got_edges) + 1))
+                assert sorted(got_edges) == good_edges
+            
+        return [(o.desc, o.get_depth(), await o.aget_children_count()) \
+                for o in await model.aget_tree()]
+
     def _assert_get_annotated_list(self, model, expected, parent=None):
         results = model.get_annotated_list(parent)
         got = [(obj[0].desc, obj[1]["open"], obj[1]["close"], obj[1]["level"]) for obj in results]
         assert expected == got
         assert all(isinstance(obj[0], model) for obj in results)
+    
+    async def _assert_get_annotated_list_async(self, model, expected, parent=None):
+        results = await model.aget_annotated_list(parent)
+        got = [(obj[0].desc, obj[1]["open"], obj[1]["close"], obj[1]["level"]) for obj in results]
+        assert expected == got
+        assert all(isinstance(obj[0], model) for obj in results)
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 class TestEmptyTree(TestTreeBase):
     def test_load_bulk_empty(self, model_without_data):
         ids = model_without_data.load_bulk(BASE_DATA)
@@ -178,6 +215,13 @@ class TestEmptyTree(TestTreeBase):
         expected_descs = [x[0] for x in UNCHANGED]
         assert sorted(got_descs) == sorted(expected_descs)
         assert self.got(model_without_data) == UNCHANGED
+
+    async def test_load_bulk_empty_async(self, model_without_data):
+        ids = await model_without_data.aload_bulk(BASE_DATA)
+        got_descs = [obj.desc async for obj in model_without_data.objects.filter(pk__in=ids)]
+        expected_descs = [x[0] for x in UNCHANGED]
+        assert sorted(got_descs) == sorted(expected_descs)
+        assert await self.agot(model_without_data) == UNCHANGED
 
     def test_dump_bulk_empty(self, model_without_data):
         assert model_without_data.dump_bulk() == []
@@ -187,26 +231,52 @@ class TestEmptyTree(TestTreeBase):
         expected = [("1", 1, 0)]
         assert self.got(model_without_data) == expected
 
+    async def test_add_root_empty_async(self, model_without_data):
+        await model_without_data.aadd_root(desc="1")
+        expected = [("1", 1, 0)]
+        assert await self.agot(model_without_data) == expected
+
     def test_get_root_nodes_empty(self, model_without_data):
         got = model_without_data.get_root_nodes()
         expected = []
         assert [node.desc for node in got] == expected
 
+    async def test_get_root_nodes_empty_async(self, model_without_data):
+        got = model_without_data.get_root_nodes()
+        expected = []
+        assert [node.desc async for node in got] == expected
+
     def test_get_first_root_node_empty(self, model_without_data):
         got = model_without_data.get_first_root_node()
+        assert got is None
+
+    async def test_get_first_root_node_empty_async(self, model_without_data):
+        got = await model_without_data.aget_first_root_node()
         assert got is None
 
     def test_get_last_root_node_empty(self, model_without_data):
         got = model_without_data.get_last_root_node()
         assert got is None
 
+    async def test_get_last_root_node_empty_async(self, model_without_data):
+        got = await model_without_data.aget_last_root_node()
+        assert got is None
+
     def test_get_tree(self, model_without_data):
         got = list(model_without_data.get_tree())
+        assert got == []
+
+    async def test_get_tree_async(self, model_without_data):
+        got = list(await model_without_data.aget_tree())
         assert got == []
 
     def test_get_annotated_list(self, model_without_data):
         expected = []
         self._assert_get_annotated_list(model_without_data, expected)
+
+    async def test_get_annotated_list_async(self, model_without_data):
+        expected = []
+        await self._assert_get_annotated_list_async(model_without_data, expected)
 
     def test_add_multiple_root_nodes_adds_sibling_leaves(self, model_without_data):
         model_without_data.add_root(desc="1")
@@ -217,12 +287,20 @@ class TestEmptyTree(TestTreeBase):
         expected = [("1", 1, 0), ("2", 1, 0), ("3", 1, 0), ("4", 1, 0)]
         assert self.got(model_without_data) == expected
 
+    async def test_add_multiple_root_nodes_adds_sibling_leaves_async(self, model_without_data):
+        await model_without_data.aadd_root(desc="1")
+        await model_without_data.aadd_root(desc="2")
+        await model_without_data.aadd_root(desc="3")
+        await model_without_data.aadd_root(desc="4")
+        # these are all sibling root nodes (depth=1), and leaf nodes (children=0)
+        expected = [("1", 1, 0), ("2", 1, 0), ("3", 1, 0), ("4", 1, 0)]
+        assert await self.agot(model_without_data) == expected
 
 class TestNonEmptyTree(TestTreeBase):
     pass
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 class TestClassMethods(TestNonEmptyTree):
     def test_load_bulk_existing(self, model):
         # inserting on an existing node
@@ -255,14 +333,54 @@ class TestClassMethods(TestNonEmptyTree):
         assert sorted(got_descs) == sorted(expected_descs)
         assert self.got(model) == expected
 
+    async def test_load_bulk_existing_async(self, model_async):
+        # inserting on an existing node
+        node = await model_async.objects.aget(desc="231")
+        ids = await model_async.aload_bulk(BASE_DATA, node)
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 4),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 1),
+            ("231", 3, 4),
+            ("1", 4, 0),
+            ("2", 4, 4),
+            ("21", 5, 0),
+            ("22", 5, 0),
+            ("23", 5, 1),
+            ("231", 6, 0),
+            ("24", 5, 0),
+            ("3", 4, 0),
+            ("4", 4, 1),
+            ("41", 5, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        expected_descs = ["1", "2", "21", "22", "23", "231", "24", "3", "4", "41"]
+        got_descs = [obj.desc async for obj in model_async.objects.filter(pk__in=ids)]
+        assert sorted(got_descs) == sorted(expected_descs)
+        assert await self.agot(model_async) == expected
+
     def test_get_tree_all(self, model):
         nodes = model.get_tree()
         got = [(o.desc, o.get_depth(), o.get_children_count()) for o in nodes]
         assert got == UNCHANGED
         assert all(isinstance(o, model) for o in nodes)
 
+    async def test_get_tree_all_async(self, model_async):
+        nodes = await model_async.aget_tree()
+        got = [(o.desc, o.get_depth(), await o.aget_children_count()) for o in nodes]
+        assert got == UNCHANGED
+        assert all(isinstance(o, model_async) for o in nodes)
+
     def test_dump_bulk_all(self, model):
         assert model.dump_bulk(keep_ids=False) == BASE_DATA
+
+    async def test_dump_bulk_all_async(self, model_async):
+        assert await model_async.adump_bulk(keep_ids=False) == BASE_DATA
 
     def test_get_tree_node(self, model):
         node = model.objects.get(desc="231")
@@ -289,6 +407,30 @@ class TestClassMethods(TestNonEmptyTree):
         assert got == expected
         assert all(isinstance(o, model) for o in nodes)
 
+    async def test_get_tree_node_async(self, model_async):
+        node = await model_async.objects.aget(desc="231")
+        await model_async.aload_bulk(BASE_DATA, node)
+
+        # the tree was modified by load_bulk, so we reload our node object
+        node = await model_async.objects.aget(pk=node.pk)
+        nodes = await model_async.aget_tree(node)
+        got = [(o.desc, o.get_depth(), await o.aget_children_count()) for o in nodes]
+        expected = [
+            ("231", 3, 4),
+            ("1", 4, 0),
+            ("2", 4, 4),
+            ("21", 5, 0),
+            ("22", 5, 0),
+            ("23", 5, 1),
+            ("231", 6, 0),
+            ("24", 5, 0),
+            ("3", 4, 0),
+            ("4", 4, 1),
+            ("41", 5, 0),
+        ]
+        assert got == expected
+        assert all(isinstance(o, model_async) for o in nodes)
+    
     def test_get_tree_leaf(self, model):
         node = model.objects.get(desc="1")
 
@@ -298,6 +440,16 @@ class TestClassMethods(TestNonEmptyTree):
         expected = [("1", 1, 0)]
         assert got == expected
         assert all(isinstance(o, model) for o in nodes)
+
+    async def test_get_tree_leaf_async(self, model_async):
+        node = await model_async.objects.aget(desc="1")
+
+        assert 0 == await node.aget_children_count()
+        nodes = await model_async.aget_tree(node)
+        got = [(o.desc, o.get_depth(), await o.aget_children_count()) for o in nodes]
+        expected = [("1", 1, 0)]
+        assert got == expected
+        assert all(isinstance(o, model_async) for o in nodes)
 
     def test_get_annotated_list_all(self, model):
         expected = [
@@ -314,6 +466,21 @@ class TestClassMethods(TestNonEmptyTree):
         ]
         self._assert_get_annotated_list(model, expected)
 
+    async def test_get_annotated_list_all_async(self, model_async):
+        expected = [
+            ("1", True, [], 0),
+            ("2", False, [], 0),
+            ("21", True, [], 1),
+            ("22", False, [], 1),
+            ("23", False, [], 1),
+            ("231", True, [0], 2),
+            ("24", False, [0], 1),
+            ("3", False, [], 0),
+            ("4", False, [], 0),
+            ("41", True, [0, 1], 1),
+        ]
+        await self._assert_get_annotated_list_async(model_async, expected)
+
     def test_get_annotated_list_node(self, model):
         node = model.objects.get(desc="2")
         expected = [
@@ -326,10 +493,27 @@ class TestClassMethods(TestNonEmptyTree):
         ]
         self._assert_get_annotated_list(model, expected, node)
 
+    async def test_get_annotated_list_node_async(self, model_async):
+        node = await model_async.objects.aget(desc="2")
+        expected = [
+            ("2", True, [], 0),
+            ("21", True, [], 1),
+            ("22", False, [], 1),
+            ("23", False, [], 1),
+            ("231", True, [0], 2),
+            ("24", False, [0, 1], 1),
+        ]
+        await self._assert_get_annotated_list_async(model_async, expected, node)
+
     def test_get_annotated_list_leaf(self, model):
         node = model.objects.get(desc="1")
         expected = [("1", True, [0], 0)]
         self._assert_get_annotated_list(model, expected, node)
+
+    async def test_get_annotated_list_leaf_async(self, model_async):
+        node = await model_async.objects.aget(desc="1")
+        expected = [("1", True, [0], 0)]
+        await self._assert_get_annotated_list_async(model_async, expected, node)
 
     def test_dump_bulk_node(self, model):
         node = model.objects.get(desc="231")
@@ -342,6 +526,17 @@ class TestClassMethods(TestNonEmptyTree):
         expected = [{"data": {"desc": "231"}, "children": BASE_DATA}]
         assert got == expected
 
+    async def test_dump_bulk_node_async(self, model_async):
+        node = await model_async.objects.aget(desc="231")
+        await model_async.aload_bulk(BASE_DATA, node)
+
+        # the tree was modified by load_bulk, so we reload our node object
+        node = await model_async.objects.aget(pk=node.pk)
+
+        got = await model_async.adump_bulk(node, False)
+        expected = [{"data": {"desc": "231"}, "children": BASE_DATA}]
+        assert got == expected
+
     def test_load_and_dump_bulk_keeping_ids(self, model):
         exp = model.dump_bulk(keep_ids=True)
         model.objects.all().delete()
@@ -350,6 +545,17 @@ class TestClassMethods(TestNonEmptyTree):
         assert got == exp
         # do we really have an unchanged tree after the dump/delete/load?
         got = [(o.desc, o.get_depth(), o.get_children_count()) for o in model.get_tree()]
+        assert got == UNCHANGED
+
+    async def test_load_and_dump_bulk_keeping_ids_async(self, model_async):
+        exp = await model_async.adump_bulk(keep_ids=True)
+        await model_async.objects.all().adelete()
+        await model_async.aload_bulk(exp, None, True)
+        got = await model_async.adump_bulk(keep_ids=True)
+        assert got == exp
+        # do we really have an unchanged tree after the dump/delete/load?
+        got = [(o.desc, o.get_depth(), await o.aget_children_count())
+                for o in await model_async.aget_tree()]
         assert got == UNCHANGED
 
     def test_load_and_dump_bulk_with_fk(self, related_model):
@@ -385,21 +591,71 @@ class TestClassMethods(TestNonEmptyTree):
         got = related_model.dump_bulk(keep_ids=False)
         assert got == related_data
 
+    async def test_load_and_dump_bulk_with_fk_async(self, related_model):
+        # https://bitbucket.org/tabo/django-treebeard/issue/48/
+        await related_model.objects.all().adelete()
+        related, created = await models.RelatedModel.objects.aget_or_create(
+            desc="Test %s" % related_model.__name__)
+
+        related_data = [
+            {"data": {"desc": "1", "related": related.pk}},
+            {
+                "data": {"desc": "2", "related": related.pk},
+                "children": [
+                    {"data": {"desc": "21", "related": related.pk}},
+                    {"data": {"desc": "22", "related": related.pk}},
+                    {
+                        "data": {"desc": "23", "related": related.pk},
+                        "children": [
+                            {"data": {"desc": "231", "related": related.pk}},
+                        ],
+                    },
+                    {"data": {"desc": "24", "related": related.pk}},
+                ],
+            },
+            {"data": {"desc": "3", "related": related.pk}},
+            {
+                "data": {"desc": "4", "related": related.pk},
+                "children": [
+                    {"data": {"desc": "41", "related": related.pk}},
+                ],
+            },
+        ]
+        await related_model.aload_bulk(related_data)
+        got = await related_model.adump_bulk(keep_ids=False)
+        assert got == related_data
+
     def test_get_root_nodes(self, model):
         got = model.get_root_nodes()
         expected = ["1", "2", "3", "4"]
         assert [node.desc for node in got] == expected
         assert all(isinstance(node, model) for node in got)
 
+    async def test_get_root_nodes_async(self, model_async):
+        got = model_async.get_root_nodes()
+        expected = ["1", "2", "3", "4"]
+        assert [node.desc async for node in got] == expected
+        assert all(isinstance(node, model_async) for node in got)
+
     def test_get_first_root_node(self, model):
         got = model.get_first_root_node()
         assert got.desc == "1"
         assert isinstance(got, model)
 
+    async def test_get_first_root_node_async(self, model_async):
+        got = await model_async.aget_first_root_node()
+        assert got.desc == "1"
+        assert isinstance(got, model_async)
+
     def test_get_last_root_node(self, model):
         got = model.get_last_root_node()
         assert got.desc == "4"
         assert isinstance(got, model)
+
+    async def test_get_last_root_node_async(self, model_async):
+        got = await model_async.aget_last_root_node()
+        assert got.desc == "4"
+        assert isinstance(got, model_async)
 
     def test_add_root(self, model):
         obj = model.add_root(desc="5")
@@ -407,6 +663,13 @@ class TestClassMethods(TestNonEmptyTree):
         got = model.get_last_root_node()
         assert got.desc == "5"
         assert isinstance(got, model)
+
+    async def test_add_root_async(self, model_async):
+        obj = await model_async.aadd_root(desc="5")
+        assert obj.get_depth() == 1
+        got = await model_async.aget_last_root_node()
+        assert got.desc == "5"
+        assert isinstance(got, model_async)
 
     def test_add_root_with_passed_instance(self, model):
         obj = model(desc="5")
@@ -416,13 +679,26 @@ class TestClassMethods(TestNonEmptyTree):
         assert got.desc == "5"
         assert isinstance(got, model)
 
+    async def test_add_root_with_passed_instance_async(self, model_async):
+        obj = model_async(desc="5")
+        result = await model_async.aadd_root(instance=obj)
+        assert result == obj
+        got = await model_async.aget_last_root_node()
+        assert got.desc == "5"
+        assert isinstance(got, model_async)
+
     def test_add_root_with_already_saved_instance(self, model):
         obj = model.objects.get(desc="4")
         with pytest.raises(NodeAlreadySaved):
             model.add_root(instance=obj)
 
+    async def test_add_root_with_already_saved_instance_async(self, model_async):
+        obj = await model_async.objects.aget(desc="4")
+        with pytest.raises(NodeAlreadySaved):
+            await model_async.aadd_root(instance=obj)
 
-@pytest.mark.django_db
+
+@pytest.mark.django_db(transaction=True)
 class TestSimpleNodeMethods(TestNonEmptyTree):
     def test_is_root(self, model):
         data = [
@@ -438,6 +714,20 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
             got = model.objects.get(desc=desc).is_root()
             assert got == expected
 
+    async def test_is_root_async(self, model_async):
+        data = [
+            ("2", True),
+            ("1", True),
+            ("4", True),
+            ("21", False),
+            ("24", False),
+            ("22", False),
+            ("231", False),
+        ]
+        for desc, expected in data:
+            got = await (await model_async.objects.aget(desc=desc)).ais_root()
+            assert got == expected
+
     def test_is_leaf(self, model):
         data = [
             ("2", False),
@@ -446,6 +736,16 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
         ]
         for desc, expected in data:
             got = model.objects.get(desc=desc).is_leaf()
+            assert got == expected
+
+    async def test_is_leaf_async(self, model_async):
+        data = [
+            ("2", False),
+            ("23", False),
+            ("231", True),
+        ]
+        for desc, expected in data:
+            got = await (await model_async.objects.aget(desc=desc)).ais_leaf()
             assert got == expected
 
     def test_get_root(self, model):
@@ -462,6 +762,21 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
             node = model.objects.get(desc=desc).get_root()
             assert node.desc == expected
             assert isinstance(node, model)
+
+    async def test_get_root_async(self, model_async):
+        data = [
+            ("2", "2"),
+            ("1", "1"),
+            ("4", "4"),
+            ("21", "2"),
+            ("24", "2"),
+            ("22", "2"),
+            ("231", "2"),
+        ]
+        for desc, expected in data:
+            node = await (await model_async.objects.aget(desc=desc)).aget_root()
+            assert node.desc == expected
+            assert isinstance(node, model_async)
 
     def test_get_parent(self, model):
         data = [
@@ -498,6 +813,41 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
             else:
                 assert parent is None
 
+    async def test_get_parent_async(self, model_async):
+        data = [
+            ("2", None),
+            ("1", None),
+            ("4", None),
+            ("21", "2"),
+            ("24", "2"),
+            ("22", "2"),
+            ("231", "23"),
+        ]
+        data = dict(data)
+        objs = {}
+        for desc, expected in data.items():
+            node = await model_async.objects.aget(desc=desc)
+            parent = await node.aget_parent()
+            if expected:
+                assert parent.desc == expected
+                assert isinstance(parent, model_async)
+            else:
+                assert parent is None
+            objs[desc] = node
+            # corrupt the objects' parent cache
+            node._parent_obj = "CORRUPTED!!!"
+
+        for desc, expected in data.items():
+            node = objs[desc]
+            # asking aget_parent to not use the parent cache (since we
+            # corrupted it in the previous loop)
+            parent = await node.aget_parent(True)
+            if expected:
+                assert parent.desc == expected
+                assert isinstance(parent, model_async)
+            else:
+                assert parent is None
+
     def test_get_children(self, model):
         data = [
             ("2", ["21", "22", "23", "24"]),
@@ -509,6 +859,17 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
             assert [node.desc for node in children] == expected
             assert all(isinstance(node, model) for node in children)
 
+    async def test_get_children_async(self, model_async):
+        data = [
+            ("2", ["21", "22", "23", "24"]),
+            ("23", ["231"]),
+            ("231", []),
+        ]
+        for desc, expected in data:
+            children = (await model_async.objects.aget(desc=desc)).get_children()
+            assert [node.desc async for node in children] == expected
+            assert all(isinstance(node, model_async) for node in children)
+
     def test_get_children_count(self, model):
         data = [
             ("2", 4),
@@ -517,6 +878,16 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
         ]
         for desc, expected in data:
             got = model.objects.get(desc=desc).get_children_count()
+            assert got == expected
+
+    async def test_get_children_count_async(self, model_async):
+        data = [
+            ("2", 4),
+            ("23", 1),
+            ("231", 0),
+        ]
+        for desc, expected in data:
+            got = await (await model_async.objects.aget(desc=desc)).aget_children_count()
             assert got == expected
 
     def test_get_siblings(self, model):
@@ -529,6 +900,17 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
             siblings = model.objects.get(desc=desc).get_siblings()
             assert [node.desc for node in siblings] == expected
             assert all(isinstance(node, model) for node in siblings)
+
+    async def test_get_siblings_async(self, model_async):
+        data = [
+            ("2", ["1", "2", "3", "4"]),
+            ("21", ["21", "22", "23", "24"]),
+            ("231", ["231"]),
+        ]
+        for desc, expected in data:
+            siblings = await (await model_async.objects.aget(desc=desc)).aget_siblings()
+            assert [node.desc async for node in siblings] == expected
+            assert all(isinstance(node, model_async) for node in siblings)
 
     def test_get_first_sibling(self, model):
         data = [
@@ -544,6 +926,21 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
             node = model.objects.get(desc=desc).get_first_sibling()
             assert node.desc == expected
             assert isinstance(node, model)
+
+    async def test_get_first_sibling_async(self, model_async):
+        data = [
+            ("2", "1"),
+            ("1", "1"),
+            ("4", "1"),
+            ("21", "21"),
+            ("24", "21"),
+            ("22", "21"),
+            ("231", "231"),
+        ]
+        for desc, expected in data:
+            node = await (await model_async.objects.aget(desc=desc)).aget_first_sibling()
+            assert node.desc == expected
+            assert isinstance(node, model_async)
 
     def test_get_prev_sibling(self, model):
         data = [
@@ -563,6 +960,24 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
                 assert node.desc == expected
                 assert isinstance(node, model)
 
+    async def test_get_prev_sibling_async(self, model_async):
+        data = [
+            ("2", "1"),
+            ("1", None),
+            ("4", "3"),
+            ("21", None),
+            ("24", "23"),
+            ("22", "21"),
+            ("231", None),
+        ]
+        for desc, expected in data:
+            node = await (await model_async.objects.aget(desc=desc)).aget_prev_sibling()
+            if expected is None:
+                assert node is None
+            else:
+                assert node.desc == expected
+                assert isinstance(node, model_async)
+
     def test_get_next_sibling(self, model):
         data = [
             ("2", "3"),
@@ -581,6 +996,24 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
                 assert node.desc == expected
                 assert isinstance(node, model)
 
+    async def test_get_next_sibling_async(self, model_async):
+        data = [
+            ("2", "3"),
+            ("1", "2"),
+            ("4", None),
+            ("21", "22"),
+            ("24", None),
+            ("22", "23"),
+            ("231", None),
+        ]
+        for desc, expected in data:
+            node = await (await model_async.objects.aget(desc=desc)).aget_next_sibling()
+            if expected is None:
+                assert node is None
+            else:
+                assert node.desc == expected
+                assert isinstance(node, model_async)
+
     def test_get_last_sibling(self, model):
         data = [
             ("2", "4"),
@@ -595,6 +1028,21 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
             node = model.objects.get(desc=desc).get_last_sibling()
             assert node.desc == expected
             assert isinstance(node, model)
+
+    async def test_get_last_sibling_async(self, model_async):
+        data = [
+            ("2", "4"),
+            ("1", "4"),
+            ("4", "4"),
+            ("21", "24"),
+            ("24", "24"),
+            ("22", "24"),
+            ("231", "231"),
+        ]
+        for desc, expected in data:
+            node = await (await model_async.objects.aget(desc=desc)).aget_last_sibling()
+            assert node.desc == expected
+            assert isinstance(node, model_async)
 
     def test_get_first_child(self, model):
         data = [
@@ -611,6 +1059,21 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
                 assert node.desc == expected
                 assert isinstance(node, model)
 
+    async def test_get_first_child_async(self, model_async):
+        data = [
+            ("2", "21"),
+            ("21", None),
+            ("23", "231"),
+            ("231", None),
+        ]
+        for desc, expected in data:
+            node = await (await model_async.objects.aget(desc=desc)).aget_first_child()
+            if expected is None:
+                assert node is None
+            else:
+                assert node.desc == expected
+                assert isinstance(node, model_async)
+
     def test_get_last_child(self, model):
         data = [
             ("2", "24"),
@@ -626,6 +1089,21 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
                 assert node.desc == expected
                 assert isinstance(node, model)
 
+    async def test_get_last_child_async(self, model_async):
+        data = [
+            ("2", "24"),
+            ("21", None),
+            ("23", "231"),
+            ("231", None),
+        ]
+        for desc, expected in data:
+            node = await (await model_async.objects.aget(desc=desc)).aget_last_child()
+            if expected is None:
+                assert node is None
+            else:
+                assert node.desc == expected
+                assert isinstance(node, model_async)
+
     def test_get_ancestors(self, model):
         data = [
             ("2", []),
@@ -636,6 +1114,17 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
             nodes = model.objects.get(desc=desc).get_ancestors()
             assert [node.desc for node in nodes] == expected
             assert all(isinstance(node, model) for node in nodes)
+
+    async def test_get_ancestors_async(self, model_async):
+        data = [
+            ("2", []),
+            ("21", ["2"]),
+            ("231", ["2", "23"]),
+        ]
+        for desc, expected in data:
+            nodes = await (await model_async.objects.aget(desc=desc)).aget_ancestors()
+            assert [node.desc for node in nodes] == expected
+            assert all(isinstance(node, model_async) for node in nodes)
 
     def test_get_descendants(self, model):
         data = [
@@ -650,6 +1139,19 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
             assert [node.desc for node in nodes] == expected
             assert all(isinstance(node, model) for node in nodes)
 
+    async def test_get_descendants_async(self, model_async):
+        data = [
+            ("2", ["21", "22", "23", "231", "24"]),
+            ("23", ["231"]),
+            ("231", []),
+            ("1", []),
+            ("4", ["41"]),
+        ]
+        for desc, expected in data:
+            nodes = await (await model_async.objects.aget(desc=desc)).aget_descendants()
+            assert [node.desc for node in nodes] == expected
+            assert all(isinstance(node, model_async) for node in nodes)
+
     def test_get_descendants_include_self(self, model):
         data = [
             ("2", ["2", "21", "22", "23", "231", "24"]),
@@ -662,6 +1164,19 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
             nodes = model.objects.get(desc=desc).get_descendants(include_self=True)
             assert [node.desc for node in nodes] == expected
             assert all(isinstance(node, model) for node in nodes)
+    
+    async def test_get_descendants_include_self_async(self, model_async):
+        data = [
+            ("2", ["2", "21", "22", "23", "231", "24"]),
+            ("23", ["23", "231"]),
+            ("231", ["231"]),
+            ("1", ["1"]),
+            ("4", ["4", "41"]),
+        ]
+        for desc, expected in data:
+            nodes = await (await model_async.objects.aget(desc=desc)).aget_descendants(include_self=True)
+            assert [node.desc for node in nodes] == expected
+            assert all(isinstance(node, model_async) for node in nodes)
 
     def test_get_descendant_count(self, model):
         data = [
@@ -673,6 +1188,18 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
         ]
         for desc, expected in data:
             got = model.objects.get(desc=desc).get_descendant_count()
+            assert got == expected
+
+    async def test_get_descendant_count_async(self, model_async):
+        data = [
+            ("2", 5),
+            ("23", 1),
+            ("231", 0),
+            ("1", 0),
+            ("4", 1),
+        ]
+        for desc, expected in data:
+            got = await (await model_async.objects.aget(desc=desc)).aget_descendant_count()
             assert got == expected
 
     def test_is_sibling_of(self, model):
@@ -690,6 +1217,22 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
             node2 = model.objects.get(desc=desc2)
             assert node1.is_sibling_of(node2) == expected
 
+    async def test_is_sibling_of_async(self, model_async):
+        data = [
+            ("2", "2", True),
+            ("2", "1", True),
+            ("21", "2", False),
+            ("231", "2", False),
+            ("22", "23", True),
+            ("231", "23", False),
+            ("231", "231", True),
+        ]
+        for desc1, desc2, expected in data:
+            node1 = await model_async.objects.aget(desc=desc1)
+            node2 = await model_async.objects.aget(desc=desc2)
+            result = await node1.ais_sibling_of(node2)
+            assert result == expected
+
     def test_is_child_of(self, model):
         data = [
             ("2", "2", False),
@@ -704,6 +1247,21 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
             node2 = model.objects.get(desc=desc2)
             assert node1.is_child_of(node2) == expected
 
+    async def test_is_child_of_async(self, model_async):
+        data = [
+            ("2", "2", False),
+            ("2", "1", False),
+            ("21", "2", True),
+            ("231", "2", False),
+            ("231", "23", True),
+            ("231", "231", False),
+        ]
+        for desc1, desc2, expected in data:
+            node1 = await model_async.objects.aget(desc=desc1)
+            node2 = await model_async.objects.aget(desc=desc2)
+            result = await node1.ais_child_of(node2)
+            assert result == expected
+
     def test_is_descendant_of(self, model):
         data = [
             ("2", "2", False),
@@ -717,9 +1275,24 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
             node1 = model.objects.get(desc=desc1)
             node2 = model.objects.get(desc=desc2)
             assert node1.is_descendant_of(node2) == expected
+        
+    async def test_is_descendant_of_async(self, model_async):
+        data = [
+            ("2", "2", False),
+            ("2", "1", False),
+            ("21", "2", True),
+            ("231", "2", True),
+            ("231", "23", True),
+            ("231", "231", False),
+        ]
+        for desc1, desc2, expected in data:
+            node1 = await model_async.objects.aget(desc=desc1)
+            node2 = await model_async.objects.aget(desc=desc2)
+            result = await node1.ais_descendant_of(node2)
+            assert result == expected
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 class TestAddChild(TestNonEmptyTree):
     def test_add_child_to_leaf(self, model):
         model.objects.get(desc="231").add_child(desc="2311")
@@ -738,6 +1311,23 @@ class TestAddChild(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    async def test_add_child_to_leaf_async(self, model_async):
+        await (await model_async.objects.aget(desc="231")).aadd_child(desc="2311")
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 4),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 1),
+            ("231", 3, 1),
+            ("2311", 4, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        assert await self.agot(model_async) == expected
+
     def test_add_child_to_node(self, model):
         model.objects.get(desc="2").add_child(desc="25")
         expected = [
@@ -754,6 +1344,23 @@ class TestAddChild(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+
+    async def test_add_child_to_node_async(self, model_async):
+        await (await model_async.objects.aget(desc="2")).aadd_child(desc="25")
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 5),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 1),
+            ("231", 3, 0),
+            ("24", 2, 0),
+            ("25", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        assert await self.agot(model_async) == expected
 
     def test_add_child_with_passed_instance(self, model):
         child = model(desc="2311")
@@ -774,10 +1381,34 @@ class TestAddChild(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    async def test_add_child_with_passed_instance_async(self, model_async):
+        child = model_async(desc="2311")
+        result = await (await model_async.objects.aget(desc="231")).aadd_child(instance=child)
+        assert result == child
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 4),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 1),
+            ("231", 3, 1),
+            ("2311", 4, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        assert await self.agot(model_async) == expected
+
     def test_add_child_with_already_saved_instance(self, model):
         child = model.objects.get(desc="21")
         with pytest.raises(NodeAlreadySaved):
             model.objects.get(desc="2").add_child(instance=child)
+
+    async def test_add_child_with_already_saved_instance_async(self, model_async):
+        child = await model_async.objects.aget(desc="21")
+        with pytest.raises(NodeAlreadySaved):
+            await (await model_async.objects.aget(desc="2")).aadd_child(instance=child)
 
     def test_add_child_with_pk_set(self, model):
         """
@@ -786,6 +1417,15 @@ class TestAddChild(TestNonEmptyTree):
         """
         child = model(pk=999999, desc="natural key")
         result = model.objects.get(desc="2").add_child(instance=child)
+        assert result == child
+
+    async def test_add_child_with_pk_set_async(self, model_async):
+        """
+        If the model is using a natural primary key then it will be
+        already set when the instance is inserted.
+        """
+        child = model_async(pk=999999, desc="natural key")
+        result = await (await model_async.objects.aget(desc="2")).aadd_child(instance=child)
         assert result == child
 
     def test_add_child_post_save(self, model):
@@ -805,17 +1445,48 @@ class TestAddChild(TestNonEmptyTree):
         finally:
             post_save.disconnect(dispatch_uid="test_add_child_post_save")
 
+    async def test_add_child_post_save_async(self, model_async):
+        try:
 
-@pytest.mark.django_db
+            @receiver(post_save, dispatch_uid="test_add_child_post_save_async")
+            async def on_post_save(instance, **kwargs):
+                async def inner():
+                    parent = await instance.aget_parent()
+                    await parent.arefresh_from_db()
+                    descendant_count = await parent.aget_descendant_count()
+                    assert descendant_count == 1
+
+                asyncio.create_task(inner())
+
+            # It's important that we're testing a leaf node
+            parent = await model_async.objects.aget(desc="231")
+            is_leaf = await parent.ais_leaf()
+            assert is_leaf
+
+            await parent.aadd_child(desc="2311")
+        finally:
+            post_save.disconnect(dispatch_uid="test_add_child_post_save_async")
+
+
+@pytest.mark.django_db(transaction=True)
 class TestAddSibling(TestNonEmptyTree):
     def test_add_sibling_invalid_pos(self, model):
         with pytest.raises(InvalidPosition):
             model.objects.get(desc="231").add_sibling("invalid_pos")
 
+    async def test_add_sibling_invalid_pos_async(self, model_async):
+        with pytest.raises(InvalidPosition):
+            await (await model_async.objects.aget(desc="231")).aadd_sibling("invalid_pos")
+
     def test_add_sibling_missing_nodeorderby(self, model):
         node_wchildren = model.objects.get(desc="2")
         with pytest.raises(MissingNodeOrderBy):
             node_wchildren.add_sibling("sorted-sibling", desc="aaa")
+
+    async def test_add_sibling_missing_nodeorderby_async(self, model_async):
+        node_wchildren = await model_async.objects.aget(desc="2")
+        with pytest.raises(MissingNodeOrderBy):
+            await node_wchildren.aadd_sibling("sorted-sibling", desc="aaa")
 
     def test_add_sibling_last_root(self, model):
         node_wchildren = model.objects.get(desc="2")
@@ -823,11 +1494,28 @@ class TestAddSibling(TestNonEmptyTree):
         assert obj.get_depth() == 1
         assert node_wchildren.get_last_sibling().desc == "5"
 
+    async def test_add_sibling_last_root_async(self, model_async):
+        node_wchildren = await model_async.objects.aget(desc="2")
+        obj = await node_wchildren.aadd_sibling("last-sibling", desc="5")
+        depth = obj.get_depth()
+        assert depth == 1
+        last_sibling = await node_wchildren.aget_last_sibling()
+        assert last_sibling.desc == "5"
+
     def test_add_sibling_last(self, model):
         node = model.objects.get(desc="231")
         obj = node.add_sibling("last-sibling", desc="232")
         assert obj.get_depth() == 3
         assert node.get_last_sibling().desc == "232"
+
+    async def test_add_sibling_last_async(self, model_async):
+        node = await model_async.objects.aget(desc="231")
+        obj = await node.aadd_sibling("last-sibling", desc="232")
+        depth = await obj.aget_depth()
+        assert depth == 3
+        last_sibling = await node.aget_last_sibling()
+        assert last_sibling.desc == "232"
+    
 
     def test_add_sibling_first_root(self, model):
         node_wchildren = model.objects.get(desc="2")
@@ -848,6 +1536,26 @@ class TestAddSibling(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    async def test_add_sibling_first_root_async(self, model_async):
+        node_wchildren = await model_async.objects.aget(desc="2")
+        obj = await node_wchildren.aadd_sibling("first-sibling", desc="new")
+        depth = obj.get_depth()
+        assert depth == 1
+        expected = [
+            ("new", 1, 0),
+            ("1", 1, 0),
+            ("2", 1, 4),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 1),
+            ("231", 3, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        assert await self.agot(model_async) == expected
+
     def test_add_sibling_first(self, model):
         node_wchildren = model.objects.get(desc="23")
         obj = node_wchildren.add_sibling("first-sibling", desc="new")
@@ -866,6 +1574,26 @@ class TestAddSibling(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+
+    async def test_add_sibling_first_async(self, model_async):
+        node_wchildren = await model_async.objects.aget(desc="23")
+        obj = await node_wchildren.aadd_sibling("first-sibling", desc="new")
+        depth = await obj.aget_depth()
+        assert depth == 2
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 5),
+            ("new", 2, 0),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 1),
+            ("231", 3, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        assert await self.agot(model_async) == expected
 
     def test_add_sibling_left_root(self, model):
         node_wchildren = model.objects.get(desc="2")
@@ -886,6 +1614,26 @@ class TestAddSibling(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    async def test_add_sibling_left_root_async(self, model_async):
+        node_wchildren = await model_async.objects.aget(desc="2")
+        obj = await node_wchildren.aadd_sibling("left", desc="new")
+        depth = obj.get_depth()
+        assert depth == 1
+        expected = [
+            ("1", 1, 0),
+            ("new", 1, 0),
+            ("2", 1, 4),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 1),
+            ("231", 3, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        assert await self.agot(model_async) == expected
+
     def test_add_sibling_left(self, model):
         node_wchildren = model.objects.get(desc="23")
         obj = node_wchildren.add_sibling("left", desc="new")
@@ -904,6 +1652,26 @@ class TestAddSibling(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+
+    async def test_add_sibling_left_async(self, model_async):
+        node_wchildren = await model_async.objects.aget(desc="23")
+        obj = await node_wchildren.aadd_sibling("left", desc="new")
+        depth = await obj.aget_depth()
+        assert depth == 2
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 5),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("new", 2, 0),
+            ("23", 2, 1),
+            ("231", 3, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        assert await self.agot(model_async) == expected
 
     def test_add_sibling_left_noleft_root(self, model):
         node = model.objects.get(desc="1")
@@ -924,6 +1692,26 @@ class TestAddSibling(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    async def test_add_sibling_left_noleft_root_async(self, model_async):
+        node = await model_async.objects.aget(desc="1")
+        obj = await node.aadd_sibling("left", desc="new")
+        depth = obj.get_depth()
+        assert depth == 1
+        expected = [
+            ("new", 1, 0),
+            ("1", 1, 0),
+            ("2", 1, 4),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 1),
+            ("231", 3, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        assert await self.agot(model_async) == expected
+
     def test_add_sibling_left_noleft(self, model):
         node = model.objects.get(desc="231")
         obj = node.add_sibling("left", desc="new")
@@ -942,6 +1730,26 @@ class TestAddSibling(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+
+    async def test_add_sibling_left_noleft_async(self, model_async):
+        node = await model_async.objects.aget(desc="231")
+        obj = await node.aadd_sibling("left", desc="new")
+        depth = await obj.aget_depth()
+        assert depth == 3
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 4),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 2),
+            ("new", 3, 0),
+            ("231", 3, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        assert await self.agot(model_async) == expected
 
     def test_add_sibling_right_root(self, model):
         node_wchildren = model.objects.get(desc="2")
@@ -962,6 +1770,26 @@ class TestAddSibling(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    async def test_add_sibling_right_root_async(self, model_async):
+        node_wchildren = await model_async.objects.aget(desc="2")
+        obj = await node_wchildren.aadd_sibling("right", desc="new")
+        depth = obj.get_depth()
+        assert depth == 1
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 4),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 1),
+            ("231", 3, 0),
+            ("24", 2, 0),
+            ("new", 1, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        assert await self.agot(model_async) == expected
+
     def test_add_sibling_right(self, model):
         node_wchildren = model.objects.get(desc="23")
         obj = node_wchildren.add_sibling("right", desc="new")
@@ -980,6 +1808,26 @@ class TestAddSibling(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+
+    async def test_add_sibling_right_async(self, model_async):
+        node_wchildren = await model_async.objects.aget(desc="23")
+        obj = await node_wchildren.aadd_sibling("right", desc="new")
+        depth = await obj.aget_depth()
+        assert depth == 2
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 5),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 1),
+            ("231", 3, 0),
+            ("new", 2, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        assert await self.agot(model_async) == expected
 
     def test_add_sibling_right_noright_root(self, model):
         node = model.objects.get(desc="4")
@@ -1000,6 +1848,27 @@ class TestAddSibling(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    async def test_add_sibling_right_noright_root_async(self, model_async):
+        node = await model_async.objects.aget(desc="4")
+        obj = await node.aadd_sibling("right", desc="new")
+        depth = obj.get_depth()
+        assert depth == 1
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 4),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 1),
+            ("231", 3, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+            ("new", 1, 0),
+        ]
+        assert await self.agot(model_async) == expected
+
+
     def test_add_sibling_right_noright(self, model):
         node = model.objects.get(desc="231")
         obj = node.add_sibling("right", desc="new")
@@ -1019,6 +1888,26 @@ class TestAddSibling(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    async def test_add_sibling_right_noright_async(self, model_async):
+        node = await model_async.objects.aget(desc="231")
+        obj = await node.aadd_sibling("right", desc="new")
+        depth = await obj.aget_depth()
+        assert depth == 3
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 4),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 2),
+            ("231", 3, 0),
+            ("new", 3, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        assert await self.agot(model_async) == expected
+
     def test_add_sibling_with_passed_instance(self, model):
         node_wchildren = model.objects.get(desc="2")
         obj = model(desc="5")
@@ -1027,11 +1916,27 @@ class TestAddSibling(TestNonEmptyTree):
         assert obj.get_depth() == 1
         assert node_wchildren.get_last_sibling().desc == "5"
 
+    async def test_add_sibling_with_passed_instance_async(self, model_async):
+        node_wchildren = await model_async.objects.aget(desc="2")
+        obj = model_async(desc="5")
+        result = await node_wchildren.aadd_sibling("last-sibling", instance=obj)
+        assert result == obj
+        depth = obj.get_depth()
+        assert depth == 1
+        last_sibling = await node_wchildren.aget_last_sibling()
+        assert last_sibling.desc == "5"
+
     def test_add_sibling_already_saved_instance(self, model):
         node_wchildren = model.objects.get(desc="2")
         existing_node = model.objects.get(desc="4")
         with pytest.raises(NodeAlreadySaved):
             node_wchildren.add_sibling("last-sibling", instance=existing_node)
+
+    async def test_add_sibling_already_saved_instance_async(self, model_async):
+        node_wchildren = await model_async.objects.aget(desc="2")
+        existing_node = await model_async.objects.aget(desc="4")
+        with pytest.raises(NodeAlreadySaved):
+            await node_wchildren.aadd_sibling("last-sibling", instance=existing_node)
 
     def test_add_child_with_pk_set(self, model):
         """
@@ -1042,8 +1947,16 @@ class TestAddSibling(TestNonEmptyTree):
         result = model.objects.get(desc="2").add_child(instance=child)
         assert result == child
 
+    async def test_add_child_with_pk_set_async(self, model_async):
+        """
+        If the model is using a natural primary key then it will be
+        already set when the instance is inserted.
+        """
+        child = model_async(pk=999999, desc="natural key")
+        result = await (await model_async.objects.aget(desc="2")).aadd_child(instance=child)
+        assert result == child
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 class TestDelete(TestTreeBase):
     @staticmethod
     @pytest.fixture(
@@ -1056,6 +1969,19 @@ class TestDelete(TestTreeBase):
         base_model.load_bulk(BASE_DATA)
         for node in base_model.objects.all():
             dep_model(node=node).save()
+        return base_model, dep_model
+    
+    @staticmethod
+    @pytest.fixture(
+        scope="function",
+        params=zip(models.BASE_MODELS, models.DEP_MODELS),
+        ids=lambda fv: f"base={fv[0].__name__} dep={fv[1].__name__}",
+    )
+    async def delete_dep_model_pair_async(request):
+        base_model, dep_model = request.param
+        await base_model.aload_bulk(BASE_DATA)
+        async for node in base_model.objects.all():
+            await dep_model(node=node).asave()
         return base_model, dep_model
 
     def test_delete_leaf(self, delete_dep_model_pair):
@@ -1075,6 +2001,23 @@ class TestDelete(TestTreeBase):
         assert self.got(delete_model) == expected
         assert result == (2, {delete_model._meta.label: 1, dep_model._meta.label: 1})
 
+    async def test_delete_leaf_async(self, delete_dep_model_pair_async):
+        delete_model, dep_model = delete_dep_model_pair_async
+        result = await (await delete_model.objects.aget(desc="231")).adelete()
+        expected = [  # noqa: F821
+            ("1", 1, 0),
+            ("2", 1, 4),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        assert await self.agot(delete_model) == expected
+        assert result == (2, {delete_model._meta.label: 1, dep_model._meta.label: 1})
+
     def test_delete_node(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
         result = delete_model.objects.get(desc="23").delete()
@@ -1091,11 +2034,34 @@ class TestDelete(TestTreeBase):
         assert self.got(delete_model) == expected
         assert result == (4, {delete_model._meta.label: 2, dep_model._meta.label: 2})
 
+    async def test_delete_node_async(self, delete_dep_model_pair_async):
+        delete_model, dep_model = delete_dep_model_pair_async
+        result = await (await delete_model.objects.aget(desc="23")).adelete()
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 3),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        assert await self.agot(delete_model) == expected
+        assert result == (4, {delete_model._meta.label: 2, dep_model._meta.label: 2})
+
     def test_delete_root(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
         result = delete_model.objects.get(desc="2").delete()
         expected = [("1", 1, 0), ("3", 1, 0), ("4", 1, 1), ("41", 2, 0)]
         assert self.got(delete_model) == expected
+        assert result == (12, {delete_model._meta.label: 6, dep_model._meta.label: 6})
+
+    async def test_delete_root_async(self, delete_dep_model_pair_async):
+        delete_model, dep_model = delete_dep_model_pair_async
+        result = await (await delete_model.objects.aget(desc="2")).adelete()
+        expected = [("1", 1, 0), ("3", 1, 0), ("4", 1, 1), ("41", 2, 0)]
+        assert await self.agot(delete_model) == expected
         assert result == (12, {delete_model._meta.label: 6, dep_model._meta.label: 6})
 
     def test_delete_filter_root_nodes(self, delete_dep_model_pair):
@@ -1105,6 +2071,13 @@ class TestDelete(TestTreeBase):
         assert self.got(delete_model) == expected
         assert result == (14, {delete_model._meta.label: 7, dep_model._meta.label: 7})
 
+    async def test_delete_filter_root_nodes_async(self, delete_dep_model_pair_async):
+        delete_model, dep_model = delete_dep_model_pair_async
+        result = await delete_model.objects.filter(desc__in=("2", "3")).adelete()
+        expected = [("1", 1, 0), ("4", 1, 1), ("41", 2, 0)]
+        assert await self.agot(delete_model) == expected
+        assert result == (14, {delete_model._meta.label: 7, dep_model._meta.label: 7})
+
     def test_delete_filter_children(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
         result = delete_model.objects.filter(desc__in=("2", "23", "231")).delete()
@@ -1112,10 +2085,23 @@ class TestDelete(TestTreeBase):
         assert self.got(delete_model) == expected
         assert result == (12, {delete_model._meta.label: 6, dep_model._meta.label: 6})
 
+    async def test_delete_filter_children_async(self, delete_dep_model_pair_async):
+        delete_model, dep_model = delete_dep_model_pair_async
+        result = await delete_model.objects.filter(desc__in=("2", "23", "231")).adelete()
+        expected = [("1", 1, 0), ("3", 1, 0), ("4", 1, 1), ("41", 2, 0)]
+        assert await self.agot(delete_model) == expected
+        assert result == (12, {delete_model._meta.label: 6, dep_model._meta.label: 6})
+
     def test_delete_nonexistant_nodes(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
         result = delete_model.objects.filter(desc__in=("ZZZ", "XXX")).delete()
         assert self.got(delete_model) == UNCHANGED
+        assert result == (0, {})
+
+    async def test_delete_nonexistant_nodes_async(self, delete_dep_model_pair_async):
+        delete_model, dep_model = delete_dep_model_pair_async
+        result = await delete_model.objects.filter(desc__in=("ZZZ", "XXX")).adelete()
+        assert await self.agot(delete_model) == UNCHANGED
         assert result == (0, {})
 
     def test_delete_same_node_twice(self, delete_dep_model_pair):
@@ -1125,31 +2111,63 @@ class TestDelete(TestTreeBase):
         assert self.got(delete_model) == expected
         assert result == (12, {delete_model._meta.label: 6, dep_model._meta.label: 6})
 
+    async def test_delete_same_node_twice_async(self, delete_dep_model_pair_async):
+        delete_model, dep_model = delete_dep_model_pair_async
+        result = await delete_model.objects.filter(desc__in=("2", "2")).adelete()
+        expected = [("1", 1, 0), ("3", 1, 0), ("4", 1, 1), ("41", 2, 0)]
+        assert await self.agot(delete_model) == expected
+        assert result == (12, {delete_model._meta.label: 6, dep_model._meta.label: 6})
+
     def test_delete_all_root_nodes(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
         result = delete_model.get_root_nodes().delete()
         assert result == (20, {delete_model._meta.label: 10, dep_model._meta.label: 10})
         assert delete_model.objects.count() == 0
 
+    async def test_delete_all_root_nodes_async(self, delete_dep_model_pair_async):
+        delete_model, dep_model = delete_dep_model_pair_async
+        result = await delete_model.get_root_nodes().adelete()
+        assert result == (20, {delete_model._meta.label: 10, dep_model._meta.label: 10})
+        count = await delete_model.objects.acount()
+        assert count == 0
+
     def test_delete_all_nodes(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
         result = delete_model.objects.all().delete()
         assert result == (20, {delete_model._meta.label: 10, dep_model._meta.label: 10})
         assert delete_model.objects.count() == 0
+    
+    async def test_delete_all_nodes_async(self, delete_dep_model_pair_async):
+        delete_model, dep_model = delete_dep_model_pair_async
+        result = await delete_model.objects.all().adelete()
+        assert result == (20, {delete_model._meta.label: 10, dep_model._meta.label: 10})
+        count = await delete_model.objects.acount()
+        assert count == 0
 
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 class TestMoveErrors(TestNonEmptyTree):
     def test_move_invalid_pos(self, model):
         node = model.objects.get(desc="231")
         with pytest.raises(InvalidPosition):
             node.move(node, "invalid_pos")
 
+    async def test_move_invalid_pos_async(self, model_async):
+        node = await model_async.objects.aget(desc="231")
+        with pytest.raises(InvalidPosition):
+            await node.amove(node, "invalid_pos")
+
     def test_move_to_descendant(self, model):
         node = model.objects.get(desc="2")
         target = model.objects.get(desc="231")
         with pytest.raises(InvalidMoveToDescendant):
             node.move(target, "first-sibling")
+
+    async def test_move_to_descendant_async(self, model_async):
+        node = await model_async.objects.aget(desc="2")
+        target = await model_async.objects.aget(desc="231")
+        with pytest.raises(InvalidMoveToDescendant):
+            await node.amove(target, "first-sibling")
 
     @pytest.mark.parametrize("pos", ("first-child", "last-child"))
     def test_cannot_move_node_to_its_own_child(self, pos, model):
@@ -1163,6 +2181,18 @@ class TestMoveErrors(TestNonEmptyTree):
         with pytest.raises(InvalidMoveToDescendant, match="move node to itself"):
             node.move(node, pos)
 
+    @pytest.mark.parametrize("pos", ("first-child", "last-child"))
+    async def test_cannot_move_node_to_its_own_child_async(self, pos, model_async):
+        # Test for non-leaf node
+        node = await model_async.objects.aget(desc="22")
+        with pytest.raises(InvalidMoveToDescendant, match="move node to itself"):
+            await node.amove(node, pos)
+
+        # Test for leaf node
+        node = await model_async.objects.aget(desc="231")
+        with pytest.raises(InvalidMoveToDescendant, match="move node to itself"):
+            await node.amove(node, pos)
+
     def test_move_missing_nodeorderby(self, model):
         node = model.objects.get(desc="231")
         with pytest.raises(MissingNodeOrderBy):
@@ -1170,16 +2200,28 @@ class TestMoveErrors(TestNonEmptyTree):
         with pytest.raises(MissingNodeOrderBy):
             node.move(node, "sorted-sibling")
 
+    async def test_move_missing_nodeorderby_async(self, model_async):
+        node = await model_async.objects.aget(desc="231")
+        with pytest.raises(MissingNodeOrderBy):
+            await node.amove(node, "sorted-child")
+        with pytest.raises(MissingNodeOrderBy):
+            await node.amove(node, "sorted-sibling")
 
-@pytest.mark.django_db
+
+@pytest.mark.django_db(transaction=True)
 class TestMoveSortedErrors(TestTreeBase):
     def test_nonsorted_move_in_sorted(self, sorted_model):
         node = sorted_model.add_root(val1=3, val2=3, desc="zxy")
         with pytest.raises(InvalidPosition):
             node.move(node, "left")
 
+    async def test_nonsorted_move_in_sorted_async(self, sorted_model):
+        node = await sorted_model.aadd_root(val1=3, val2=3, desc="zxy")
+        with pytest.raises(InvalidPosition):
+            await node.amove(node, "left")
 
-@pytest.mark.django_db
+
+@pytest.mark.django_db(transaction=True)
 class TestMoveLeafRoot(TestNonEmptyTree):
     def test_move_leaf_last_sibling_root(self, model):
         target = model.objects.get(desc="2")
@@ -1198,6 +2240,24 @@ class TestMoveLeafRoot(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    async def test_move_leaf_last_sibling_root_async(self, model_async):
+        target = await model_async.objects.aget(desc="2")
+        node = await model_async.objects.aget(desc="231")
+        await node.amove(target, "last-sibling")
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 4),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+            ("231", 1, 0),
+        ]
+        assert await self.agot(model_async) == expected
+
     def test_move_leaf_first_sibling_root(self, model):
         target = model.objects.get(desc="2")
         model.objects.get(desc="231").move(target, "first-sibling")
@@ -1214,6 +2274,24 @@ class TestMoveLeafRoot(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+
+    async def test_move_leaf_first_sibling_root_async(self, model_async):
+        target = await model_async.objects.aget(desc="2")
+        node = await model_async.objects.aget(desc="231")
+        await node.amove(target, "first-sibling")
+        expected = [
+            ("231", 1, 0),
+            ("1", 1, 0),
+            ("2", 1, 4),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        assert await self.agot(model_async) == expected
 
     def test_move_leaf_left_sibling_root(self, model):
         target = model.objects.get(desc="2")
@@ -1232,6 +2310,24 @@ class TestMoveLeafRoot(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    async def test_move_leaf_left_sibling_root_async(self, model_async):
+        target = await model_async.objects.aget(desc="2")
+        node = await model_async.objects.aget(desc="231")
+        await node.amove(target, "left")
+        expected = [
+            ("1", 1, 0),
+            ("231", 1, 0),
+            ("2", 1, 4),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        assert await self.agot(model_async) == expected
+
     def test_move_leaf_right_sibling_root(self, model):
         target = model.objects.get(desc="2")
         model.objects.get(desc="231").move(target, "right")
@@ -1248,6 +2344,24 @@ class TestMoveLeafRoot(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+
+    async def test_move_leaf_right_sibling_root_async(self, model_async):
+        target = await model_async.objects.aget(desc="2")
+        node = await model_async.objects.aget(desc="231")
+        await node.amove(target, "right")
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 4),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 0),
+            ("24", 2, 0),
+            ("231", 1, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        assert await self.agot(model_async) == expected
 
     def test_move_leaf_last_child_root(self, model):
         target = model.objects.get(desc="2")
@@ -1266,6 +2380,24 @@ class TestMoveLeafRoot(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    async def test_move_leaf_last_child_root_async(self, model_async):
+        target = await model_async.objects.aget(desc="2")
+        node = await model_async.objects.aget(desc="231")
+        await node.amove(target, "last-child")
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 5),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 0),
+            ("24", 2, 0),
+            ("231", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        assert await self.agot(model_async) == expected
+
     def test_move_leaf_first_child_root(self, model):
         target = model.objects.get(desc="2")
         model.objects.get(desc="231").move(target, "first-child")
@@ -1283,8 +2415,26 @@ class TestMoveLeafRoot(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    async def test_move_leaf_first_child_root_async(self, model_async):
+        target = await model_async.objects.aget(desc="2")
+        node = await model_async.objects.aget(desc="231")
+        await node.amove(target, "first-child")
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 5),
+            ("231", 2, 0),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        assert await self.agot(model_async) == expected
 
-@pytest.mark.django_db
+
+@pytest.mark.django_db(transaction=True)
 class TestMoveLeaf(TestNonEmptyTree):
     def test_move_leaf_last_sibling(self, model):
         target = model.objects.get(desc="22")
@@ -1303,6 +2453,24 @@ class TestMoveLeaf(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    async def test_move_leaf_last_sibling_async(self, model_async):
+        target = await model_async.objects.aget(desc="22")
+        node = await model_async.objects.aget(desc="231")
+        await node.amove(target, "last-sibling")
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 5),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 0),
+            ("24", 2, 0),
+            ("231", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        assert await self.agot(model_async) == expected
+
     def test_move_leaf_first_sibling(self, model):
         target = model.objects.get(desc="22")
         model.objects.get(desc="231").move(target, "first-sibling")
@@ -1319,6 +2487,24 @@ class TestMoveLeaf(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+
+    async def test_move_leaf_first_sibling_async(self, model_async):
+        target = await model_async.objects.aget(desc="22")
+        node = await model_async.objects.aget(desc="231")
+        await node.amove(target, "first-sibling")
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 5),
+            ("231", 2, 0),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        assert await self.agot(model_async) == expected
 
     def test_move_leaf_left_sibling(self, model):
         target = model.objects.get(desc="22")
@@ -1337,6 +2523,24 @@ class TestMoveLeaf(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    async def test_move_leaf_left_sibling_async(self, model_async):
+        target = await model_async.objects.aget(desc="22")
+        node = await model_async.objects.aget(desc="231")
+        await node.amove(target, "left")
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 5),
+            ("21", 2, 0),
+            ("231", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        assert await self.agot(model_async) == expected
+
     def test_move_leaf_right_sibling(self, model):
         target = model.objects.get(desc="22")
         model.objects.get(desc="231").move(target, "right")
@@ -1354,10 +2558,34 @@ class TestMoveLeaf(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    async def test_move_leaf_right_sibling_async(self, model_async):
+        target = await model_async.objects.aget(desc="22")
+        node = await model_async.objects.aget(desc="231")
+        await node.amove(target, "right")
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 5),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("231", 2, 0),
+            ("23", 2, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        assert await self.agot(model_async) == expected
+
     def test_move_leaf_left_sibling_itself(self, model):
         target = model.objects.get(desc="231")
         model.objects.get(desc="231").move(target, "left")
         assert self.got(model) == UNCHANGED
+
+    async def test_move_leaf_left_sibling_itself_async(self, model_async):
+        target = await model_async.objects.aget(desc="231")
+        node = await model_async.objects.aget(desc="231")
+        await node.amove(target, "left")
+        assert await self.agot(model_async) == UNCHANGED
 
     def test_move_leaf_last_child(self, model):
         target = model.objects.get(desc="22")
@@ -1376,6 +2604,24 @@ class TestMoveLeaf(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    async def test_move_leaf_last_child_async(self, model_async):
+        target = await model_async.objects.aget(desc="22")
+        node = await model_async.objects.aget(desc="231")
+        await node.amove(target, "last-child")
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 4),
+            ("21", 2, 0),
+            ("22", 2, 1),
+            ("231", 3, 0),
+            ("23", 2, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        assert await self.agot(model_async) == expected
+
     def test_move_leaf_first_child(self, model):
         target = model.objects.get(desc="22")
         model.objects.get(desc="231").move(target, "first-child")
@@ -1393,8 +2639,26 @@ class TestMoveLeaf(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    async def test_move_leaf_first_child_async(self, model_async):
+        target = await model_async.objects.aget(desc="22")
+        node = await model_async.objects.aget(desc="231")
+        await node.amove(target, "first-child")
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 4),
+            ("21", 2, 0),
+            ("22", 2, 1),
+            ("231", 3, 0),
+            ("23", 2, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        assert await self.agot(model_async) == expected
 
-@pytest.mark.django_db
+
+@pytest.mark.django_db(transaction=True)
 class TestMoveBranchRoot(TestNonEmptyTree):
     def test_move_branch_first_sibling_root(self, model):
         target = model.objects.get(desc="2")
@@ -1413,6 +2677,24 @@ class TestMoveBranchRoot(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    async def test_move_branch_first_sibling_root_async(self, model_async):
+        target = await model_async.objects.aget(desc="2")
+        node = await model_async.objects.aget(desc="4")
+        await node.amove(target, "first-sibling")
+        expected = [
+            ("4", 1, 1),
+            ("41", 2, 0),
+            ("1", 1, 0),
+            ("2", 1, 4),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 1),
+            ("231", 3, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+        ]
+        assert await self.agot(model_async) == expected
+
     def test_move_branch_last_sibling_root(self, model):
         target = model.objects.get(desc="2")
         model.objects.get(desc="4").move(target, "last-sibling")
@@ -1429,6 +2711,24 @@ class TestMoveBranchRoot(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+
+    async def test_move_branch_last_sibling_root_async(self, model_async):
+        target = await model_async.objects.aget(desc="2")
+        node = await model_async.objects.aget(desc="4")
+        await node.amove(target, "last-sibling")
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 4),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 1),
+            ("231", 3, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        assert await self.agot(model_async) == expected
 
     def test_move_branch_left_sibling_root(self, model):
         target = model.objects.get(desc="2")
@@ -1447,6 +2747,24 @@ class TestMoveBranchRoot(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    async def test_move_branch_left_sibling_root_async(self, model_async):
+        target = await model_async.objects.aget(desc="2")
+        node = await model_async.objects.aget(desc="4")
+        await node.amove(target, "left")
+        expected = [
+            ("1", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+            ("2", 1, 4),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 1),
+            ("231", 3, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+        ]
+        assert await self.agot(model_async) == expected
+
     def test_move_branch_right_sibling_root(self, model):
         target = model.objects.get(desc="2")
         model.objects.get(desc="4").move(target, "right")
@@ -1463,6 +2781,24 @@ class TestMoveBranchRoot(TestNonEmptyTree):
             ("3", 1, 0),
         ]
         assert self.got(model) == expected
+
+    async def test_move_branch_right_sibling_root_async(self, model_async):
+        target = await model_async.objects.aget(desc="2")
+        node = await model_async.objects.aget(desc="4")
+        await node.amove(target, "right")
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 4),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 1),
+            ("231", 3, 0),
+            ("24", 2, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+            ("3", 1, 0),
+        ]
+        assert await self.agot(model_async) == expected
 
     def test_move_branch_left_noleft_sibling_root(self, model):
         target = model.objects.get(desc="2").get_first_sibling()
@@ -1481,6 +2817,25 @@ class TestMoveBranchRoot(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    async def test_move_branch_left_noleft_sibling_root_async(self, model_async):
+        target = await model_async.objects.aget(desc="2")
+        target = await target.aget_first_sibling()
+        node = await model_async.objects.aget(desc="4")
+        await node.amove(target, "left")
+        expected = [
+            ("4", 1, 1),
+            ("41", 2, 0),
+            ("1", 1, 0),
+            ("2", 1, 4),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 1),
+            ("231", 3, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+        ]
+        assert await self.agot(model_async) == expected
+
     def test_move_branch_right_noright_sibling_root(self, model):
         target = model.objects.get(desc="2").get_last_sibling()
         model.objects.get(desc="4").move(target, "right")
@@ -1497,6 +2852,25 @@ class TestMoveBranchRoot(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+
+    async def test_move_branch_right_noright_sibling_root_async(self, model_async):
+        target = await model_async.objects.aget(desc="2")
+        target = await target.aget_last_sibling()
+        node = await model_async.objects.aget(desc="4")
+        await node.amove(target, "right")
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 4),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 1),
+            ("231", 3, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        assert await self.agot(model_async) == expected
 
     def test_move_branch_first_child_root(self, model):
         target = model.objects.get(desc="2")
@@ -1515,6 +2889,24 @@ class TestMoveBranchRoot(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    async def test_move_branch_first_child_root_async(self, model_async):
+        target = await model_async.objects.aget(desc="2")
+        node = await model_async.objects.aget(desc="4")
+        await node.amove(target, "first-child")
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 5),
+            ("4", 2, 1),
+            ("41", 3, 0),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 1),
+            ("231", 3, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+        ]
+        assert await self.agot(model_async) == expected
+
     def test_move_branch_last_child_root(self, model):
         target = model.objects.get(desc="2")
         model.objects.get(desc="4").move(target, "last-child")
@@ -1532,8 +2924,26 @@ class TestMoveBranchRoot(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    async def test_move_branch_last_child_root_async(self, model_async):
+        target = await model_async.objects.aget(desc="2")
+        node = await model_async.objects.aget(desc="4")
+        await node.amove(target, "last-child")
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 5),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 1),
+            ("231", 3, 0),
+            ("24", 2, 0),
+            ("4", 2, 1),
+            ("41", 3, 0),
+            ("3", 1, 0),
+        ]
+        assert await self.agot(model_async) == expected
 
-@pytest.mark.django_db
+
+@pytest.mark.django_db(transaction=True)
 class TestMoveBranch(TestNonEmptyTree):
     def test_move_branch_first_sibling(self, model):
         target = model.objects.get(desc="23")
@@ -1552,6 +2962,24 @@ class TestMoveBranch(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    async def test_move_branch_first_sibling_async(self, model_async):
+        target = await model_async.objects.aget(desc="23")
+        node = await model_async.objects.aget(desc="4")
+        await node.amove(target, "first-sibling")
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 5),
+            ("4", 2, 1),
+            ("41", 3, 0),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 1),
+            ("231", 3, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+        ]
+        assert await self.agot(model_async) == expected
+
     def test_move_branch_last_sibling(self, model):
         target = model.objects.get(desc="23")
         model.objects.get(desc="4").move(target, "last-sibling")
@@ -1568,6 +2996,24 @@ class TestMoveBranch(TestNonEmptyTree):
             ("3", 1, 0),
         ]
         assert self.got(model) == expected
+
+    async def test_move_branch_last_sibling_async(self, model_async):
+        target = await model_async.objects.aget(desc="23")
+        node = await model_async.objects.aget(desc="4")
+        await node.amove(target, "last-sibling")
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 5),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 1),
+            ("231", 3, 0),
+            ("24", 2, 0),
+            ("4", 2, 1),
+            ("41", 3, 0),
+            ("3", 1, 0),
+        ]
+        assert await self.agot(model_async) == expected
 
     def test_move_branch_left_sibling(self, model):
         target = model.objects.get(desc="23")
@@ -1586,6 +3032,24 @@ class TestMoveBranch(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    async def test_move_branch_left_sibling_async(self, model_async):
+        target = await model_async.objects.aget(desc="23")
+        node = await model_async.objects.aget(desc="4")
+        await node.amove(target, "left")
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 5),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("4", 2, 1),
+            ("41", 3, 0),
+            ("23", 2, 1),
+            ("231", 3, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+        ]
+        assert await self.agot(model_async) == expected
+
     def test_move_branch_right_sibling(self, model):
         target = model.objects.get(desc="23")
         model.objects.get(desc="4").move(target, "right")
@@ -1602,6 +3066,24 @@ class TestMoveBranch(TestNonEmptyTree):
             ("3", 1, 0),
         ]
         assert self.got(model) == expected
+
+    async def test_move_branch_right_sibling_async(self, model_async):
+        target = await model_async.objects.aget(desc="23")
+        node = await model_async.objects.aget(desc="4")
+        await node.amove(target, "right")
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 5),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 1),
+            ("231", 3, 0),
+            ("4", 2, 1),
+            ("41", 3, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+        ]
+        assert await self.agot(model_async) == expected
 
     def test_move_branch_left_noleft_sibling(self, model):
         target = model.objects.get(desc="23").get_first_sibling()
@@ -1620,6 +3102,25 @@ class TestMoveBranch(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    async def test_move_branch_left_noleft_sibling_async(self, model_async):
+        target = await model_async.objects.aget(desc="23")
+        target = await target.aget_first_sibling()
+        node = await model_async.objects.aget(desc="4")
+        await node.amove(target, "left")
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 5),
+            ("4", 2, 1),
+            ("41", 3, 0),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 1),
+            ("231", 3, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+        ]
+        assert await self.agot(model_async) == expected
+
     def test_move_branch_right_noright_sibling(self, model):
         target = model.objects.get(desc="23").get_last_sibling()
         model.objects.get(desc="4").move(target, "right")
@@ -1637,10 +3138,35 @@ class TestMoveBranch(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    async def test_move_branch_right_noright_sibling_async(self, model_async):
+        target = await model_async.objects.aget(desc="23")
+        target = await target.aget_last_sibling()
+        node = await model_async.objects.aget(desc="4")
+        await node.amove(target, "right")
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 5),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 1),
+            ("231", 3, 0),
+            ("24", 2, 0),
+            ("4", 2, 1),
+            ("41", 3, 0),
+            ("3", 1, 0),
+        ]
+        assert await self.agot(model_async) == expected
+
     def test_move_branch_left_itself_sibling(self, model):
         target = model.objects.get(desc="4")
         model.objects.get(desc="4").move(target, "left")
         assert self.got(model) == UNCHANGED
+
+    async def test_move_branch_left_itself_sibling_async(self, model_async):
+        target = await model_async.objects.aget(desc="4")
+        node = await model_async.objects.aget(desc="4")
+        await node.amove(target, "left")
+        assert await self.agot(model_async) == UNCHANGED
 
     def test_move_branch_first_child(self, model):
         target = model.objects.get(desc="23")
@@ -1659,6 +3185,24 @@ class TestMoveBranch(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    async def test_move_branch_first_child_async(self, model_async):
+        target = await model_async.objects.aget(desc="23")
+        node = await model_async.objects.aget(desc="4")
+        await node.amove(target, "first-child")
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 4),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 2),
+            ("4", 3, 1),
+            ("41", 4, 0),
+            ("231", 3, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+        ]
+        assert await self.agot(model_async) == expected
+
     def test_move_branch_last_child(self, model):
         target = model.objects.get(desc="23")
         model.objects.get(desc="4").move(target, "last-child")
@@ -1676,11 +3220,35 @@ class TestMoveBranch(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    async def test_move_branch_last_child_async(self, model_async):
+        target = await model_async.objects.aget(desc="23")
+        node = await model_async.objects.aget(desc="4")
+        await node.amove(target, "last-child")
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 4),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 2),
+            ("231", 3, 0),
+            ("4", 3, 1),
+            ("41", 4, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+        ]
+        assert await self.agot(model_async) == expected
 
-@pytest.mark.django_db
+
+@pytest.mark.django_db(transaction=True)
 class TestTreeSorted(TestTreeBase):
     def got(self, sorted_model):
         return [(o.val1, o.val2, o.desc, o.get_depth(), o.get_children_count()) for o in sorted_model.get_tree()]
+
+    async def agot(self, sorted_model):
+        objs = []
+        for o in await sorted_model.aget_tree():
+            objs.append((o.val1, o.val2, o.desc, await o.aget_depth(), await o.aget_children_count()))
+        return objs
 
     def test_add_root_sorted(self, sorted_model):
         sorted_model.add_root(val1=3, val2=3, desc="zxy")
@@ -1702,6 +3270,27 @@ class TestTreeSorted(TestTreeBase):
             (4, 1, "fgh", 1, 0),
         ]
         assert self.got(sorted_model) == expected
+
+    async def test_add_root_sorted_async(self, sorted_model):
+        await sorted_model.aadd_root(val1=3, val2=3, desc="zxy")
+        await sorted_model.aadd_root(val1=1, val2=4, desc="bcd")
+        await sorted_model.aadd_root(val1=2, val2=5, desc="zxy")
+        await sorted_model.aadd_root(val1=3, val2=3, desc="abc")
+        await sorted_model.aadd_root(val1=4, val2=1, desc="fgh")
+        await sorted_model.aadd_root(val1=3, val2=3, desc="abc")
+        await sorted_model.aadd_root(val1=2, val2=2, desc="qwe")
+        await sorted_model.aadd_root(val1=3, val2=2, desc="vcx")
+        expected = [
+            (1, 4, "bcd", 1, 0),
+            (2, 2, "qwe", 1, 0),
+            (2, 5, "zxy", 1, 0),
+            (3, 2, "vcx", 1, 0),
+            (3, 3, "abc", 1, 0),
+            (3, 3, "abc", 1, 0),
+            (3, 3, "zxy", 1, 0),
+            (4, 1, "fgh", 1, 0),
+        ]
+        assert await self.agot(sorted_model) == expected
 
     def test_add_child_root_sorted(self, sorted_model):
         root = sorted_model.add_root(val1=0, val2=0, desc="aaa")
@@ -1726,6 +3315,29 @@ class TestTreeSorted(TestTreeBase):
         ]
         assert self.got(sorted_model) == expected
 
+    async def test_add_child_root_sorted_async(self, sorted_model):
+        root = await sorted_model.aadd_root(val1=0, val2=0, desc="aaa")
+        await root.aadd_child(val1=3, val2=3, desc="zxy")
+        await root.aadd_child(val1=1, val2=4, desc="bcd")
+        await root.aadd_child(val1=2, val2=5, desc="zxy")
+        await root.aadd_child(val1=3, val2=3, desc="abc")
+        await root.aadd_child(val1=4, val2=1, desc="fgh")
+        await root.aadd_child(val1=3, val2=3, desc="abc")
+        await root.aadd_child(val1=2, val2=2, desc="qwe")
+        await root.aadd_child(val1=3, val2=2, desc="vcx")
+        expected = [
+            (0, 0, "aaa", 1, 8),
+            (1, 4, "bcd", 2, 0),
+            (2, 2, "qwe", 2, 0),
+            (2, 5, "zxy", 2, 0),
+            (3, 2, "vcx", 2, 0),
+            (3, 3, "abc", 2, 0),
+            (3, 3, "abc", 2, 0),
+            (3, 3, "zxy", 2, 0),
+            (4, 1, "fgh", 2, 0),
+        ]
+        assert await self.agot(sorted_model) == expected
+
     def test_add_child_nonroot_sorted(self, sorted_model):
         def get_node(node_id):
             return sorted_model.objects.get(pk=node_id)
@@ -1748,6 +3360,31 @@ class TestTreeSorted(TestTreeBase):
             (0, 0, "av", 2, 0),
         ]
         assert self.got(sorted_model) == expected
+
+    async def test_add_child_nonroot_sorted_async(self, sorted_model):
+        async def aget_node(node_id):
+            return await sorted_model.objects.aget(pk=node_id)
+
+        root = await sorted_model.aadd_root(val1=0, val2=0, desc="a")
+        node = await root.aadd_child(val1=0, val2=0, desc="ac")
+        node_id = node.pk
+        await root.aadd_child(val1=0, val2=0, desc="aa")
+        await root.aadd_child(val1=0, val2=0, desc="av")
+        node = await aget_node(node_id)
+        await node.aadd_child(val1=0, val2=0, desc="aca")
+        await node.aadd_child(val1=0, val2=0, desc="acc")
+        await node.aadd_child(val1=0, val2=0, desc="acb")
+
+        expected = [
+            (0, 0, "a", 1, 3),
+            (0, 0, "aa", 2, 0),
+            (0, 0, "ac", 2, 3),
+            (0, 0, "aca", 3, 0),
+            (0, 0, "acb", 3, 0),
+            (0, 0, "acc", 3, 0),
+            (0, 0, "av", 2, 0),
+        ]
+        assert await self.agot(sorted_model) == expected
 
     def test_move_sorted(self, sorted_model):
         sorted_model.add_root(val1=3, val2=3, desc="zxy")
@@ -1776,6 +3413,37 @@ class TestTreeSorted(TestTreeBase):
             (4, 1, "fgh", 2, 0),
         ]
         assert self.got(sorted_model) == expected
+
+    async def test_move_sorted_async(self, sorted_model):
+        await sorted_model.aadd_root(val1=3, val2=3, desc="zxy")
+        await sorted_model.aadd_root(val1=1, val2=4, desc="bcd")
+        await sorted_model.aadd_root(val1=2, val2=5, desc="zxy")
+        await sorted_model.aadd_root(val1=3, val2=3, desc="abc")
+        await sorted_model.aadd_root(val1=4, val2=1, desc="fgh")
+        await sorted_model.aadd_root(val1=3, val2=3, desc="abc")
+        await sorted_model.aadd_root(val1=2, val2=2, desc="qwe")
+        await sorted_model.aadd_root(val1=3, val2=2, desc="vcx")
+        root_nodes = []
+        for node in await sorted_model.aget_tree():
+            if node.is_root():
+                root_nodes.append(node)
+        target = root_nodes[0]
+        for node in root_nodes[1:]:
+            # because raw queries don't update django objects
+            node = await sorted_model.objects.aget(pk=node.pk)
+            target = await sorted_model.objects.aget(pk=target.pk)
+            await node.amove(target, "sorted-child")
+        expected = [
+            (1, 4, "bcd", 1, 7),
+            (2, 2, "qwe", 2, 0),
+            (2, 5, "zxy", 2, 0),
+            (3, 2, "vcx", 2, 0),
+            (3, 3, "abc", 2, 0),
+            (3, 3, "abc", 2, 0),
+            (3, 3, "zxy", 2, 0),
+            (4, 1, "fgh", 2, 0),
+        ]
+        assert await self.agot(sorted_model) == expected
 
     def test_move_sortedsibling(self, sorted_model):
         # https://bitbucket.org/tabo/django-treebeard/issue/27
@@ -1808,8 +3476,42 @@ class TestTreeSorted(TestTreeBase):
         ]
         assert self.got(sorted_model) == expected
 
+    async def test_move_sortedsibling_async(self, sorted_model):
+        # https://bitbucket.org/tabo/django-treebeard/issue/27
+        await sorted_model.aadd_root(val1=3, val2=3, desc="zxy")
+        await sorted_model.aadd_root(val1=1, val2=4, desc="bcd")
+        await sorted_model.aadd_root(val1=2, val2=5, desc="zxy")
+        await sorted_model.aadd_root(val1=3, val2=3, desc="abc")
+        await sorted_model.aadd_root(val1=4, val2=1, desc="fgh")
+        await sorted_model.aadd_root(val1=3, val2=3, desc="abc")
+        await sorted_model.aadd_root(val1=2, val2=2, desc="qwe")
+        await sorted_model.aadd_root(val1=3, val2=2, desc="vcx")
+        root_nodes = []
+        for node in await sorted_model.aget_tree():
+            if node.is_root():
+                root_nodes.append(node)
+        target = root_nodes[0]
+        for node in root_nodes[1:]:
+            # because raw queries don't update django objects
+            node = await sorted_model.objects.aget(pk=node.pk)
+            target = await sorted_model.objects.aget(pk=target.pk)
+            node.val1 -= 2
+            await node.asave()
+            await node.amove(target, "sorted-sibling")
+        expected = [
+            (0, 2, "qwe", 1, 0),
+            (0, 5, "zxy", 1, 0),
+            (1, 2, "vcx", 1, 0),
+            (1, 3, "abc", 1, 0),
+            (1, 3, "abc", 1, 0),
+            (1, 3, "zxy", 1, 0),
+            (1, 4, "bcd", 1, 0),
+            (2, 1, "fgh", 1, 0),
+        ]
+        assert await self.agot(sorted_model) == expected
 
-@pytest.mark.django_db
+
+@pytest.mark.django_db(transaction=True)
 class TestInheritedModels(TestTreeBase):
     @staticmethod
     @pytest.fixture(
@@ -1832,6 +3534,29 @@ class TestInheritedModels(TestTreeBase):
         node3 = inherited_model(desc="3")
         base_model.add_root(instance=node3)
         return inherited_model
+    
+    @staticmethod
+    @pytest.fixture(
+        scope="function",
+        params=zip(models.BASE_MODELS, models.INHERITED_MODELS),
+        ids=lambda fv: f"base={fv[0].__name__} inherited={fv[1].__name__}",
+    )
+    async def inherited_model_async(request):
+        base_model, inherited_model = request.param
+        await base_model.aadd_root(desc="1")
+        await base_model.aadd_root(desc="2")
+
+        node21 = inherited_model(desc="21")
+        await (await base_model.objects.aget(desc="2")).aadd_child(instance=node21)
+
+        await (await base_model.objects.aget(desc="21")).aadd_child(desc="211")
+        await (await base_model.objects.aget(desc="21")).aadd_child(desc="212")
+        await (await base_model.objects.aget(desc="2")).aadd_child(desc="22")
+
+        node3 = inherited_model(desc="3")
+        await base_model.aadd_root(instance=node3)
+        return inherited_model
+
 
     def test_get_tree_all(self, inherited_model):
         got = [(o.desc, o.get_depth(), o.get_children_count()) for o in inherited_model.get_tree()]
@@ -1846,6 +3571,21 @@ class TestInheritedModels(TestTreeBase):
         ]
         assert got == expected
 
+    async def test_get_tree_all_async(self, inherited_model_async):
+        objs = []
+        for o in await inherited_model_async.aget_tree():
+            objs.append((o.desc, await o.aget_depth(), await o.aget_children_count()))
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 2),
+            ("21", 2, 2),
+            ("211", 3, 0),
+            ("212", 3, 0),
+            ("22", 2, 0),
+            ("3", 1, 0),
+        ]
+        assert objs == expected
+
     def test_get_tree_node(self, inherited_model):
         node = inherited_model.objects.get(desc="21")
 
@@ -1857,17 +3597,45 @@ class TestInheritedModels(TestTreeBase):
         ]
         assert got == expected
 
+    async def test_get_tree_node_async(self, inherited_model_async):
+        node = await inherited_model_async.objects.aget(desc="21")
+
+        objs = []
+        for o in await inherited_model_async.aget_tree(node):
+            objs.append((o.desc, await o.aget_depth(), await o.aget_children_count()))
+        expected = [
+            ("21", 2, 2),
+            ("211", 3, 0),
+            ("212", 3, 0),
+        ]
+        assert objs == expected
+
     def test_get_root_nodes(self, inherited_model):
         got = inherited_model.get_root_nodes()
         expected = ["1", "2", "3"]
         assert [node.desc for node in got] == expected
 
+    async def test_get_root_nodes_async(self, inherited_model_async):
+        objs = []
+        async for node in inherited_model_async.get_root_nodes():
+            objs.append(node.desc)
+        expected = ["1", "2", "3"]
+        assert objs == expected
+
     def test_get_first_root_node(self, inherited_model):
         got = inherited_model.get_first_root_node()
         assert got.desc == "1"
 
+    async def test_get_first_root_node_async(self, inherited_model_async):
+        got = await inherited_model_async.aget_first_root_node()
+        assert got.desc == "1"
+
     def test_get_last_root_node(self, inherited_model):
         got = inherited_model.get_last_root_node()
+        assert got.desc == "3"
+
+    async def test_get_last_root_node_async(self, inherited_model_async):
+        got = await inherited_model_async.aget_last_root_node()
         assert got.desc == "3"
 
     def test_is_root(self, inherited_model):
@@ -1876,11 +3644,23 @@ class TestInheritedModels(TestTreeBase):
         assert node21.is_root() is False
         assert node3.is_root() is True
 
+    async def test_is_root_async(self, inherited_model_async):
+        node21 = await inherited_model_async.objects.aget(desc="21")
+        node3 = await inherited_model_async.objects.aget(desc="3")
+        assert await node21.ais_root() is False
+        assert await node3.ais_root() is True
+
     def test_is_leaf(self, inherited_model):
         node21 = inherited_model.objects.get(desc="21")
         node3 = inherited_model.objects.get(desc="3")
         assert node21.is_leaf() is False
         assert node3.is_leaf() is True
+
+    async def test_is_leaf_async(self, inherited_model_async):
+        node21 = await inherited_model_async.objects.aget(desc="21")
+        node3 = await inherited_model_async.objects.aget(desc="3")
+        assert await node21.ais_leaf() is False
+        assert await node3.ais_leaf() is True
 
     def test_get_root(self, inherited_model):
         node21 = inherited_model.objects.get(desc="21")
@@ -1888,11 +3668,27 @@ class TestInheritedModels(TestTreeBase):
         assert node21.get_root().desc == "2"
         assert node3.get_root().desc == "3"
 
+    async def test_get_root_async(self, inherited_model_async):
+        node21 = await inherited_model_async.objects.aget(desc="21")
+        node3 = await inherited_model_async.objects.aget(desc="3")
+        root21 = await node21.aget_root()
+        root3 = await node3.aget_root()
+        assert root21.desc == "2"
+        assert root3.desc == "3"
+
     def test_get_parent(self, inherited_model):
         node21 = inherited_model.objects.get(desc="21")
         node3 = inherited_model.objects.get(desc="3")
         assert node21.get_parent().desc == "2"
         assert node3.get_parent() is None
+
+    async def test_get_parent_async(self, inherited_model_async):
+        node21 = await inherited_model_async.objects.aget(desc="21")
+        node3 = await inherited_model_async.objects.aget(desc="3")
+        parent21 = await node21.aget_parent()
+        parent3 = await node3.aget_parent()
+        assert parent21.desc == "2"
+        assert parent3 is None
 
     def test_get_children(self, inherited_model):
         node21 = inherited_model.objects.get(desc="21")
@@ -1900,11 +3696,31 @@ class TestInheritedModels(TestTreeBase):
         assert [node.desc for node in node21.get_children()] == ["211", "212"]
         assert [node.desc for node in node3.get_children()] == []
 
+    async def test_get_children_async(self, inherited_model_async):
+        node21 = await inherited_model_async.objects.aget(desc="21")
+        node3 = await inherited_model_async.objects.aget(desc="3")
+        children21 = []
+        async for node in node21.get_children():
+            children21.append(node.desc)
+        children3 = []
+        async for node in node3.get_children():
+            children3.append(node.desc)
+        assert children21 == ["211", "212"]
+        assert children3 == []
+
     def test_get_children_count(self, inherited_model):
         node21 = inherited_model.objects.get(desc="21")
         node3 = inherited_model.objects.get(desc="3")
         assert node21.get_children_count() == 2
         assert node3.get_children_count() == 0
+
+    async def test_get_children_count_async(self, inherited_model_async):
+        node21 = await inherited_model_async.objects.aget(desc="21")
+        node3 = await inherited_model_async.objects.aget(desc="3")
+        count21 = await node21.aget_children_count()
+        count3 = await node3.aget_children_count()
+        assert count21 == 2
+        assert count3 == 0
 
     def test_get_siblings(self, inherited_model):
         node21 = inherited_model.objects.get(desc="21")
@@ -1912,11 +3728,31 @@ class TestInheritedModels(TestTreeBase):
         assert [node.desc for node in node21.get_siblings()] == ["21", "22"]
         assert [node.desc for node in node3.get_siblings()] == ["1", "2", "3"]
 
+    async def test_get_siblings_async(self, inherited_model_async):
+        node21 = await inherited_model_async.objects.aget(desc="21")
+        node3 = await inherited_model_async.objects.aget(desc="3")
+        siblings21 = []
+        async for node in await node21.aget_siblings():
+            siblings21.append(node.desc)
+        siblings3 = []
+        async for node in await node3.aget_siblings():
+            siblings3.append(node.desc)
+        assert siblings21 == ["21", "22"]
+        assert siblings3 == ["1", "2", "3"]
+
     def test_get_first_sibling(self, inherited_model):
         node21 = inherited_model.objects.get(desc="21")
         node3 = inherited_model.objects.get(desc="3")
         assert node21.get_first_sibling().desc == "21"
         assert node3.get_first_sibling().desc == "1"
+
+    async def test_get_first_sibling_async(self, inherited_model_async):
+        node21 = await inherited_model_async.objects.aget(desc="21")
+        node3 = await inherited_model_async.objects.aget(desc="3")
+        first21 = await node21.aget_first_sibling()
+        first3 = await node3.aget_first_sibling()
+        assert first21.desc == "21"
+        assert first3.desc == "1"
 
     def test_get_prev_sibling(self, inherited_model):
         node21 = inherited_model.objects.get(desc="21")
@@ -1924,11 +3760,27 @@ class TestInheritedModels(TestTreeBase):
         assert node21.get_prev_sibling() is None
         assert node3.get_prev_sibling().desc == "2"
 
+    async def test_get_prev_sibling_async(self, inherited_model_async):
+        node21 = await inherited_model_async.objects.aget(desc="21")
+        node3 = await inherited_model_async.objects.aget(desc="3")
+        prev21 = await node21.aget_prev_sibling()
+        prev3 = await node3.aget_prev_sibling()
+        assert prev21 is None
+        assert prev3.desc == "2"
+
     def test_get_next_sibling(self, inherited_model):
         node21 = inherited_model.objects.get(desc="21")
         node3 = inherited_model.objects.get(desc="3")
         assert node21.get_next_sibling().desc == "22"
         assert node3.get_next_sibling() is None
+
+    async def test_get_next_sibling_async(self, inherited_model_async):
+        node21 = await inherited_model_async.objects.aget(desc="21")
+        node3 = await inherited_model_async.objects.aget(desc="3")
+        next21 = await node21.aget_next_sibling()
+        next3 = await node3.aget_next_sibling()
+        assert next21.desc == "22"
+        assert next3 is None
 
     def test_get_last_sibling(self, inherited_model):
         node21 = inherited_model.objects.get(desc="21")
@@ -1936,11 +3788,27 @@ class TestInheritedModels(TestTreeBase):
         assert node21.get_last_sibling().desc == "22"
         assert node3.get_last_sibling().desc == "3"
 
+    async def test_get_last_sibling_async(self, inherited_model_async):
+        node21 = await inherited_model_async.objects.aget(desc="21")
+        node3 = await inherited_model_async.objects.aget(desc="3")
+        last21 = await node21.aget_last_sibling()
+        last3 = await node3.aget_last_sibling()
+        assert last21.desc == "22"
+        assert last3.desc == "3"
+
     def test_get_first_child(self, inherited_model):
         node21 = inherited_model.objects.get(desc="21")
         node3 = inherited_model.objects.get(desc="3")
         assert node21.get_first_child().desc == "211"
         assert node3.get_first_child() is None
+
+    async def test_get_first_child_async(self, inherited_model_async):
+        node21 = await inherited_model_async.objects.aget(desc="21")
+        node3 = await inherited_model_async.objects.aget(desc="3")
+        first21 = await node21.aget_first_child()
+        first3 = await node3.aget_first_child()
+        assert first21.desc == "211"
+        assert first3 is None
 
     def test_get_last_child(self, inherited_model):
         node21 = inherited_model.objects.get(desc="21")
@@ -1948,11 +3816,31 @@ class TestInheritedModels(TestTreeBase):
         assert node21.get_last_child().desc == "212"
         assert node3.get_last_child() is None
 
+    async def test_get_last_child_async(self, inherited_model_async):
+        node21 = await inherited_model_async.objects.aget(desc="21")
+        node3 = await inherited_model_async.objects.aget(desc="3")
+        last21 = await node21.aget_last_child()
+        last3 = await node3.aget_last_child()
+        assert last21.desc == "212"
+        assert last3 is None
+
     def test_get_ancestors(self, inherited_model):
         node21 = inherited_model.objects.get(desc="21")
         node3 = inherited_model.objects.get(desc="3")
         assert [node.desc for node in node21.get_ancestors()] == ["2"]
         assert [node.desc for node in node3.get_ancestors()] == []
+
+    async def test_get_ancestors_async(self, inherited_model_async):
+        node21 = await inherited_model_async.objects.aget(desc="21")
+        node3 = await inherited_model_async.objects.aget(desc="3")
+        ancestors21 = []
+        for node in await node21.aget_ancestors():
+            ancestors21.append(node.desc)
+        ancestors3 = []
+        for node in await node3.aget_ancestors():
+            ancestors3.append(node.desc)
+        assert ancestors21 == ["2"]
+        assert ancestors3 == []
 
     def test_get_descendants(self, inherited_model):
         node21 = inherited_model.objects.get(desc="21")
@@ -1960,11 +3848,31 @@ class TestInheritedModels(TestTreeBase):
         assert [node.desc for node in node21.get_descendants()] == ["211", "212"]
         assert [node.desc for node in node3.get_descendants()] == []
 
+    async def test_get_descendants_async(self, inherited_model_async):
+        node21 = await inherited_model_async.objects.aget(desc="21")
+        node3 = await inherited_model_async.objects.aget(desc="3")
+        descendants21 = []
+        for node in await node21.aget_descendants():
+            descendants21.append(node.desc)
+        descendants3 = []
+        for node in await node3.aget_descendants():
+            descendants3.append(node.desc)
+        assert descendants21 == ["211", "212"]
+        assert descendants3 == []
+
     def test_get_descendant_count(self, inherited_model):
         node21 = inherited_model.objects.get(desc="21")
         node3 = inherited_model.objects.get(desc="3")
         assert node21.get_descendant_count() == 2
         assert node3.get_descendant_count() == 0
+
+    async def test_get_descendant_count_async(self, inherited_model_async):
+        node21 = await inherited_model_async.objects.aget(desc="21")
+        node3 = await inherited_model_async.objects.aget(desc="3")
+        count21 = await node21.aget_descendant_count()
+        count3 = await node3.aget_descendant_count()
+        assert count21 == 2
+        assert count3 == 0
 
     def test_cascading_deletion(self, inherited_model):
         # Deleting a node by calling delete() on the inherited_model class
@@ -1979,8 +3887,25 @@ class TestInheritedModels(TestTreeBase):
             assert not base_model.objects.filter(desc=desc).exists()
         assert [node.desc for node in node2.get_descendants()] == ["22"]
 
+    async def test_cascading_deletion_async(self, inherited_model_async):
+        # Deleting a node by calling delete() on the inherited_model class
+        # should delete descendants, even if those descendants are not
+        # instances of inherited_model
+        base_model = inherited_model_async.__bases__[0]
 
-@pytest.mark.django_db
+        node21 = await inherited_model_async.objects.aget(desc="21")
+        await node21.adelete()
+        node2 = await base_model.objects.aget(desc="2")
+        for desc in ["21", "211", "212"]:
+            exists = await base_model.objects.filter(desc=desc).aexists()
+            assert not exists
+        descendants = []
+        for node in await node2.aget_descendants():
+            descendants.append(node.desc)
+        assert descendants == ["22"]
+
+
+@pytest.mark.django_db(transaction=True)
 class TestMP_TreeAlphabet(TestTreeBase):
     @pytest.mark.skipif(
         not os.getenv("TREEBEARD_TEST_ALPHABET", False),
@@ -2020,8 +3945,49 @@ class TestMP_TreeAlphabet(TestTreeBase):
             last_good = alphabet
         assert False, f"Best BASE85 based alphabet for your setup: {last_good} (base {len(last_good)})"
 
+    @pytest.mark.skipif(
+        not os.getenv("TREEBEARD_TEST_ALPHABET", False),
+        reason="TREEBEARD_TEST_ALPHABET env variable not set.",
+    )
+    async def test_alphabet_async(self, mpalphabet_model):
+        """This isn't actually a test, it's an informational routine."""
+        basealpha = numconv.BASE85
+        got_err = False
+        last_good = None
+        for alphabetlen in range(3, len(basealpha) + 1):
+            alphabet = basealpha[0:alphabetlen]
+            assert len(alphabet) >= 3
+            expected = [alphabet[0] + char for char in alphabet[1:]]
+            expected.extend([alphabet[1] + char for char in alphabet])
+            expected.append(alphabet[2] + alphabet[0])
 
-@pytest.mark.django_db
+            # remove all nodes
+            await mpalphabet_model.objects.all().adelete()
+
+            # change the model's alphabet
+            mpalphabet_model.alphabet = alphabet
+            mpalphabet_model.numconv_obj_ = None
+
+            # insert root nodes
+            for pos in range(len(alphabet) * 2):
+                try:
+                    await mpalphabet_model.aadd_root(numval=pos)
+                except Exception:
+                    got_err = True
+                    break
+            if got_err:
+                break
+            objs = []
+            async for obj in mpalphabet_model.objects.all().aiterator():
+                objs.append(obj)
+            got = [obj.path for obj in objs]
+            if got != expected:
+                break
+            last_good = alphabet
+        assert False, f"Best BASE85 based alphabet for your setup: {last_good} (base {len(last_good)})"
+
+
+@pytest.mark.django_db(transaction=True)
 class TestHelpers(TestTreeBase):
     @staticmethod
     @pytest.fixture(scope="function", params=models.BASE_MODELS + models.PROXY_MODELS)
@@ -2032,10 +3998,30 @@ class TestHelpers(TestTreeBase):
             model.load_bulk(BASE_DATA, node)
         model.add_root(desc="5")
         return model
+    
+    @staticmethod
+    @pytest.fixture(scope="function", params=models.BASE_MODELS + models.PROXY_MODELS)
+    async def helpers_model_async(request):
+        model = request.param
+        await model.aload_bulk(BASE_DATA)
+        async for node in model.get_root_nodes():
+            await model.aload_bulk(BASE_DATA, node)
+        await model.aadd_root(desc="5")
+        return model
 
     def test_descendants_group_count_root(self, helpers_model):
         expected = [(o.desc, o.get_descendant_count()) for o in helpers_model.get_root_nodes()]
         got = [(o.desc, o.descendants_count) for o in helpers_model.get_descendants_group_count()]
+        assert got == expected
+
+    async def test_descendants_group_count_root_async(self, helpers_model_async):
+        expected = []
+        async for o in helpers_model_async.get_root_nodes():
+            count = await o.aget_descendant_count()
+            expected.append((o.desc, count))
+        got = []
+        for o in await helpers_model_async.aget_descendants_group_count():
+            got.append((o.desc, o.descendants_count))
         assert got == expected
 
     def test_descendants_group_count_node(self, helpers_model):
@@ -2044,8 +4030,19 @@ class TestHelpers(TestTreeBase):
         got = [(o.desc, o.descendants_count) for o in helpers_model.get_descendants_group_count(parent)]
         assert got == expected
 
+    async def test_descendants_group_count_node_async(self, helpers_model_async):
+        parent = await helpers_model_async.get_root_nodes().aget(desc="2")
+        expected = []
+        async for o in parent.get_children():
+            count = await o.aget_descendant_count()
+            expected.append((o.desc, count))
+        got = []
+        for o in await helpers_model_async.aget_descendants_group_count(parent):
+            got.append((o.desc, o.descendants_count))
+        assert got == expected
 
-@pytest.mark.django_db
+
+@pytest.mark.django_db(transaction=True)
 class TestMP_TreeSortedAutoNow(TestTreeBase):
     """
     The sorting mechanism used by treebeard when adding a node can fail if the
@@ -2057,6 +4054,13 @@ class TestMP_TreeSortedAutoNow(TestTreeBase):
         for i in range(1, 5):
             mpsortedautonow_model.add_root(desc="node%d" % (i,), created=datetime.datetime.now())
 
+    async def test_sorted_by_autonow_workaround_async(self, mpsortedautonow_model):
+        # workaround
+        for i in range(1, 5):
+            await mpsortedautonow_model.aadd_root(
+                desc="node%d" % (i,), created=datetime.datetime.now()
+            )
+
     def test_sorted_by_autonow_FAIL(self, mpsortedautonow_model):
         """
         This test asserts that we have a problem.
@@ -2066,8 +4070,17 @@ class TestMP_TreeSortedAutoNow(TestTreeBase):
         with pytest.raises(ValueError):
             mpsortedautonow_model.add_root(desc="node2")
 
+    async def test_sorted_by_autonow_FAIL_async(self, mpsortedautonow_model):
+        """
+        This test asserts that we have a problem.
+        fix this, somehow
+        """
+        await mpsortedautonow_model.aadd_root(desc="node1")
+        with pytest.raises(ValueError):
+            await mpsortedautonow_model.aadd_root(desc="node2")
 
-@pytest.mark.django_db
+
+@pytest.mark.django_db(transaction=True)
 class TestMP_TreeStepOverflow(TestTreeBase):
     def test_add_root(self, mpsmallstep_model):
         method = mpsmallstep_model.add_root
@@ -2075,6 +4088,13 @@ class TestMP_TreeStepOverflow(TestTreeBase):
             method()
         with pytest.raises(PathOverflow):
             method()
+
+    async def test_add_root_async(self, mpsmallstep_model):
+        method = mpsmallstep_model.aadd_root
+        for i in range(1, 10):
+            await method()
+        with pytest.raises(PathOverflow):
+            await method()
 
     def test_add_child(self, mpsmallstep_model):
         root = mpsmallstep_model.add_root()
@@ -2084,6 +4104,14 @@ class TestMP_TreeStepOverflow(TestTreeBase):
         with pytest.raises(PathOverflow):
             method()
 
+    async def test_add_child_async(self, mpsmallstep_model):
+        root = await mpsmallstep_model.aadd_root()
+        method = root.aadd_child
+        for i in range(1, 10):
+            await method()
+        with pytest.raises(PathOverflow):
+            await method()
+
     def test_add_sibling(self, mpsmallstep_model):
         root = mpsmallstep_model.add_root()
         for i in range(1, 10):
@@ -2092,6 +4120,16 @@ class TestMP_TreeStepOverflow(TestTreeBase):
         for pos in positions:
             with pytest.raises(PathOverflow):
                 root.get_last_child().add_sibling(pos)
+
+    async def test_add_sibling_async(self, mpsmallstep_model):
+        root = await mpsmallstep_model.aadd_root()
+        for i in range(1, 10):
+            await root.aadd_child()
+        positions = ("first-sibling", "left", "right", "last-sibling")
+        for pos in positions:
+            last_child = await root.aget_last_child()
+            with pytest.raises(PathOverflow):
+                await last_child.aadd_sibling(pos)
 
     def test_move(self, mpsmallstep_model):
         root = mpsmallstep_model.add_root()
@@ -2110,8 +4148,25 @@ class TestMP_TreeStepOverflow(TestTreeBase):
                 with pytest.raises(PathOverflow):
                     newroot.move(target, pos)
 
+    async def test_move_async(self, mpsmallstep_model):
+        root = await mpsmallstep_model.aadd_root()
+        for i in range(1, 10):
+            await root.aadd_child()
+        newroot = await mpsmallstep_model.aadd_root()
+        targets = [
+            (root, ["first-child", "last-child"]),
+            (
+                await root.aget_first_child(),
+                ["first-sibling", "left", "right", "last-sibling"],
+            ),
+        ]
+        for target, positions in targets:
+            for pos in positions:
+                with pytest.raises(PathOverflow):
+                    await newroot.amove(target, pos)
 
-@pytest.mark.django_db
+
+@pytest.mark.django_db(transaction=True)
 class TestMP_TreeShortPath(TestTreeBase):
     """Test a tree with a very small path field (max_length=4) and a
     steplen of 1
@@ -2123,8 +4178,14 @@ class TestMP_TreeShortPath(TestTreeBase):
         with pytest.raises(PathOverflow):
             obj.add_child()
 
+    async def test_short_path_async(self, mpshortnotsorted_model):
+        obj = await mpshortnotsorted_model.aadd_root()
+        obj = await (await (await obj.aadd_child()).aadd_child()).aadd_child()
+        with pytest.raises(PathOverflow):
+            await obj.aadd_child()
 
-@pytest.mark.django_db
+
+@pytest.mark.django_db(transaction=True)
 class TestMP_TreeFindProblems(TestTreeBase):
     def test_find_problems(self, mpalphabet_model):
         mpalphabet_model.alphabet = "01234"
@@ -2157,8 +4218,41 @@ class TestMP_TreeFindProblems(TestTreeBase):
         assert ["03", "0301", "030102"] == got(wrong_numchild)
         assert ["04", "0401"] == got(wrong_depth)
 
+    async def test_find_problems_async(self, mpalphabet_model):
+        mpalphabet_model.alphabet = "01234"
+        await mpalphabet_model(path="01", depth=1, numchild=0, numval=0).asave()
+        await mpalphabet_model(path="1", depth=1, numchild=0, numval=0).asave()
+        await mpalphabet_model(path="111", depth=1, numchild=0, numval=0).asave()
+        await mpalphabet_model(path="abcd", depth=1, numchild=0, numval=0).asave()
+        await mpalphabet_model(path="qa#$%!", depth=1, numchild=0, numval=0).asave()
+        await mpalphabet_model(path="0201", depth=2, numchild=0, numval=0).asave()
+        await mpalphabet_model(path="020201", depth=3, numchild=0, numval=0).asave()
+        await mpalphabet_model(path="03", depth=1, numchild=2, numval=0).asave()
+        await mpalphabet_model(path="0301", depth=2, numchild=0, numval=0).asave()
+        await mpalphabet_model(path="030102", depth=3, numchild=10, numval=0).asave()
+        await mpalphabet_model(path="04", depth=10, numchild=1, numval=0).asave()
+        await mpalphabet_model(path="0401", depth=20, numchild=0, numval=0).asave()
 
-@pytest.mark.django_db
+        async def agot(ids):
+            return [
+                o.path async for o in mpalphabet_model.objects.filter(pk__in=ids)
+            ]
+
+        (
+            evil_chars,
+            bad_steplen,
+            orphans,
+            wrong_depth,
+            wrong_numchild,
+        ) = await mpalphabet_model.afind_problems()
+        assert ["abcd", "qa#$%!"] == await agot(evil_chars)
+        assert ["1", "111"] == await agot(bad_steplen)
+        assert ["0201", "020201"] == await agot(orphans)
+        assert ["03", "0301", "030102"] == await agot(wrong_numchild)
+        assert ["04", "0401"] == await agot(wrong_depth)
+
+
+@pytest.mark.django_db(transaction=True)
 class TestMP_TreeFix(TestTreeBase):
     expected_no_holes = {
         models.MP_TestNodeShortPath: [
@@ -2231,6 +4325,12 @@ class TestMP_TreeFix(TestTreeBase):
 
     def got(self, model):
         return [(o.path, o.desc, o.get_depth(), o.get_children_count()) for o in model.get_tree()]
+    
+    async def agot(self, model):
+        objs = []
+        async for o in model.aget_tree():
+            objs.append((o.path, o.desc, await o.aget_depth(), await o.aget_children_count()))
+        return objs
 
     def add_broken_test_data(self, model):
         model(path="4", depth=2, numchild=2, desc="a").save()
@@ -2248,6 +4348,22 @@ class TestMP_TreeFix(TestTreeBase):
         model(path="1", depth=10, numchild=3, desc="b").save()
         model(path="2", depth=10, numchild=3, desc="d").save()
 
+    async def add_broken_test_data_async(self, model):
+        await model(path="4", depth=2, numchild=2, desc="a").asave()
+        await model(path="13", depth=1000, numchild=0, desc="u").asave()
+        await model(path="14", depth=4, numchild=500, desc="o").asave()
+        await model(path="134", depth=321, numchild=543, desc="i").asave()
+        await model(path="1343", depth=321, numchild=543, desc="e").asave()
+        await model(path="42", depth=1, numchild=1, desc="a").asave()
+        await model(path="43", depth=1000, numchild=0, desc="u").asave()
+        await model(path="44", depth=4, numchild=500, desc="o").asave()
+        await model(path="434", depth=321, numchild=543, desc="i").asave()
+        await model(path="4343", depth=321, numchild=543, desc="e").asave()
+        await model(path="41", depth=1, numchild=1, desc="a").asave()
+        await model(path="3", depth=221, numchild=322, desc="g").asave()
+        await model(path="1", depth=10, numchild=3, desc="b").asave()
+        await model(path="2", depth=10, numchild=3, desc="d").asave()
+
     def test_fix_tree_non_destructive(self, mpshort_model):
         self.add_broken_test_data(mpshort_model)
         mpshort_model.fix_tree(destructive=False)
@@ -2255,6 +4371,14 @@ class TestMP_TreeFix(TestTreeBase):
         expected = self.expected_with_holes[mpshort_model]
         assert got == expected
         mpshort_model.find_problems()
+
+    async def test_fix_tree_non_destructive_async(self, mpshort_model):
+        await self.add_broken_test_data_async(mpshort_model)
+        await mpshort_model.afix_tree(destructive=False)
+        got = await self.agot(mpshort_model)
+        expected = self.expected_with_holes[mpshort_model]
+        assert got == expected
+        await mpshort_model.afind_problems()
 
     def test_fix_tree_destructive(self, mpshort_model):
         self.add_broken_test_data(mpshort_model)
@@ -2264,6 +4388,14 @@ class TestMP_TreeFix(TestTreeBase):
         assert got == expected
         mpshort_model.find_problems()
 
+    async def test_fix_tree_destructive_async(self, mpshort_model):
+        await self.add_broken_test_data_async(mpshort_model)
+        await mpshort_model.afix_tree(destructive=True)
+        got = await self.agot(mpshort_model)
+        expected = self.expected_no_holes[mpshort_model]
+        assert got == expected
+        await mpshort_model.afind_problems()
+
     def test_fix_tree_with_fix_paths(self, mpshort_model):
         self.add_broken_test_data(mpshort_model)
         mpshort_model.fix_tree(fix_paths=True)
@@ -2272,8 +4404,16 @@ class TestMP_TreeFix(TestTreeBase):
         assert got == expected
         mpshort_model.find_problems()
 
+    async def test_fix_tree_with_fix_paths_async(self, mpshort_model):
+        await self.add_broken_test_data_async(mpshort_model)
+        await mpshort_model.afix_tree(fix_paths=True)
+        got = await self.agot(mpshort_model)
+        expected = self.expected_no_holes[mpshort_model]
+        assert got == expected
+        await mpshort_model.afind_problems()
 
-@pytest.mark.django_db
+
+@pytest.mark.django_db(transaction=True)
 class TestIssues(TestTreeBase):
     # test for http://code.google.com/p/django-treebeard/issues/detail?id=14
 
@@ -2321,8 +4461,55 @@ class TestIssues(TestTreeBase):
 
         qs_check_first_or_user(["first"], root, anonuserobj)
 
+    async def test_many_to_many_django_user_anonymous_async(self, mpm2muser_model):
+        # Using AnonymousUser() in the querysets will expose non-treebeard
+        # related problems in Django 1.0
+        #
+        # Postgres:
+        #   ProgrammingError: can't adapt
+        # SQLite:
+        #   InterfaceError: Error binding parameter 4 - probably unsupported
+        #   type.
+        # MySQL compared a string to an integer field:
+        #   `treebeard_mp_testissue14_users`.`user_id` = 'AnonymousUser'
+        #
+        # Using a None field instead works (will be translated to IS NULL).
+        #
+        # anonuserobj = AnonymousUser()
+        anonuserobj = None
 
-@pytest.mark.django_db
+        async def qs_check(qs, expected):
+            objs = []
+            async for o in qs:
+                objs.append(o)
+            assert [o.name for o in objs] == expected
+
+        async def qs_check_first_or_user(expected, root, user):
+            await qs_check(
+                root.aget_children().filter(Q(name="first") | Q(users=user)), expected
+            )
+
+        user = await User.objects.acreate_user("test_user", "test@example.com", "testpasswd")
+        await user.asave()
+        root = mpm2muser_model.add_root(name="the root node")
+        await root.aadd_child(name="first")
+        second = await root.aadd_child(name="second")
+        await qs_check(root.aget_children(), ["first", "second"])
+        await qs_check(root.aget_children().filter(Q(name="first")), ["first"])
+        await qs_check(root.aget_children().filter(Q(users=user)), [])
+
+        await qs_check_first_or_user(["first"], root, user)
+
+        await qs_check_first_or_user(["first", "second"], root, anonuserobj)
+
+        user = await User.objects.aget(username="test_user")
+        await second.ausers_add(user)
+        await qs_check_first_or_user(["first", "second"], root, user)
+
+        await qs_check_first_or_user(["first"], root, anonuserobj)
+
+
+@pytest.mark.django_db(transaction=True)
 class TestMoveNodeForm(TestNonEmptyTree):
     def _get_nodes_list(self, nodes):
         return [(pk, "%s%s" % ("&nbsp;" * 4 * (depth - 1), str)) for pk, str, depth in nodes]
@@ -2349,9 +4536,25 @@ class TestMoveNodeForm(TestNonEmptyTree):
         node = nodes.pop(0)
         safe_parent_nodes = self._get_node_ids_strs_and_depths(nodes)
         self._move_node_helper(node, safe_parent_nodes)
+    
+    async def test_form_root_node_async(self, model):
+        nodes = []
+        async for node in model.aget_tree():
+            nodes.append(node)
+        node = nodes.pop(0)
+        safe_parent_nodes = self._get_node_ids_strs_and_depths(nodes)
+        self._move_node_helper(node, safe_parent_nodes)
 
     def test_form_leaf_node(self, model):
         nodes = list(model.get_tree())
+        safe_parent_nodes = self._get_node_ids_strs_and_depths(nodes)
+        node = nodes.pop()
+        self._move_node_helper(node, safe_parent_nodes)
+
+    async def test_form_leaf_node_async(self, model):
+        nodes = []
+        async for node in model.aget_tree():
+            nodes.append(node)
         safe_parent_nodes = self._get_node_ids_strs_and_depths(nodes)
         node = nodes.pop()
         self._move_node_helper(node, safe_parent_nodes)
@@ -2377,8 +4580,32 @@ class TestMoveNodeForm(TestNonEmptyTree):
             nodes = self._get_nodes_list(safe_parent_nodes)
             self._assert_nodes_in_choices(form, nodes)
 
+    async def test_form_admin_async(self, async_model):
+        request = None
+        nodes = []
+        async for node in async_model.aget_tree():
+            nodes.append(node)
+        safe_parent_nodes = self._get_node_ids_strs_and_depths(nodes)
+        for node in async_model.objects.all():
+            site = AdminSite()
+            form_class = movenodeform_factory(async_model)
+            admin_class = admin_factory(form_class)
+            ma = admin_class(async_model, site)
+            got = list(ma.get_form(request).base_fields.keys())
+            desc_pos_refnodeid = ["desc", "_position", "_ref_node_id"]
+            assert desc_pos_refnodeid == got
+            got = ma.get_fieldsets(request)
+            expected = [(None, {"fields": desc_pos_refnodeid})]
+            assert got == expected
+            got = ma.get_fieldsets(request, node)
+            assert got == expected
+            form = ma.get_form(request)()
+            nodes = self._get_nodes_list(safe_parent_nodes)
+            self._assert_nodes_in_choices(form, nodes)
+        
 
-@pytest.mark.django_db
+
+@pytest.mark.django_db(transaction=True)
 class TestModelAdmin(TestNonEmptyTree):
     def test_default_fields(self, model):
         site = AdminSite()
@@ -2391,8 +4618,19 @@ class TestModelAdmin(TestNonEmptyTree):
             "_ref_node_id",
         ]
 
+    async def test_default_fields_async(self, async_model):
+        site = AdminSite()
+        form_class = movenodeform_factory(async_model)
+        admin_class = admin_factory(form_class)
+        ma = admin_class(async_model, site)
+        assert list(ma.get_form(None).base_fields.keys()) == [
+            "desc",
+            "_position",
+            "_ref_node_id",
+        ]
 
-@pytest.mark.django_db
+
+@pytest.mark.django_db(transaction=True)
 class TestSortedForm(TestTreeSorted):
     def test_sorted_form(self, sorted_model):
         sorted_model.add_root(val1=3, val2=3, desc="zxy")
@@ -2425,8 +4663,40 @@ class TestSortedForm(TestTreeSorted):
         assert "id__position" in str(form)
         assert "id__ref_node_id" in str(form)
 
+    async def test_sorted_form_async(self, async_sorted_model):
+        await async_sorted_model.aadd_root(val1=3, val2=3, desc="zxy")
+        await async_sorted_model.aadd_root(val1=1, val2=4, desc="bcd")
+        await async_sorted_model.aadd_root(val1=2, val2=5, desc="zxy")
+        await async_sorted_model.aadd_root(val1=3, val2=3, desc="abc")
+        await async_sorted_model.aadd_root(val1=4, val2=1, desc="fgh")
+        await async_sorted_model.aadd_root(val1=3, val2=3, desc="abc")
+        await async_sorted_model.aadd_root(val1=2, val2=2, desc="qwe")
+        await async_sorted_model.aadd_root(val1=3, val2=2, desc="vcx")
 
-@pytest.mark.django_db
+        form_class = movenodeform_factory(async_sorted_model)
+        form = form_class()
+        assert list(form.fields.keys()) == [
+            "val1",
+            "val2",
+            "desc",
+            "_position",
+            "_ref_node_id",
+        ]
+
+        instance = await async_sorted_model.objects.aget(desc="bcd")
+        form = form_class(instance=instance)
+        assert list(form.fields.keys()) == [
+            "val1",
+            "val2",
+            "desc",
+            "_position",
+            "_ref_node_id",
+        ]
+        assert "id__position" in str(form)
+        assert "id__ref_node_id" in str(form)
+
+
+@pytest.mark.django_db(transaction=True)
 class TestForm(TestNonEmptyTree):
     def test_form(self, model):
         form_class = movenodeform_factory(model)
@@ -2438,10 +4708,34 @@ class TestForm(TestNonEmptyTree):
         assert "id__position" in str(form)
         assert "id__ref_node_id" in str(form)
 
+    async def test_form_async(self, async_model):
+        form_class = movenodeform_factory(async_model)
+        form = form_class()
+        assert list(form.fields.keys()) == ["desc", "_position", "_ref_node_id"]
+
+        instance = await async_model.objects.aget(desc="1")
+        form = form_class(instance=instance)
+        assert list(form.fields.keys()) == ["desc", "_position", "_ref_node_id"]
+        assert "id__position" in str(form)
+        assert "id__ref_node_id" in str(form)
+
     def test_move_node_form(self, model):
         form_class = movenodeform_factory(model)
 
         bad_node = model.objects.get(desc="1").add_child(desc='Benign<script>alert("Compromised");</script>')
+
+        form = form_class(instance=bad_node)
+        rendered_html = form.as_p()
+        assert "Benign" in rendered_html
+        assert "<script>" not in rendered_html
+        assert "&lt;script&gt;" in rendered_html
+
+    async def test_move_node_form_async(self, async_model):
+        form_class = movenodeform_factory(async_model)
+
+        bad_node = await (await async_model.objects.aget(desc="1")).aadd_child(
+            desc='Benign<script>alert("Compromised");</script>'
+        )
 
         form = form_class(instance=bad_node)
         rendered_html = form.as_p()
@@ -2480,11 +4774,58 @@ class TestForm(TestNonEmptyTree):
             "_ref_node_id": model.objects.get(desc="23").pk,
         }
 
+    async def test_get_position_ref_node_async(self, async_model):
+        form_class = movenodeform_factory(async_model)
+
+        instance_parent = await async_model.objects.aget(desc="1")
+        form = form_class(instance=instance_parent)
+        assert form._get_position_ref_node(instance_parent) == {
+            "_position": "first-child",
+            "_ref_node_id": "",
+        }
+
+        instance_child = await async_model.objects.aget(desc="21")
+        form = form_class(instance=instance_child)
+        assert form._get_position_ref_node(instance_child) == {
+            "_position": "first-child",
+            "_ref_node_id": (await async_model.objects.aget(desc="2")).pk,
+        }
+
+        instance_grandchild = await async_model.objects.aget(desc="22")
+        form = form_class(instance=instance_grandchild)
+        assert form._get_position_ref_node(instance_grandchild) == {
+            "_position": "right",
+            "_ref_node_id": (await async_model.objects.aget(desc="21")).pk,
+        }
+
+        instance_grandchild = await async_model.objects.aget(desc="231")
+        form = form_class(instance=instance_grandchild)
+        assert form._get_position_ref_node(instance_grandchild) == {
+            "_position": "first-child",
+            "_ref_node_id": (await async_model.objects.aget(desc="23")).pk,
+        }
+
     def test_clean_cleaned_data(self, model):
         instance_parent = model.objects.get(desc="1")
         _position = "first-child"
         _ref_node_id = ""
         form_class = movenodeform_factory(model)
+        form = form_class(
+            instance=instance_parent,
+            data={
+                "_position": _position,
+                "_ref_node_id": _ref_node_id,
+                "desc": instance_parent.desc,
+            },
+        )
+        assert form.is_valid()
+        assert form._clean_cleaned_data() == (_position, _ref_node_id)
+
+    async def test_clean_cleaned_data_async(self, async_model):
+        instance_parent = await async_model.objects.aget(desc="1")
+        _position = "first-child"
+        _ref_node_id = ""
+        form_class = movenodeform_factory(async_model)
         form = form_class(
             instance=instance_parent,
             data={
@@ -2534,6 +4875,44 @@ class TestForm(TestNonEmptyTree):
         assert restored_instance.is_root()
         assert restored_instance.is_leaf()
 
+    async def test_save_edit_async(self, async_model):
+        instance_parent = await async_model.objects.aget(desc="1")
+        original_count = len(async_model.objects.all())
+        form_class = movenodeform_factory(async_model)
+        form = form_class(
+            instance=instance_parent,
+            data={
+                "_position": "first-child",
+                "_ref_node_id": (await async_model.objects.aget(desc="2")).pk,
+                "desc": instance_parent.desc,
+            },
+        )
+        assert form.is_valid()
+        saved_instance = form.save()
+        assert original_count == async_model.objects.all().count()
+        assert await saved_instance.aget_children_count() == 0
+        assert await saved_instance.aget_depth() == 2
+        assert not await saved_instance.ais_root()
+        assert await saved_instance.ais_leaf()
+
+        # Return to original state
+        form_class = movenodeform_factory(async_model)
+        form = form_class(
+            instance=saved_instance,
+            data={
+                "_position": "first-child",
+                "_ref_node_id": "",
+                "desc": saved_instance.desc,
+            },
+        )
+        assert form.is_valid()
+        restored_instance = form.save()
+        assert original_count == async_model.objects.all().count()
+        assert await restored_instance.aget_children_count() == 0
+        assert await restored_instance.aget_depth() == 1
+        assert await restored_instance.ais_root()
+        assert await restored_instance.ais_leaf()
+
     def test_save_new(self, model):
         original_count = model.objects.all().count()
         assert original_count == 10
@@ -2543,6 +4922,16 @@ class TestForm(TestNonEmptyTree):
         assert form.is_valid()
         assert form.save() is not None
         assert original_count < model.objects.all().count()
+
+    async def test_save_new_async(self, async_model):
+        original_count = await async_model.objects.acount()
+        assert original_count == 10
+        _position = "first-child"
+        form_class = movenodeform_factory(async_model)
+        form = form_class(data={"_position": _position, "desc": "New Form Test"})
+        assert form.is_valid()
+        assert await form.asave() is not None
+        assert original_count < await async_model.objects.acount()
 
     def test_save_new_with_pk_set(self, model):
         """
@@ -2562,6 +4951,24 @@ class TestForm(TestNonEmptyTree):
         assert form.save() is not None
         assert original_count < model.objects.all().count()
 
+    async def test_save_new_with_pk_set_async(self, async_model):
+        """
+        If the model is using a natural primary key then it will be
+        already set when the instance is inserted.
+        """
+        original_count = await async_model.objects.acount()
+        assert original_count == 10
+        _position = "first-child"
+        form_class = movenodeform_factory(async_model)
+        form = form_class(data={"_position": _position, "id": 999999, "desc": "New Form Test"})
+        assert form.is_valid()
+        # Fake a natural key by updating the instance directly, because
+        # the model form will have removed the id from cleaned data because
+        # it thinks it is an AutoField.
+        form.instance.id = 999999
+        assert await form.asave() is not None
+        assert original_count < await async_model.objects.acount()
+
     def test_save_instance(self, model):
         form_class = movenodeform_factory(model)
         form = form_class(data={"_position": "first-child", "desc": "Test Instance"})
@@ -2570,8 +4977,16 @@ class TestForm(TestNonEmptyTree):
         instance = form.save()
         assert instance.desc == "Modified Instance"
 
+    async def test_save_instance_async(self, async_model):
+        form_class = movenodeform_factory(async_model)
+        form = form_class(data={"_position": "first-child", "desc": "Test Instance"})
+        assert form.is_valid()
+        form.instance.desc = "Modified Instance"
+        instance = await form.asave()
+        assert instance.desc == "Modified Instance"
 
-@pytest.mark.django_db
+
+@pytest.mark.django_db(transaction=True)
 class TestAdminTreeContext(TestNonEmptyTree):
     def test_tree_context(self, model_without_proxy):
         model = model_without_proxy
@@ -2611,8 +5026,46 @@ class TestAdminTreeContext(TestNonEmptyTree):
                 "children-num": obj.get_children_count(),
             }
 
+    async def test_tree_context_async(self, model_without_proxy):
+        model = model_without_proxy
+        request = RequestFactory().get("/admin/tree/")
+        request.user = AnonymousUser()
+        site = AdminSite()
+        form_class = movenodeform_factory(model)
+        admin_class = admin_factory(form_class)
+        m = admin_class(model, site)
+        list_display = m.get_list_display(request)
+        list_display_links = m.get_list_display_links(request, list_display)
+        cl = ChangeList(
+            *get_changelist_args(
+                request,
+                model,
+                list_display,
+                list_display_links,
+                m.list_filter,
+                m.date_hierarchy,
+                m.search_fields,
+                m.list_select_related,
+                m.list_per_page,
+                m.list_max_show_all,
+                m.list_editable,
+                m,
+                [],
+            )
+        )
+        cl.formset = None
+        tree_ctx = tree_context(cl)
 
-@pytest.mark.django_db
+        for idx, obj in enumerate(cl.result_list):
+            assert tree_ctx[idx] == {
+                "node-id": str(obj.pk),
+                "parent-id": 0 if obj.is_root() else obj.get_parent().pk,
+                "level": obj.get_depth(),
+                "children-num": obj.get_children_count(),
+            }
+
+
+@pytest.mark.django_db(transaction=True)
 class TestAdminTreeList(TestNonEmptyTree):
     template = Template("{% load admin_tree_list %}{% result_tree cl request %}")
 
@@ -2654,6 +5107,45 @@ class TestAdminTreeList(TestNonEmptyTree):
         for object in model.objects.all():
             expected_output = output_template % (object.pk, str(object))
             assert expected_output in table_output
+    
+    async def test_result_tree_list_async(self, model_without_proxy):
+        """
+        Verifies that inclusion tag result_list generates a table when with
+        default ModelAdmin settings.
+        """
+        model = model_without_proxy
+        request = RequestFactory().get("/admin/tree/")
+        request.user = AnonymousUser()
+        site = AdminSite()
+        form_class = movenodeform_factory(model)
+        admin_class = admin_factory(form_class)
+        m = admin_class(model, site)
+        list_display = m.get_list_display(request)
+        list_display_links = m.get_list_display_links(request, list_display)
+        cl = ChangeList(
+            *get_changelist_args(
+                request,
+                model,
+                list_display,
+                list_display_links,
+                m.list_filter,
+                m.date_hierarchy,
+                m.search_fields,
+                m.list_select_related,
+                m.list_per_page,
+                m.list_max_show_all,
+                m.list_editable,
+                m,
+                [],
+            )
+        )
+        cl.formset = None
+        context = Context({"cl": cl, "request": request})
+        table_output = self.template.render(context)
+        output_template = '<li><a href="%s/" >%s</a>'
+        async for object in model.objects.all():
+            expected_output = output_template % (object.pk, str(object))
+            assert expected_output in table_output
 
     def test_result_tree_list_with_action(self, model_without_proxy):
         model = model_without_proxy
@@ -2690,6 +5182,44 @@ class TestAdminTreeList(TestNonEmptyTree):
         )
 
         for object in model.objects.all():
+            expected_output = output_template % (object.pk, object.pk, str(object))
+            assert expected_output in table_output
+        
+    async def test_result_tree_list_with_action_async(self, model_without_proxy):
+        model = model_without_proxy
+        request = RequestFactory().get("/admin/tree/")
+        request.user = AnonymousUser()
+        site = AdminSite()
+        form_class = movenodeform_factory(model)
+        admin_class = admin_factory(form_class)
+        m = admin_class(model, site)
+        list_display = m.get_list_display(request)
+        list_display_links = m.get_list_display_links(request, list_display)
+        cl = ChangeList(
+            *get_changelist_args(
+                request,
+                model,
+                list_display,
+                list_display_links,
+                m.list_filter,
+                m.date_hierarchy,
+                m.search_fields,
+                m.list_select_related,
+                m.list_per_page,
+                m.list_max_show_all,
+                m.list_editable,
+                m,
+                [],
+            )
+        )
+        cl.formset = None
+        context = Context({"cl": cl, "request": request, "action_form": True})
+        table_output = self.template.render(context)
+        output_template = (
+            '<input type="checkbox" class="action-select" value="%s" name="_selected_action" /> <a href="%s/" >%s</a>'
+        )
+
+        async for object in model.objects.all():
             expected_output = output_template % (object.pk, object.pk, str(object))
             assert expected_output in table_output
 
@@ -2731,6 +5261,44 @@ class TestAdminTreeList(TestNonEmptyTree):
             expected_output = output_template % object.pk
             assert expected_output in table_output
 
+    async def test_result_tree_list_with_get_async(self, model_without_proxy):
+        model = model_without_proxy
+        pk_field = model._meta.pk.attname
+        # Test t GET parameter with value id
+        request = RequestFactory().get(f"/admin/tree/?{TO_FIELD_VAR}={pk_field}")
+        request.user = AnonymousUser()
+        site = AdminSite()
+        admin_register_all(site)
+        form_class = movenodeform_factory(model)
+        admin_class = admin_factory(form_class)
+        m = admin_class(model, site)
+        list_display = m.get_list_display(request)
+        list_display_links = m.get_list_display_links(request, list_display)
+        cl = ChangeList(
+            *get_changelist_args(
+                request,
+                model,
+                list_display,
+                list_display_links,
+                m.list_filter,
+                m.date_hierarchy,
+                m.search_fields,
+                m.list_select_related,
+                m.list_per_page,
+                m.list_max_show_all,
+                m.list_editable,
+                m,
+                [],
+            )
+        )
+        cl.formset = None
+        context = Context({"cl": cl, "request": request})
+        table_output = self.template.render(context)
+        output_template = "opener.dismissRelatedLookupPopup(window, '%s');"
+        async for object in model.objects.all():
+            expected_output = output_template % object.pk
+            assert expected_output in table_output
+
     def test_result_tree_list_escapes_labels(self, model_with_unicode):
         """
         Verifies that inclusion tag result_list generates a table when with
@@ -2768,13 +5336,53 @@ class TestAdminTreeList(TestNonEmptyTree):
         expected_output = f'<li><a href="{object.pk}/" >&lt;&gt;</a>'
         assert expected_output in table_output
 
+    async def test_result_tree_list_escapes_labels_async(self, model_with_unicode):
+        """
+        Verifies that inclusion tag result_list generates a table when with
+        default ModelAdmin settings.
+        """
+        object = await model_with_unicode.aadd_root(desc="<>")
+        request = RequestFactory().get("/admin/tree/")
+        request.user = AnonymousUser()
+        site = AdminSite()
+        form_class = movenodeform_factory(model_with_unicode)
+        admin_class = admin_factory(form_class)
+        m = admin_class(model_with_unicode, site)
+        list_display = m.get_list_display(request)
+        list_display_links = m.get_list_display_links(request, list_display)
+        cl = ChangeList(
+            *get_changelist_args(
+                request,
+                model_with_unicode,
+                list_display,
+                list_display_links,
+                m.list_filter,
+                m.date_hierarchy,
+                m.search_fields,
+                m.list_select_related,
+                m.list_per_page,
+                m.list_max_show_all,
+                m.list_editable,
+                m,
+                [],
+            )
+        )
+        cl.formset = None
+        context = Context({"cl": cl, "request": request})
+        table_output = self.template.render(context)
+        expected_output = f'<li><a href="{object.pk}/" >&lt;&gt;</a>'
+        assert expected_output in table_output
 
-@pytest.mark.django_db
+
+@pytest.mark.django_db(transaction=True)
 class TestTreeAdmin(TestNonEmptyTree):
     site = AdminSite()
 
     def _create_user(self, username, **kwargs):
         return User.objects.create(username=username, **kwargs)
+    
+    async def _create_user_async(self, username, **kwargs):
+        return await User.objects.acreate(username=username, **kwargs)
 
     def _mocked_request(self, data, user=None):
         request = RequestFactory().post("/", data=data)
@@ -2791,6 +5399,17 @@ class TestTreeAdmin(TestNonEmptyTree):
     def test_changelist_view(self):
         request = RequestFactory().get("/")
         request.user = self._create_user("changelist_tmp", is_superuser=True)
+        admin_obj = self._get_admin_obj(models.AL_TestNode)
+        admin_obj.changelist_view(request)
+        assert admin_obj.change_list_template == "admin/tree_list.html"
+
+        admin_obj = self._get_admin_obj(models.MP_TestNode)
+        admin_obj.changelist_view(request)
+        assert admin_obj.change_list_template != "admin/tree_list.html"
+
+    async def test_changelist_view_async(self):
+        request = RequestFactory().get("/")
+        request.user = await self._create_user_async("changelist_tmp", is_superuser=True)
         admin_obj = self._get_admin_obj(models.AL_TestNode)
         admin_obj.changelist_view(request)
         assert admin_obj.change_list_template == "admin/tree_list.html"
@@ -2821,10 +5440,37 @@ class TestTreeAdmin(TestNonEmptyTree):
         assert '<input type="hidden" id="has-change-permission" value="0"/>' in content
         assert '<input type="hidden" id="has-filters" value="1"/>' in content
 
+    async def test_changelist_view_renders_hidden_inputs_with_extra_context_async(self):
+        user = await self._create_user_async("changelist_tmp", is_superuser=True)
+        request = RequestFactory().get("/")
+        request.user = user
+        admin_obj = self._get_admin_obj(models.MP_TestNode)
+        response = admin_obj.changelist_view(request)
+        response.render()
+        content = response.content.decode()
+        assert '<input type="hidden" id="has-change-permission" value="1"/>' in content
+        assert '<input type="hidden" id="has-filters" value="0"/>' in content
+        assert '<script id="tree-context" type="application/json">[]</script>' in content
+
+        request = RequestFactory().get("/?desc=foo")
+        request.user = user
+        admin_obj = self._get_admin_obj(models.MP_TestNode)
+        with patch.object(admin_obj, "has_change_permission", return_value=False):
+            response = admin_obj.changelist_view(request)
+            response.render()
+            content = response.content.decode()
+        assert '<input type="hidden" id="has-change-permission" value="0"/>' in content
+        assert '<input type="hidden" id="has-filters" value="1"/>' in content
+
     def test_get_node(self, model):
         admin_obj = self._get_admin_obj(model)
         target = model.objects.get(desc="2")
         assert admin_obj.get_node(target.pk) == target
+
+    async def test_get_node_async(self, async_model):
+        admin_obj = self._get_admin_obj(async_model)
+        target = await async_model.objects.aget(desc="2")
+        assert await admin_obj.aget_node(target.pk) == target
 
     def test_move_node_validate_keyerror(self, model):
         admin_obj = self._get_admin_obj(model)
@@ -2837,10 +5483,28 @@ class TestTreeAdmin(TestNonEmptyTree):
         assert response.status_code == 400
         assert response.content.decode() == "Malformed POST params"
 
+    async def test_move_node_validate_keyerror_async(self, async_model):
+        admin_obj = self._get_admin_obj(async_model)
+        request = self._mocked_request(data={})
+        response = await admin_obj.amove_node(request)
+        assert response.status_code == 400
+        assert response.content.decode() == "Malformed POST params"
+        request = self._mocked_request(data={"node_id": 1})
+        response = await admin_obj.amove_node(request)
+        assert response.status_code == 400
+        assert response.content.decode() == "Malformed POST params"
+
     def test_move_node_validate_valueerror(self, model):
         admin_obj = self._get_admin_obj(model)
         request = self._mocked_request(data={"node_id": 1, "sibling_id": 2, "as_child": "invalid"})
         response = admin_obj.move_node(request)
+        assert response.status_code == 400
+        assert response.content.decode() == "Malformed POST params"
+
+    async def test_move_node_validate_valueerror_async(self, async_model):
+        admin_obj = self._get_admin_obj(async_model)
+        request = self._mocked_request(data={"node_id": 1, "sibling_id": 2, "as_child": "invalid"})
+        response = await admin_obj.amove_node(request)
         assert response.status_code == 400
         assert response.content.decode() == "Malformed POST params"
 
@@ -2854,11 +5518,28 @@ class TestTreeAdmin(TestNonEmptyTree):
         response = admin_obj.try_to_move_node(True, node, "sorted-sibling", request, target=node)
         assert response.status_code == 400
 
+    async def test_move_validate_missing_nodeorderby_async(self, async_model):
+        node = await async_model.objects.aget(desc="231")
+        admin_obj = self._get_admin_obj(async_model)
+        request = self._mocked_request(data={})
+        response = await admin_obj.atry_to_move_node(True, node, "sorted-child", request, target=node)
+        assert response.status_code == 400
+
+        response = await admin_obj.atry_to_move_node(True, node, "sorted-sibling", request, target=node)
+        assert response.status_code == 400
+
     def test_move_validate_invalid_pos(self, model):
         node = model.objects.get(desc="231")
         admin_obj = self._get_admin_obj(model)
         request = self._mocked_request(data={})
         response = admin_obj.try_to_move_node(True, node, "invalid_pos", request, target=node)
+        assert response.status_code == 400
+
+    async def test_move_validate_invalid_pos_async(self, async_model):
+        node = await async_model.objects.aget(desc="231")
+        admin_obj = self._get_admin_obj(async_model)
+        request = self._mocked_request(data={})
+        response = await admin_obj.atry_to_move_node(True, node, "invalid_pos", request, target=node)
         assert response.status_code == 400
 
     def test_move_validate_to_descendant(self, model):
@@ -2867,6 +5548,14 @@ class TestTreeAdmin(TestNonEmptyTree):
         admin_obj = self._get_admin_obj(model)
         request = self._mocked_request(data={})
         response = admin_obj.try_to_move_node(True, node, "first-sibling", request, target)
+        assert response.status_code == 400
+
+    async def test_move_validate_to_descendant_async(self, async_model):
+        node = await async_model.objects.aget(desc="2")
+        target = await async_model.objects.aget(desc="231")
+        admin_obj = self._get_admin_obj(async_model)
+        request = self._mocked_request(data={})
+        response = await admin_obj.atry_to_move_node(True, node, "first-sibling", request, target)
         assert response.status_code == 400
 
     def test_move_requires_change_permission(self, model):
@@ -2885,6 +5574,24 @@ class TestTreeAdmin(TestNonEmptyTree):
 
         with patch.object(admin_obj, "has_change_permission", return_value=True):
             response = admin_obj.move_node(request)
+            assert response.status_code == 200
+
+    async def test_move_requires_change_permission_async(self, async_model):
+        node = await async_model.objects.aget(desc="231")
+        target = await async_model.objects.aget(desc="2")
+
+        admin_obj = self._get_admin_obj(async_model)
+        request = self._mocked_request(
+            data={"node_id": node.pk, "sibling_id": target.pk, "as_child": 0},
+            user=await self._create_user_async("test_move_perm"),
+        )
+
+        with patch.object(admin_obj, "has_change_permission", return_value=False):
+            with pytest.raises(PermissionDenied):
+                await admin_obj.amove_node(request)
+
+        with patch.object(admin_obj, "has_change_permission", return_value=True):
+            response = await admin_obj.amove_node(request)
             assert response.status_code == 200
 
     def test_move_left(self, model):
@@ -2912,6 +5619,31 @@ class TestTreeAdmin(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    async def test_move_left_async(self, async_model):
+        node = await async_model.objects.aget(desc="231")
+        target = await async_model.objects.aget(desc="2")
+
+        admin_obj = self._get_admin_obj(async_model)
+        request = self._mocked_request(
+            data={"node_id": node.pk, "sibling_id": target.pk, "as_child": 0},
+            user=await self._create_user_async("tmp", is_superuser=True),
+        )
+        response = await admin_obj.amove_node(request)
+        assert response.status_code == 200
+        expected = [
+            ("1", 1, 0),
+            ("231", 1, 0),
+            ("2", 1, 4),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        assert await self.agot(async_model) == expected
+
     def test_move_last_child(self, model):
         node = model.objects.get(desc="231")
         target = model.objects.get(desc="2")
@@ -2937,8 +5669,33 @@ class TestTreeAdmin(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    async def test_move_last_child_async(self, async_model):
+        node = await async_model.objects.aget(desc="231")
+        target = await async_model.objects.aget(desc="2")
 
-@pytest.mark.django_db
+        admin_obj = self._get_admin_obj(async_model)
+        request = self._mocked_request(
+            data={"node_id": node.pk, "sibling_id": target.pk, "as_child": 1},
+            user=await self._create_user_async("tmp", is_superuser=True),
+        )
+        response = await admin_obj.amove_node(request)
+        assert response.status_code == 200
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 5),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 0),
+            ("24", 2, 0),
+            ("231", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        assert await self.agot(async_model) == expected
+
+
+@pytest.mark.django_db(transaction=True)
 class TestMPFormPerformance:
     def test_form_add_subtree_no_of_queries(self, django_assert_num_queries):
         model = models.MP_TestNode
@@ -2948,8 +5705,16 @@ class TestMPFormPerformance:
         with django_assert_num_queries(len(model.get_root_nodes()) + 1):
             form.mk_dropdown_tree(model)
 
+    async def test_form_add_subtree_no_of_queries_async(self, django_assert_num_queries):
+        model = models.MP_TestNode
+        await model.aload_bulk(BASE_DATA)
+        form_class = movenodeform_factory(model)
+        form = form_class()
+        with django_assert_num_queries(len([_ async for _ in model.aroots()]) + 1):
+            await form.amk_dropdown_tree(model)
 
-@pytest.mark.django_db
+
+@pytest.mark.django_db(transaction=True)
 class TestMP_TreeDescendantsPerformance(TestTreeBase):
     def test_get_descendants_no_of_queries(self, django_assert_num_queries):
         model = models.MP_TestNode
@@ -2969,8 +5734,26 @@ class TestMP_TreeDescendantsPerformance(TestTreeBase):
                 # converting to list to force queryset evaluation
                 list(node.get_descendants())
 
+    async def test_get_descendants_no_of_queries_async(self, django_assert_num_queries):
+        model = models.MP_TestNode
+        await model.aload_bulk(BASE_DATA)
 
-@pytest.mark.django_db
+        data = [
+            ("2", 1),
+            ("23", 1),
+            ("231", 0),
+            ("1", 0),
+            ("4", 1),
+        ]
+
+        for desc, expected in data:
+            node = await model.objects.aget(desc=desc)
+            with django_assert_num_queries(expected):
+                # converting to list to force queryset evaluation
+                _ = [child async for child in node.get_descendants()]
+
+
+@pytest.mark.django_db(transaction=True)
 class TestRegression:
     def test_dump_bulk_regression_issue_219(self):
         data = [
@@ -2998,8 +5781,33 @@ class TestRegression:
         except KeyError:
             pytest.fail("It should not have raised an KeyError")
 
+    async def test_adump_bulk_regression_issue_219_async(self):
+        data = [
+            {
+                "data": {"name": "A"},
+                "children": [
+                    {"data": {"name": "X1"}},
+                    {"data": {"name": "X2"}},
+                    {
+                        "data": {"name": "X3"},
+                        "children": [
+                            # We need to create a large number of nodes to
+                            # to try the DB gives them in an arbitrary order
+                            {"data": {"name": f"Z{index}"}}
+                            for index in range(10000)
+                        ],
+                    },
+                    {"data": {"name": "X4"}},
+                ],
+            },
+        ]
+        await models.MP_RegressionIssue219.aload_bulk(data)
+        try:
+            await models.MP_RegressionIssue219.adump_bulk()
+        except KeyError:
+            pytest.fail("It should not have raised an KeyError")
 
-@pytest.mark.django_db
+@pytest.mark.django_db(transaction=True)
 class TestRefreshFromDb:
     def test_get_parent(self, model):
         parent1 = model.objects.get(desc=2)
@@ -3010,6 +5818,15 @@ class TestRefreshFromDb:
         node.refresh_from_db()
         assert node.get_parent() == parent2
 
+    async def test_get_parent_async(self, async_model):
+        parent1 = await async_model.objects.aget(desc=2)
+        parent2 = await async_model.objects.aget(desc=4)
+        node = await async_model.objects.aget(desc=21)
+        assert await node.aget_parent() == parent1
+        await node.amove(parent2, pos="last-child")
+        await node.arefresh_from_db()
+        assert await node.aget_parent() == parent2
+
     def test_get_depth(self, model):
         node = model.objects.get(desc=1)
         new_parent = model.objects.get(desc=2)
@@ -3017,3 +5834,11 @@ class TestRefreshFromDb:
         node.move(new_parent, pos="last-child")
         node.refresh_from_db()
         assert node.get_depth() == 2
+
+    async def test_get_depth_async(self, async_model):
+        node = await async_model.objects.aget(desc=1)
+        new_parent = await async_model.objects.aget(desc=2)
+        assert await node.aget_depth() == 1
+        await node.amove(new_parent, pos="last-child")
+        await node.arefresh_from_db()
+        assert await node.aget_depth() == 2

--- a/treebeard/models.py
+++ b/treebeard/models.py
@@ -1,4 +1,5 @@
 """Models and base API"""
+from asgiref.sync import sync_to_async
 
 import operator
 from contextlib import suppress
@@ -38,6 +39,28 @@ class Node(models.Model):
         raise NotImplementedError
 
     @classmethod
+    async def aadd_root(cls, **kwargs):  # pragma: no cover
+        """
+        **Async version of add_root.**
+        Adds a root node to the tree. The new root node will be the new
+        rightmost root node. If you want to insert a root node at a specific
+        position, use :meth:`add_sibling` in an already existing root node
+        instead.
+
+        :param `**kwargs`: object creation data that will be passed to the
+            inherited Node model
+        :param instance: Instead of passing object creation data, you can
+            pass an already-constructed (but not yet saved) model instance to
+            be inserted into the tree.
+
+        :returns: the created node object. It will be save()d by this method.
+
+        :raise NodeAlreadySaved: when the passed ``instance`` already exists
+            in the database
+        """
+        raise NotImplementedError
+
+    @classmethod
     def get_foreign_keys(cls):
         """Get foreign keys and models they refer to, so we can pre-process
         the data for load_bulk
@@ -57,6 +80,18 @@ class Node(models.Model):
         for key in foreign_keys.keys():
             if key in node_data:
                 node_data[key] = foreign_keys[key].objects.get(pk=node_data[key])
+
+    @classmethod
+    async def _aprocess_foreign_keys(cls, foreign_keys, node_data):
+        """
+        **Async version of _process_foreign_keys**
+        For each foreign key try to load the actual object so aload_bulk
+        doesn't fail trying to load an int where django expects a
+        model instance
+        """
+        for key in foreign_keys.keys():
+            if key in node_data:
+                node_data[key] = await foreign_keys[key].objects.aget(pk=node_data[key])
 
     @classmethod
     def load_bulk(cls, bulk_data, parent=None, keep_ids=False):
@@ -98,7 +133,7 @@ class Node(models.Model):
         # stack of nodes to analyze
         stack = [(parent, node) for node in bulk_data[::-1]]
         foreign_keys = cls.get_foreign_keys()
-        pk_field = cls._meta.pk.attname
+        pk_field = cls._meta.pk.attname  # type: ignore
 
         while stack:
             parent, node_struct = stack.pop()
@@ -119,8 +154,93 @@ class Node(models.Model):
         return added
 
     @classmethod
+    async def aload_bulk(cls, bulk_data, parent=None, keep_ids=False):
+        """
+        **Async version of load_bulk.**
+
+        Loads a list/dictionary structure to the tree.
+
+
+        :param bulk_data:
+
+            The data that will be loaded, the structure is a list of
+            dictionaries with 2 keys:
+
+            - ``data``: will store arguments that will be passed for object
+              creation, and
+
+            - ``children``: a list of dictionaries, each one has it's own
+              ``data`` and ``children`` keys (a recursive structure)
+
+
+        :param parent:
+
+            The node that will receive the structure as children, if not
+            specified the first level of the structure will be loaded as root
+            nodes
+
+
+        :param keep_ids:
+
+            If enabled, loads the nodes with the same primary keys that are
+            given in the structure. Will error if there are nodes without
+            primary key info or if the primary keys are already used.
+
+
+        :returns: A list of the added node ids.
+
+        """
+
+        # tree, iterative preorder
+        added = []
+        # stack of nodes to analyze
+        stack = [(parent, node) for node in bulk_data[::-1]]
+        foreign_keys = cls.get_foreign_keys()
+        pk_field = cls._meta.pk.attname  # type: ignore
+
+        while stack:
+            parent, node_struct = stack.pop()
+            # shallow copy of the data structure so it doesn't persist...
+            node_data = node_struct["data"].copy()
+            await cls._aprocess_foreign_keys(foreign_keys, node_data)
+            if keep_ids:
+                node_data[pk_field] = node_struct[pk_field]
+            if parent:
+                node_obj = await parent.aadd_child(**node_data)
+            else:
+                node_obj = await cls.aadd_root(**node_data)
+            added.append(node_obj.pk)
+            if "children" in node_struct:
+                # extending the stack with the current node as the parent of
+                # the new nodes
+                stack.extend([(node_obj, node) for node in node_struct["children"][::-1]])
+        return added
+
+    @classmethod
     def dump_bulk(cls, parent=None, keep_ids=True):  # pragma: no cover
         """
+        Dumps a tree branch to a python data structure.
+
+        :param parent:
+
+            The node whose descendants will be dumped. The node itself will be
+            included in the dump. If not given, the entire tree will be dumped.
+
+        :param keep_ids:
+
+            Stores the pk value (primary key) of every node. Enabled by
+            default.
+
+        :returns: A python data structure, described with detail in
+                  :meth:`load_bulk`
+        """
+        raise NotImplementedError
+
+    @classmethod
+    async def adump_bulk(cls, parent=None, keep_ids=True):  # pragma: no cover
+        """
+        **Async version of dump_bulk.**
+
         Dumps a tree branch to a python data structure.
 
         :param parent:
@@ -156,6 +276,19 @@ class Node(models.Model):
             return None
 
     @classmethod
+    async def aget_first_root_node(cls):
+        """
+        **Async version of get_first_root_node.**
+        :returns:
+
+            The first root node in the tree or ``None`` if it is empty.
+        """
+        try:
+            return await cls.get_root_nodes().afirst()
+        except IndexError:
+            return None
+
+    @classmethod
     def get_last_root_node(cls):
         """
         :returns:
@@ -168,8 +301,29 @@ class Node(models.Model):
             return None
 
     @classmethod
+    async def aget_last_root_node(cls):
+        """
+        **Async version of get_last_root_node.**
+        :returns:
+
+            The last root node in the tree or ``None`` if it is empty.
+        """
+        try:
+            return await cls.get_root_nodes().alast()
+        except IndexError:
+            return None
+
+    @classmethod
     def find_problems(cls):  # pragma: no cover
         """Checks for problems in the tree structure."""
+        raise NotImplementedError
+
+    @classmethod
+    async def afind_problems(cls):  # pragma: no cover
+        """
+        **Async version of find_problems.**
+        Checks for problems in the tree structure.
+        """
         raise NotImplementedError
 
     @classmethod
@@ -181,8 +335,29 @@ class Node(models.Model):
         raise NotImplementedError
 
     @classmethod
+    async def afix_tree(cls):  # pragma: no cover
+        """
+        **Async version of fix_tree.**
+
+        Solves problems that can appear when transactions are not used and
+        a piece of code breaks, leaving the tree in an inconsistent state.
+        """
+        raise NotImplementedError
+
+    @classmethod
     def get_tree(cls, parent=None):
         """
+        :returns:
+
+            A list of nodes ordered as DFS, including the parent. If
+            no parent is given, the entire tree is returned.
+        """
+        raise NotImplementedError
+
+    @classmethod
+    async def aget_tree(cls, parent=None):
+        """
+        **Async version of get_tree.**
         :returns:
 
             A list of nodes ordered as DFS, including the parent. If
@@ -215,12 +390,57 @@ class Node(models.Model):
             node.descendants_count = node.get_descendant_count()
         return nodes
 
+    @classmethod
+    async def aget_descendants_group_count(cls, parent=None):
+        """
+        **Async version of get_descendants_group_count.**
+
+        Helper for a very common case: get a group of siblings and the number
+        of *descendants* (not only children) in every sibling.
+
+        :param parent:
+
+            The parent of the siblings to return. If no parent is given, the
+            root nodes will be returned.
+
+        :returns:
+
+            A `list` (**NOT** a Queryset) of node objects with an extra
+            attribute: `descendants_count`.
+        """
+        if parent is None:
+            qset = cls.get_root_nodes()
+        else:
+            qset = parent.get_children()
+        nodes = [val async for val in qset]
+        for node in nodes:
+            node.descendants_count = await node.aget_descendant_count()
+        return nodes
+
     def get_depth(self):  # pragma: no cover
         """:returns: the depth (level) of the node"""
         raise NotImplementedError
+    
+    async def aget_depth(self):  # pragma: no cover
+        """
+        **Async version of get_depth.**
+        :returns: the depth (level) of the node
+        """
+        raise NotImplementedError
+
 
     def get_siblings(self):  # pragma: no cover
         """
+        :returns:
+
+            A queryset of all the node's siblings, including the node
+            itself.
+        """
+        raise NotImplementedError
+
+    async def aget_siblings(self):  # pragma: no cover
+        """
+        **Async version of get_siblings.**
         :returns:
 
             A queryset of all the node's siblings, including the node
@@ -236,8 +456,25 @@ class Node(models.Model):
         """:returns: The number of the node's children"""
         return self.get_children().count()
 
+    async def aget_children_count(self):
+        """
+        **Async version of get_children_count.**
+        :returns: The number of the node's children
+        """
+        return await self.get_children().acount()
+
     def get_descendants(self):
         """
+        :returns:
+
+            A queryset of all the node's descendants, doesn't
+            include the node itself (some subclasses may return a list).
+        """
+        raise NotImplementedError
+
+    async def aget_descendants(self):
+        """
+        **Async version of get_descendants.**
         :returns:
 
             A queryset of all the node's descendants, doesn't
@@ -249,6 +486,13 @@ class Node(models.Model):
         """:returns: the number of descendants of a node."""
         return self.get_descendants().count()
 
+    async def aget_descendant_count(self):
+        """
+        **Async version of get_descendant_count.**
+        :returns: the number of descendants of a node.
+        """
+        return len(await self.aget_descendants())
+
     def get_first_child(self):
         """
         :returns:
@@ -257,6 +501,18 @@ class Node(models.Model):
         """
         try:
             return self.get_children()[0]
+        except IndexError:
+            return None
+
+    async def aget_first_child(self):
+        """
+        **Async version of get_first_child.**
+        :returns:
+
+            The leftmost node's child, or None if it has no children.
+        """
+        try:
+            return await self.get_children().afirst()
         except IndexError:
             return None
 
@@ -271,6 +527,18 @@ class Node(models.Model):
         except IndexError:
             return None
 
+    async def aget_last_child(self):
+        """
+        **Async version of get_last_child.**
+        :returns:
+
+            The rightmost node's child, or None if it has no children.
+        """
+        try:
+            return await self.get_children().alast()
+        except IndexError:
+            return None
+
     def get_first_sibling(self):
         """
         :returns:
@@ -279,6 +547,16 @@ class Node(models.Model):
             it was the leftmost sibling.
         """
         return self.get_siblings()[0]
+
+    async def aget_first_sibling(self):
+        """
+        **Async version of get_first_sibling.**
+        :returns:
+
+            The leftmost node's sibling, can return the node itself if
+            it was the leftmost sibling.
+        """
+        return await (await self.aget_siblings()).afirst()
 
     def get_last_sibling(self):
         """
@@ -289,6 +567,16 @@ class Node(models.Model):
         """
         return self.get_siblings().reverse()[0]
 
+    async def aget_last_sibling(self):
+        """
+        **Async version of get_last_sibling.**
+        :returns:
+
+            The rightmost node's sibling, can return the node itself if
+            it was the rightmost sibling.
+        """
+        return await (await self.aget_siblings()).alast()
+
     def get_prev_sibling(self):
         """
         :returns:
@@ -298,6 +586,21 @@ class Node(models.Model):
         """
         siblings = self.get_siblings()
         ids = [obj.pk for obj in siblings]
+        if self.pk in ids:
+            idx = ids.index(self.pk)
+            if idx > 0:
+                return siblings[idx - 1]
+
+    async def aget_prev_sibling(self):
+        """
+        **Async version of get_prev_sibling.**
+        :returns:
+
+            The previous node's sibling, or None if it was the leftmost
+            sibling.
+        """
+        siblings = await self.aget_siblings()
+        ids = [obj.pk async for obj in siblings]
         if self.pk in ids:
             idx = ids.index(self.pk)
             if idx > 0:
@@ -317,6 +620,21 @@ class Node(models.Model):
             if idx < len(siblings) - 1:
                 return siblings[idx + 1]
 
+    async def aget_next_sibling(self):
+        """
+        **Async version of get_next_sibling.**
+        :returns:
+
+            The next node's sibling, or None if it was the rightmost
+            sibling.
+        """
+        siblings = await self.aget_siblings()
+        ids = [obj.pk async for obj in siblings]
+        if self.pk in ids:
+            idx = ids.index(self.pk)
+            if idx < len(siblings) - 1:
+                return siblings[idx + 1]
+
     def is_sibling_of(self, node):
         """
         :returns: ``True`` if the node is a sibling of another node given as an
@@ -327,6 +645,18 @@ class Node(models.Model):
             The node that will be checked as a sibling
         """
         return self.get_siblings().filter(pk=node.pk).exists()
+
+    async def ais_sibling_of(self, node):
+        """
+        **Async version of is_sibling_of.**
+        :returns: ``True`` if the node is a sibling of another node given as an
+            argument, else, returns ``False``
+
+        :param node:
+
+            The node that will be checked as a sibling
+        """
+        return await (await self.aget_siblings()).filter(pk=node.pk).aexists()
 
     def is_child_of(self, node):
         """
@@ -339,8 +669,32 @@ class Node(models.Model):
         """
         return node.get_children().filter(pk=self.pk).exists()
 
+    async def ais_child_of(self, node):
+        """
+        **Async version of is_child_of.**
+        :returns: ``True`` if the node is a child of another node given as an
+            argument, else, returns ``False``
+
+        :param node:
+
+            The node that will be checked as a parent
+        """
+        return await node.get_children().filter(pk=self.pk).aexists()
+
     def is_descendant_of(self, node):  # pragma: no cover
         """
+        :returns: ``True`` if the node is a descendant of another node given
+            as an argument, else, returns ``False``
+
+        :param node:
+
+            The node that will be checked as an ancestor
+        """
+        raise NotImplementedError
+    
+    async def ais_descendant_of(self, node):  # pragma: no cover
+        """
+        **Async version of is_descendant_of.**
         :returns: ``True`` if the node is a descendant of another node given
             as an argument, else, returns ``False``
 
@@ -352,6 +706,29 @@ class Node(models.Model):
 
     def add_child(self, **kwargs):  # pragma: no cover
         """
+        Adds a child to the node. The new node will be the new rightmost
+        child. If you want to insert a node at a specific position,
+        use the :meth:`add_sibling` method of an already existing
+        child node instead.
+
+        :param `**kwargs`:
+
+            Object creation data that will be passed to the inherited Node
+            model
+        :param instance: Instead of passing object creation data, you can
+            pass an already-constructed (but not yet saved) model instance to
+            be inserted into the tree.
+
+        :returns: The created node object. It will be save()d by this method.
+
+        :raise NodeAlreadySaved: when the passed ``instance`` already exists
+            in the database
+        """
+        raise NotImplementedError
+
+    async def aadd_child(self, **kwargs):  # pragma: no cover
+        """
+        **Async version of add_child.**
         Adds a child to the node. The new node will be the new rightmost
         child. If you want to insert a node at a specific position,
         use the :meth:`add_sibling` method of an already existing
@@ -411,17 +788,79 @@ class Node(models.Model):
         """
         raise NotImplementedError
 
+    async def aadd_sibling(self, pos=None, **kwargs):  # pragma: no cover
+        """
+        **Async version of add_sibling.**
+        Adds a new node as a sibling to the current node object.
+
+
+        :param pos:
+            The position, relative to the current node object, where the
+            new node will be inserted, can be one of:
+
+            - ``first-sibling``: the new node will be the new leftmost sibling
+            - ``left``: the new node will take the node's place, which will be
+              moved to the right 1 position
+            - ``right``: the new node will be inserted at the right of the node
+            - ``last-sibling``: the new node will be the new rightmost sibling
+            - ``sorted-sibling``: the new node will be at the right position
+              according to the value of node_order_by
+
+        :param `**kwargs`:
+
+            Object creation data that will be passed to the inherited
+            Node model
+        :param instance: Instead of passing object creation data, you can
+            pass an already-constructed (but not yet saved) model instance to
+            be inserted into the tree.
+
+        :returns:
+
+            The created node object. It will be saved by this method.
+
+        :raise InvalidPosition: when passing an invalid ``pos`` parm
+        :raise InvalidPosition: when :attr:`node_order_by` is enabled and the
+           ``pos`` parm wasn't ``sorted-sibling``
+        :raise MissingNodeOrderBy: when passing ``sorted-sibling`` as ``pos``
+           and the :attr:`node_order_by` attribute is missing
+        :raise NodeAlreadySaved: when the passed ``instance`` already exists
+            in the database
+        """
+        raise NotImplementedError
+
     def get_root(self):  # pragma: no cover
         """:returns: the root node for the current node object."""
+        raise NotImplementedError
+
+    async def aget_root(self):  # pragma: no cover
+        """
+        **Async version of get_root.**
+        :returns: the root node for the current node object.
+        """
         raise NotImplementedError
 
     def is_root(self):
         """:returns: True if the node is a root node (else, returns False)"""
         return self.get_root().pk == self.pk
 
+    async def ais_root(self):
+        """
+        **Async version of is_root.**
+        :returns: True if the node is a root node (else, returns False)
+        """
+        root = await self.aget_root()
+        return root.pk == self.pk
+
     def is_leaf(self):
         """:returns: True if the node is a leaf node (else, returns False)"""
         return not self.get_children().exists()
+
+    async def ais_leaf(self):
+        """
+        **Async version of is_leaf.**
+        :returns: True if the node is a leaf node (else, returns False)
+        """
+        return not (await self.get_children().aexists())
 
     def get_ancestors(self):  # pragma: no cover
         """
@@ -433,8 +872,29 @@ class Node(models.Model):
         """
         raise NotImplementedError
 
+    async def aget_ancestors(self):  # pragma: no cover
+        """
+        **Async version of get_ancestors.**
+        :returns:
+
+            A queryset containing the current node object's ancestors,
+            starting by the root node and descending to the parent.
+            (some subclasses may return a list)
+        """
+        raise NotImplementedError
+
     def get_parent(self, update=False):  # pragma: no cover
         """
+        :returns: the parent node of the current node object.
+            Caches the result in the object itself to help in loops.
+
+        :param update: Updates the cached value.
+        """
+        raise NotImplementedError
+
+    async def aget_parent(self, update=False):  # pragma: no cover
+        """
+        **Async version of get_parent.**
         :returns: the parent node of the current node object.
             Caches the result in the object itself to help in loops.
 
@@ -494,9 +954,63 @@ class Node(models.Model):
         """
         raise NotImplementedError
 
+    async def amove(self, target, pos=None):  # pragma: no cover
+        """
+        **Async version of move.**
+        Moves the current node and all it's descendants to a new position
+        relative to another node.
+
+        :param target:
+
+            The node that will be used as a relative child/sibling when moving
+        :param pos:
+            The position, relative to the target node, where the
+            current node object will be moved to, can be one of:
+            - ``first-child``: the node will be the new leftmost child of the
+              ``target`` node
+            - ``last-child``: the node will be the new rightmost child of the
+              ``target`` node
+            - ``sorted-child``: the new node will be moved as a child of the
+              ``target`` node according to the value of :attr:`node_order_by`
+            - ``first-sibling``: the node will be the new leftmost sibling of
+              the ``target`` node
+            - ``left``: the node will be the new left sibling of the ``target``
+              node
+            - ``right``: the node will be the new right sibling of the
+              ``target`` node
+            - ``last-sibling``: the node will be the new rightmost sibling of
+              the ``target`` node
+            - ``sorted-sibling``: the new node will  be moved as a sibling of
+              the ``target`` node according to the value of
+              :attr:`node_order_by`
+
+            .. note::
+
+               If no ``pos`` is given the library will use ``last-sibling``
+               or ``sorted-sibling``if :attr:`node_order_by` is enabled.
+
+        :returns: None
+
+        :raise InvalidPosition: when passing an invalid ``pos`` parm
+        :raise InvalidPosition: when :attr:`node_order_by` is enabled and the
+           ``pos`` parm wasn't ``sorted-sibling`` or ``sorted-child``
+        :raise InvalidMoveToDescendant: when trying to move a node to one of
+           it's own descendants
+        :raise PathOverflow: when the library can't make room for the
+           node's new position
+        :raise MissingNodeOrderBy: when passing ``sorted-sibling`` or
+           ``sorted-child`` as ``pos`` and the :attr:`node_order_by`
+           attribute is missing
+        """
+        return await sync_to_async(self.move)(target, pos=pos)
+
     def delete(self, *args, **kwargs):
         """Removes a node and all it's descendants."""
         return self.__class__.objects.filter(pk=self.pk).delete(*args, **kwargs)
+
+    async def adelete(self, *args, **kwargs):
+        """Removes a node and all it's descendants."""
+        return await self.__class__.objects.filter(pk=self.pk).adelete(*args, **kwargs)
 
     delete.alters_data = True
     delete.queryset_only = True
@@ -517,6 +1031,23 @@ class Node(models.Model):
             raise MissingNodeOrderBy("Missing node_order_by attribute.")
         return pos
 
+    async def _aprepare_pos_var(self, pos, method_name, valid_pos, valid_sorted_pos):
+        if pos is None:
+            if self.node_order_by:
+                pos = "sorted-sibling"
+            else:
+                pos = "last-sibling"
+        if pos not in valid_pos:
+            raise InvalidPosition("Invalid relative position: %s" % (pos,))
+        if self.node_order_by and pos not in valid_sorted_pos:
+            raise InvalidPosition(
+                "Must use %s in %s when node_order_by is enabled" % (" or ".join(valid_sorted_pos), method_name)
+            )
+        if pos in valid_sorted_pos and not self.node_order_by:
+            raise MissingNodeOrderBy("Missing node_order_by attribute.")
+        return pos
+
+
     _valid_pos_for_add_sibling = ("first-sibling", "left", "right", "last-sibling", "sorted-sibling")
     _valid_pos_for_sorted_add_sibling = ("sorted-sibling",)
 
@@ -528,8 +1059,18 @@ class Node(models.Model):
     _valid_pos_for_move = _valid_pos_for_add_sibling + ("first-child", "last-child", "sorted-child")
     _valid_pos_for_sorted_move = _valid_pos_for_sorted_add_sibling + ("sorted-child",)
 
+    async def _aprepare_pos_var_add_sibling(self, pos):
+        return await self._aprepare_pos_var(
+            pos, "add_sibling", self._valid_pos_for_add_sibling, self._valid_pos_for_sorted_add_sibling
+        )
+
     def _prepare_pos_var_for_move(self, pos):
         return self._prepare_pos_var(pos, "move", self._valid_pos_for_move, self._valid_pos_for_sorted_move)
+
+    async def _aprepare_pos_var_for_move(self, pos):
+        return await self._aprepare_pos_var(
+            pos, "move", self._valid_pos_for_move, self._valid_pos_for_sorted_move
+        )
 
     def get_sorted_pos_queryset(self, siblings, newobj):
         """
@@ -550,6 +1091,27 @@ class Node(models.Model):
             fields.append((field, value))
         return siblings.filter(reduce(operator.or_, filters))
 
+    async def aget_sorted_pos_queryset(self, siblings, newobj):
+        """
+        **Async version of get_sorted_pos_queryset.**
+        :returns:
+
+            A queryset of the nodes that must be moved to the right.
+            Called only for Node models with :attr:`node_order_by`
+
+        This function is based on _insertion_target_filters from django-mptt
+        (BSD licensed) by Jonathan Buchanan:
+        https://github.com/django-mptt/django-mptt/blob/0.3.0/mptt/signals.py
+        """
+        
+        fields, filters = [], []
+        for field in self.node_order_by:
+            value = getattr(newobj, field)
+            filters.append(Q(*[Q(**{f: v}) for f, v in fields] + [Q(**{"%s__gt" % field: value})]))
+            fields.append((field, value))
+        return siblings.filter(reduce(operator.or_, filters))
+
+
     def _clear_cached_attributes(self):
         for attr in self._cached_attributes:
             with suppress(AttributeError):
@@ -562,6 +1124,33 @@ class Node(models.Model):
     @classmethod
     def get_annotated_list_qs(cls, qs):
         """
+        Gets an annotated list from a queryset.
+        """
+        result, info = [], {}
+        start_depth, prev_depth = (None, None)
+        for node in qs:
+            depth = node.get_depth()
+            if start_depth is None:
+                start_depth = depth
+            open = depth and (prev_depth is None or depth > prev_depth)
+            if prev_depth is not None and depth < prev_depth:
+                info["close"] = list(range(0, prev_depth - depth))
+            info = {"open": open, "close": [], "level": depth - start_depth}
+            result.append(
+                (
+                    node,
+                    info,
+                )
+            )
+            prev_depth = depth
+        if start_depth and start_depth > 0:
+            info["close"] = list(range(0, prev_depth - start_depth + 1))
+        return result
+
+    @classmethod
+    async def aget_annotated_list_qs(cls, qs):
+        """
+        **Async version of get_annotated_list_qs.**
         Gets an annotated list from a queryset.
         """
         result, info = [], {}
@@ -604,6 +1193,27 @@ class Node(models.Model):
         if max_depth:
             qs = qs.filter(depth__lte=max_depth)
         return cls.get_annotated_list_qs(qs)
+
+    @classmethod
+    async def aget_annotated_list(cls, parent=None, max_depth=None):
+        """
+        **Async version of get_annotated_list.**
+        Gets an annotated list from a tree branch.
+
+        :param parent:
+
+            The node whose descendants will be annotated. The node itself
+            will be included in the list. If not given, the entire tree
+            will be annotated.
+
+        :param max_depth:
+
+            Optionally limit to specified depth
+        """
+        qs = await cls.aget_tree(parent)
+        if max_depth:
+            qs = qs.filter(depth__lte=max_depth)
+        return await cls.aget_annotated_list_qs(qs)
 
     @classmethod
     def _get_serializable_model(cls):


### PR DESCRIPTION
Hi,

I'm adding support for ``async`` (issue #334). The strategy this PR follows is the following:

- Try to avoid as much as possible the ``sync_to_async`` while being somehow pragmatic. I suggest to have full async support as using this helpers is tricky. However, as I want to it to be ready, I use sometimes, when their isn't any other way or I would need much more time to do it.
- I added the prefix ``a`` for the async functions. So for instance, ``get_parent()`` has its async as ``aget_parent``. I tried to follows the naming convention used by django.
- I'm aware that the support sometimes doesn't really use the full async benefits. Hopefully in the future will do. This can be noticed in several places where everything is parsed to a list instead of using queries. In the sync version it doesn't show a lot because the ``.all()`` hides it. 
- There are 2 tests: sync and async. The async one is the same as the sync but for async. **The sync tests have been not been modified**.