### PR TITLE
Refactor MoveNodeForm to use a reusable ModelChoiceField

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,8 +3,9 @@ Release 4.9.0 (in development)
 * Add support for Python 3.14.
 * Add support for Django 6.0.
 * Drop support for Django 5.1.
+* `MoveNodeForm` has been refactored to use a `ModelChoiceField` for selecting the relative node.
 * Internal fields used by Treebeard's `MoveNodeForm` have been renamed from 
-`_position` to `treebeard_position` and `_ref_node_id` to `treebeard_ref_node_id`.
+`_position` to `treebeard_position` and `_ref_node_id` to `treebeard_ref_node`.
 * The initialisation signatures for the internal `MP_AddChildHandler` and `MP_AddSiblingHandler`
   classes have changed to avoid collisions with model field names. Both constructors now expect
   a mapping of model creation arguments as a single parameter, instead of keywords arguments passed to the constructor.

--- a/docs/source/admin.rst
+++ b/docs/source/admin.rst
@@ -65,3 +65,35 @@ Example:
             form = movenodeform_factory(MyNode)
 
         admin.site.register(MyNode, MyAdmin)
+
+
+Foreign keys and One-to-one relationships
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If your project contains models that have a foreign key or one-to-one relationship with a tree model,
+you can leverage ``TreeNodeChoiceField`` to display the choices nicely in the Django admin. Given the following models:
+
+    .. code-block:: python
+
+        class TreeNode(MP_Node):
+            ...
+
+        class RelatedModel(models.Model):
+            tree_node = models.ForeignKey("TreeNode")
+
+You can configure the admin form for ``RelatedModel`` as follows for it to render the choices for ``tree_node`` in a nested list:
+
+    .. code-block:: python
+
+        class RelatedModelAdminForm(forms.ModelForm):
+            tree_node = TreeNodeChoiceField(queryset=TreeNode.objects.all())
+
+        class RelatedModelAdmin(admin.ModelAdmin):
+            form = RelatedModelAdminForm
+
+        admin.site.register(MyNode, MyAdmin)
+
+.. warning::
+
+   ``TreeNodeChoiceField`` should not be used with AL nodes, because they cannot be queried efficiently
+   in this context.

--- a/treebeard/forms.py
+++ b/treebeard/forms.py
@@ -2,14 +2,32 @@
 
 from django import forms
 from django.forms.models import modelform_factory as django_modelform_factory
-from django.forms.utils import ErrorList
-from django.utils.html import escape
+from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 
 from treebeard.al_tree import AL_Node
 from treebeard.mp_tree import MP_Node
 from treebeard.ns_tree import NS_Node
+
+
+class TreeNodeChoiceField(forms.ModelChoiceField):
+    """
+    ModelChoiceField for use with tree models. Applies indentation
+    to the label to reflect the depth of the node.
+
+    The queryset/choices provided to the field must be ordered
+    in order for the choices to appear in the order that the tree is organised.
+    """
+
+    DEPTH_SEPARATOR = mark_safe("&nbsp;&nbsp;&nbsp;&nbsp;")
+
+    def _get_indent(self, obj):
+        return mark_safe(conditional_escape(self.DEPTH_SEPARATOR) * (obj.get_depth() - 1))
+
+    def label_from_instance(self, obj):
+        label = super().label_from_instance(obj)
+        return mark_safe(conditional_escape(self._get_indent(obj)) + conditional_escape(label))
 
 
 class MoveNodeForm(forms.ModelForm):
@@ -38,7 +56,6 @@ class MoveNodeForm(forms.ModelForm):
 
         It is recommended that the :py:func:`movenodeform_factory`
         function is used instead.
