### PR TITLE
Fix incorrect behaviour in NS_Tree.add_child if called consecutively

### DIFF
--- a/tests/test_treebeard.py
+++ b/tests/test_treebeard.py
@@ -765,6 +765,16 @@ class TestAddChild(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
 
+    def test_add_child_called_consecutively(self, model_without_data):
+        # Regression test for https://github.com/django-treebeard/django-treebeard/issues/307
+        parent = model_without_data.add_root(desc="1")
+        child1 = model_without_data(desc="11")
+        child2 = model_without_data(desc="12")
+        assert parent.get_children_count() == 0
+        parent.add_child(instance=child1)
+        parent.add_child(instance=child2)
+        assert list(parent.get_children().values_list("desc", flat=True)) == [child1.desc, child2.desc]
+
     def test_add_child_with_already_saved_instance(self, model):
         child = model.objects.get(desc="21")
         with pytest.raises(NodeAlreadySaved):

--- a/treebeard/ns_tree.py
+++ b/treebeard/ns_tree.py
@@ -217,7 +217,9 @@ class NS_Node(Node):
                 pos = "last-sibling"
             last_child = self.get_last_child()
             last_child._cached_parent_obj = self
-            return last_child.add_sibling(pos, **kwargs)
+            new_sibling = last_child.add_sibling(pos, **kwargs)
+            self.rgt += 2  # Update the rgt of the parent object, which may be used again in a loop
+            return new_sibling
 
         # we're adding the first child of this node
         sql, params = self.__class__._move_right(self.tree_id, self.rgt, False, 2)


### PR DESCRIPTION
Logic that was used to update the rgt value on the parent object was only applied for leaf nodes, when it is applicable for any parent.

Fixes #307