### PR TITLE
Use rollback in TreeAdmin if there were errors in the form

### DIFF
--- a/treebeard/admin.py
+++ b/treebeard/admin.py
@@ -5,6 +5,7 @@ import sys
 from django.conf import settings
 from django.contrib import admin, messages
 from django.core.exceptions import PermissionDenied
+from django.db import transaction
 from django.http import HttpResponse, HttpResponseBadRequest
 from django.urls import path
 from django.utils.encoding import force_str
@@ -63,6 +64,18 @@ class TreeAdmin(admin.ModelAdmin):
         extra_context["has_change_permission"] = self.has_change_permission(request)
         extra_context["filtered"] = not check_empty_dict(request.GET)
         return super().changelist_view(request, extra_context)
+
+    def _changeform_view(self, *args, **kwargs):
+        # Because Treebeard frequently needs to modify many objects in a tree when one node
+        # is added/updated, the normal behaviour of relying on `commit=False` to create
+        # unsaved objects before validating inlines etc doesn't work: Treebeard has already
+        # made database changes to prepare to insert/move a node.
+        # For this reason, if the form has error
+        response = super()._changeform_view(*args, **kwargs)
+        if getattr(response, "context_data", {}).get("errors", None):
+            # There was an error somewhere, likely in an inline, so we'll need to roll back
+            transaction.set_rollback(True)
+        return response
 
     def get_urls(self):
         """

--- a/treebeard/forms.py
+++ b/treebeard/forms.py
@@ -148,6 +148,17 @@ class MoveNodeForm(forms.ModelForm):
         self._set_ref_model_queryset(opts, instance)
 
     def save(self, commit=True):
+        """
+        Saves the model form.
+
+        WARNING: Treebeard does not respect commit=False: other nodes that
+        need to be modified to make space for the edited node will be updated
+        in the database, and thus it is difficult to avoid writing any changes to the database.
+
+        TreeAdmin handles this by rolling back the entire transaction if the form or any
+        inlines report an error. If you use this form elsewhere, you will need to do the same.
+        """
+
         reference_node = self.cleaned_data.pop("treebeard_ref_node", None)
         position_type = self.cleaned_data.pop("treebeard_position")
 


### PR DESCRIPTION
Django admin forms use a `commit=False` argument to prepare objects for save, but waits until all validation has been run before actually saving them.

This doesn't play nicely with Treebeard, which often has to modify several objects in the tree in order to make space for a new/changed node. These are written to the database immediately.

This change (a) documents that Treebeard ignores `commit=False` and forces the transaction to roll back in the event that errors are reported. This ensures that the tree doesn't end up in an inconsistent state because of partial updates.

Fixes #73