### PR TITLE
Perform all create/update operations inside transactions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,9 @@
-Release 4.9.0 (in development)
+Release 5.0.0 (in development)
 ----------------------------
 * Add support for Python 3.14.
 * Add support for Django 6.0.
 * Drop support for Django 5.1.
+* All node create and update operations are now run in a transaction to mitigate against race conditions.
 * `MoveNodeForm` has been refactored to use a `ModelChoiceField` for selecting the relative node.
 * Internal fields used by Treebeard's `MoveNodeForm` have been renamed from 
 `_position` to `treebeard_position` and `_ref_node_id` to `treebeard_ref_node`.

--- a/docs/source/caveats.rst
+++ b/docs/source/caveats.rst
@@ -12,6 +12,22 @@ Because of this, if you have a node in memory and plan to use it after a
 tree modification (adding/removing/moving nodes), you need to reload it.
 
 
+Inconsistent state
+------------------
+
+The nature of tree implementations means that updating one object in a tree
+frequently requires making updates to several other objects (e.g., parents, siblings, children)
+in order to ensure efficiency of querying.
+
+Treebeard wraps all create/update operations in a database transaction to minimise the impact of
+race conditions, but it is still possible for data to end up in an inconsistent state in cases where
+large numbers of concurrent writes take place. Projects may wish to consider overriding Treebeard methods to apply additional 
+locks (e.g., lock the whole table when performing a move) to further reduce the chance of inconsistencies.
+This comes with a potentially significant performance penalty.
+
+``MP_Node`` ships with a ``fix_tree()`` method that can be used to find and correct inconsistencies
+in Materialized Path trees.
+
 Overriding the default manager
 ------------------------------
 

--- a/treebeard/al_tree.py
+++ b/treebeard/al_tree.py
@@ -1,7 +1,7 @@
 """Adjacency List"""
 
 from django.core import serializers
-from django.db import models
+from django.db import models, transaction
 from django.utils.translation import gettext_noop as _
 
 from treebeard.exceptions import InvalidMoveToDescendant, NodeAlreadySaved
@@ -56,6 +56,7 @@ class AL_Node(Node):
     )
 
     @classmethod
+    @transaction.atomic
     def add_root(cls, **kwargs):
         """Adds a root node to the tree."""
 
@@ -210,6 +211,7 @@ class AL_Node(Node):
             lnk[node.pk] = newobj
         return ret
 
+    @transaction.atomic
     def add_child(self, **kwargs):
         """Adds a child to the node."""
         cls = get_result_class(self.__class__)
@@ -284,6 +286,7 @@ class AL_Node(Node):
             return get_result_class(self.__class__).objects.filter(parent=self.parent)
         return self.__class__.get_root_nodes()
 
+    @transaction.atomic
     def add_sibling(self, pos=None, **kwargs):
         """Adds a new node as a sibling to the current node object."""
         pos = self._prepare_pos_var_for_add_sibling(pos)
@@ -341,6 +344,7 @@ class AL_Node(Node):
             sib_order = cls._make_hole_and_get_sibling_order(pos, target_node)
         return sib_order
 
+    @transaction.atomic
     def move(self, target, pos=None):
         """
         Moves the current node and all it's descendants to a new position

--- a/treebeard/models.py
+++ b/treebeard/models.py
@@ -4,7 +4,7 @@ import operator
 from contextlib import suppress
 from functools import reduce
 
-from django.db import connections, models, router
+from django.db import connections, models, router, transaction
 from django.db.models import Q
 
 from treebeard.exceptions import InvalidPosition, MissingNodeOrderBy
@@ -59,6 +59,7 @@ class Node(models.Model):
                 node_data[key] = foreign_keys[key].objects.get(pk=node_data[key])
 
     @classmethod
+    @transaction.atomic
     def load_bulk(cls, bulk_data, parent=None, keep_ids=False):
         """
         Loads a list/dictionary structure to the tree.

--- a/treebeard/ns_tree.py
+++ b/treebeard/ns_tree.py
@@ -4,7 +4,7 @@ import operator
 from functools import reduce
 
 from django.core import serializers
-from django.db import connection, models
+from django.db import connection, models, transaction
 from django.db.models import Q
 from django.utils.translation import gettext_noop as _
 
@@ -138,6 +138,7 @@ class NS_Node(Node):
     )
 
     @classmethod
+    @transaction.atomic
     def add_root(cls, **kwargs):
         """Adds a root node to the tree."""
 
@@ -207,6 +208,7 @@ class NS_Node(Node):
         }
         return sql, []
 
+    @transaction.atomic
     def add_child(self, **kwargs):
         """Adds a child to the node."""
         if not self.is_leaf():
@@ -251,6 +253,7 @@ class NS_Node(Node):
 
         return newobj
 
+    @transaction.atomic
     def add_sibling(self, pos=None, **kwargs):
         """Adds a new node as a sibling to the current node object."""
 
@@ -344,6 +347,7 @@ class NS_Node(Node):
 
         return newobj
 
+    @transaction.atomic
     def move(self, target, pos=None):
         """
         Moves the current node and all it's descendants to a new position
@@ -500,6 +504,7 @@ class NS_Node(Node):
         return sql, []
 
     @classmethod
+    @transaction.atomic
     def load_bulk(cls, bulk_data, parent=None, keep_ids=False):
         """Loads a list/dictionary structure to the tree."""
 


### PR DESCRIPTION
The nature of the tree implementations means that when creating or updating a tree node, other nodes (parents, siblings etc) also need updating in the database. This increases the risk of race conditions leading to inconsistent state and/or exceptions when performing large numbers of operations.

Treebeard should try to minimise this, and wrapping these operations in transactions is an easy way to do this.

This mitigates the following issues: #53, #220, #278.

Transactions alone do not necessarily avoid these issues: for some operations (e.g., moves), a lock would need to be placed on the entire table to eliminate any risk. It is suggested that projects that need to do so add such locking themselves, as there are performance implications.

Fixes #53, fixes #220, fixes #278.