-
     """
 
     __position_choices_sorted = (
@@ -53,148 +70,104 @@ class MoveNodeForm(forms.ModelForm):
     )
 
     treebeard_position = forms.ChoiceField(required=True, label=_("Position"))
+    treebeard_ref_node = TreeNodeChoiceField(
+        required=False,
+        label=_("Relative to"),
+        empty_label=_("-- root --"),
+        queryset=None,  # Populated in __init__
+    )
 
-    treebeard_ref_node_id = forms.ChoiceField(required=False, label=_("Relative to"))
-
-    def _get_position_ref_node(self, instance):
+    def _get_initial(self, instance):
         if self.is_sorted:
             position = "sorted-child"
-            node_parent = instance.get_parent()
-            if node_parent:
-                ref_node_id = node_parent.pk
-            else:
-                ref_node_id = ""
+            ref_node = instance.get_parent()
         else:
             prev_sibling = instance.get_prev_sibling()
             if prev_sibling:
                 position = "right"
-                ref_node_id = prev_sibling.pk
+                ref_node = prev_sibling
             else:
                 position = "first-child"
                 if instance.is_root():
-                    ref_node_id = ""
+                    ref_node = None
                 else:
-                    ref_node_id = instance.get_parent().pk
-        return {"treebeard_ref_node_id": ref_node_id, "treebeard_position": position}
+                    ref_node = instance.get_parent()
+        return {"treebeard_ref_node": ref_node, "treebeard_position": position}
 
-    def __init__(
-        self,
-        data=None,
-        files=None,
-        auto_id="id_%s",
-        prefix=None,
-        initial=None,
-        error_class=ErrorList,
-        label_suffix=":",
-        empty_permitted=False,
-        instance=None,
-        **kwargs,
-    ):
+    def _set_ref_model_queryset(self, opts, instance):
+        """
+        Sets the queryset (or choices) on the treebeard_ref_model field.
+
+        For AL trees, this sets a list of nodes as the choices. For all other trees,
+        sets a queryset.
+
+        Excludes the instance and its descendants since a move relative to those would be invalid
+        """
+        if issubclass(opts.model, AL_Node):
+            choices = opts.model.get_tree()
+            descendants = instance.get_descendants(include_self=True) if instance else []
+            field = self.fields["treebeard_ref_node"]
+            self.fields["treebeard_ref_node"]._choices = [("", "--------")] + [
+                (field.prepare_value(node), field.label_from_instance(node))
+                for node in choices
+                if node not in descendants
+            ]
+            # Must set queryset so that the manually defined choices are valid.
+            # Must also do this *after* setting _choices above, otherwise the setter
+            # for queryset will overwrite the choices.
+            self.fields["treebeard_ref_node"].queryset = opts.model.objects.all()
+            return
+
+        queryset = opts.model.get_tree()
+        descendants = instance.get_descendants(include_self=True) if instance else None
+        if descendants:
+            queryset = queryset.exclude(pk__in=descendants.values_list("pk", flat=True))
+
+        self.fields["treebeard_ref_node"].queryset = queryset
+
+    def __init__(self, *args, initial=None, instance=None, **kwargs):
         opts = self._meta
         if opts.model is None:
             raise ValueError("ModelForm has no model class specified")
 
-        # update the 'treebeard_position' field choices
         self.is_sorted = getattr(opts.model, "node_order_by", False)
-        if self.is_sorted:
-            choices_sort_mode = self.__class__.__position_choices_sorted
-        else:
-            choices_sort_mode = self.__class__.__position_choices_unsorted
-        self.declared_fields["treebeard_position"].choices = choices_sort_mode
 
-        # update the 'treebeard_ref_node_id' choices
-        choices = self.mk_dropdown_tree(opts.model, for_node=instance)
-        self.declared_fields["treebeard_ref_node_id"].choices = choices
-        # use the formfield `to_python` method to coerse the field for custom ids
-        pkFormField = opts.model._meta.pk.formfield()
-        self.declared_fields["treebeard_ref_node_id"].coerce = pkFormField.to_python if pkFormField else int
+        # Set initial values for treebeard fields
 
-        # put initial data for these fields into a map, update the map with
-        # initial data, and pass this new map to the parent constructor as
-        # initial data
-        if instance is None:
-            initial_ = {}
-        else:
-            initial_ = self._get_position_ref_node(instance)
-
+        initial_ = self._get_initial(instance) if instance else {}
         if initial is not None:
             initial_.update(initial)
 
-        super().__init__(
-            data=data,
-            files=files,
-            auto_id=auto_id,
-            prefix=prefix,
-            initial=initial_,
-            error_class=error_class,
-            label_suffix=label_suffix,
-            empty_permitted=empty_permitted,
-            instance=instance,
-            **kwargs,
+        super().__init__(*args, instance=instance, initial=initial_, **kwargs)
+
+        # update the 'treebeard_position' field choices
+        self.fields["treebeard_position"].choices = (
+            self.__position_choices_sorted if self.is_sorted else self.__position_choices_unsorted
         )
 
-    def _clean_cleaned_data(self):
-        """delete auxilary fields not belonging to node model"""
-        reference_node_id = self.cleaned_data.pop("treebeard_ref_node_id", None)
-
-        if reference_node_id and reference_node_id.isdigit():
-            reference_node_id = int(reference_node_id)
-
-        position_type = self.cleaned_data.pop("treebeard_position")
-
-        return position_type, reference_node_id
+        self._set_ref_model_queryset(opts, instance)
 
     def save(self, commit=True):
-        position_type, reference_node_id = self._clean_cleaned_data()
+        reference_node = self.cleaned_data.pop("treebeard_ref_node", None)
+        position_type = self.cleaned_data.pop("treebeard_position")
 
         if self.instance._state.adding:
-            if reference_node_id:
-                reference_node = self._meta.model.objects.get(pk=reference_node_id)
+            if reference_node:
                 self.instance = reference_node.add_child(instance=self.instance)
                 self.instance.move(reference_node, pos=position_type)
             else:
                 self.instance = self._meta.model.add_root(instance=self.instance)
         else:
             self.instance.save()
-            if reference_node_id:
-                reference_node = self._meta.model.objects.get(pk=reference_node_id)
+            if reference_node:
                 self.instance.move(reference_node, pos=position_type)
             else:
-                if self.is_sorted:
-                    pos = "sorted-sibling"
-                else:
-                    pos = "first-sibling"
+                pos = "sorted-sibling" if self.is_sorted else "first-sibling"
                 self.instance.move(self._meta.model.get_first_root_node(), pos)
         # Reload the instance
         self.instance.refresh_from_db()
         super().save(commit=commit)
         return self.instance
-
-    @staticmethod
-    def is_loop_safe(for_node, possible_parent):
-        if for_node is not None:
-            return not (possible_parent == for_node) or (possible_parent.is_descendant_of(for_node))
-        return True
-
-    @staticmethod
-    def mk_indent(level):
-        return "&nbsp;&nbsp;&nbsp;&nbsp;" * (level - 1)
-
-    @classmethod
-    def add_subtree(cls, for_node, node, options):
-        """Recursively build options tree."""
-        if cls.is_loop_safe(for_node, node):
-            for item, _ in node.get_annotated_list(node):
-                options.append((item.pk, mark_safe(cls.mk_indent(item.get_depth()) + escape(item))))
-
-    @classmethod
-    def mk_dropdown_tree(cls, model, for_node=None):
-        """Creates a tree-like list of choices"""
-
-        options = [(None, _("-- root --"))]
-        for node in model.get_root_nodes():
-            cls.add_subtree(for_node, node, options)
-        return options
 
 
 def movenodeform_factory(model, form=MoveNodeForm, exclude=None, **kwargs):


### PR DESCRIPTION
Refactors `MoveNodeForm` to use a `ModelChoiceField` for rendering the related node field. This field can also be used by projects for other fields (foreign keys, one-to-one fields) that reference a tree model. 

This also improves compatibility with Django's admin form, passing through all kwargs instead of listing them explicitly.

Fixes #180