### PR TITLE
Remove all use of raw SQL in favour of ORM queries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@ Release 5.0.0 (in development)
 * Add support for Python 3.14.
 * Add support for Django 6.0.
 * Drop support for Django 5.1.
+* Replace all raw SQL queries made by Treebeard with ORM queries, for better security, portability and compatibility.
+* Remove the `Node.get_database_vendor()` helper function which is no longer used.
 * All node create and update operations are now run in a transaction to mitigate against race conditions.
 * `MoveNodeForm` has been refactored to use a `ModelChoiceField` for selecting the relative node.
 * Internal fields used by Treebeard's `MoveNodeForm` have been renamed from 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -413,16 +413,5 @@ API
 
   .. automethod:: get_annotated_list_qs
 
-  .. automethod:: get_database_vendor
-
-     Example:
-
-     .. code-block:: python
-
-        MyNodeModel.get_database_vendor("write")
-
-
-     .. versionadded:: 1.61
-
 
 .. _django-mptt: https://github.com/django-mptt/django-mptt/

--- a/docs/source/caveats.rst
+++ b/docs/source/caveats.rst
@@ -1,15 +1,13 @@
 Known Caveats
 =============
 
-Raw Queries
------------
+Updating objects
+----------------
 
-``django-treebeard`` uses Django raw SQL queries for
-some write operations, and raw queries don't update the objects in the
-ORM since it's being bypassed.
-
-Because of this, if you have a node in memory and plan to use it after a
-tree modification (adding/removing/moving nodes), you need to reload it.
+The nature of tree data means that many operations (e.g., adding a child to a tree node)
+affect related objects (e.g., the parent node). ``django-treebeard`` updates these in the database, 
+but if you have a node in memory and plan to use it after a tree modification 
+(e.g., adding/removing/moving nodes), you may need to reload it with ``object_instance.refresh_from_db()``.
 
 
 Inconsistent state

--- a/tests/test_treebeard.py
+++ b/tests/test_treebeard.py
@@ -1974,6 +1974,26 @@ class TestInheritedModels(TestTreeBase):
             assert not base_model.objects.filter(desc=desc).exists()
         assert [node.desc for node in node2.get_descendants()] == ["22"]
 
+    def test_move_with_children(self, inherited_model):
+        base_model = inherited_model.__bases__[0]
+
+        node1 = base_model.objects.get(desc="1")
+        node21 = inherited_model.objects.get(desc="21")
+        node21.move(node1, "first-child")
+
+        node1.refresh_from_db()
+        node21.refresh_from_db()
+        assert [node.desc for node in node1.get_children()] == ["21"]
+        assert [node.desc for node in node21.get_children()] == ["211", "212"]
+
+    def test_get_descendants_group_count(self, inherited_model):
+        base_model = inherited_model.__bases__[0]
+        for node in base_model.get_descendants_group_count():
+            assert node.descendants_count == node.get_descendant_count()
+
+        for node in inherited_model.get_descendants_group_count():
+            assert node.descendants_count == node.get_descendant_count()
+
 
 @pytest.mark.django_db
 class TestMP_TreeAlphabet(TestTreeBase):

--- a/treebeard/models.py
+++ b/treebeard/models.py
@@ -4,7 +4,7 @@ import operator
 from contextlib import suppress
 from functools import reduce
 
-from django.db import connections, models, router, transaction
+from django.db import models, transaction
 from django.db.models import Q
 
 from treebeard.exceptions import InvalidPosition, MissingNodeOrderBy
@@ -603,28 +603,6 @@ class Node(models.Model):
         while current_class._meta.proxy:
             current_class = current_class._meta.proxy_for_model
         return current_class
-
-    @classmethod
-    def _get_database_connection(cls, action):
-        return {"read": connections[router.db_for_read(cls)], "write": connections[router.db_for_write(cls)]}[action]
-
-    @classmethod
-    def get_database_vendor(cls, action):
-        """
-        returns the supported database vendor used by a treebeard model when
-        performing read (select) or write (update, insert, delete) operations.
-
-        :param action:
-
-            `read` or `write`
-
-        :returns: postgresql, mysql or sqlite
-        """
-        return cls._get_database_connection(action).vendor
-
-    @classmethod
-    def _get_database_cursor(cls, action):
-        return cls._get_database_connection(action).cursor()
 
     class Meta:
         """Abstract model."""


### PR DESCRIPTION
This PR replaces all use of raw SQL queries in Treebeard with ORM queries. This is preferable because:

- It avoids potential issues with SQL injection: I found at least one instance where in specific (admittedly rare) circumstances injection could be performed;
- It means we can remove all the vendor-specific workarounds and leave it to Django itself to handle differences between databases;
- In a few cases it results in more efficient querying;
- Delegates selection of the right database, and things like quoting database name, to Django, simplifying our code considerably.

Fixes #196, fixes #300, fixes #299, fixes #232.