### PR TITLE
Use more efficient query for TreeAdmin list context

### DIFF
--- a/tests/test_treebeard.py
+++ b/tests/test_treebeard.py
@@ -2660,7 +2660,7 @@ class TestAdminTreeContext(TestNonEmptyTree):
                 "node-id": str(obj.pk),
                 "parent-id": 0 if obj.is_root() else obj.get_parent().pk,
                 "level": obj.get_depth(),
-                "children-num": obj.get_children_count(),
+                "has-children": 0 if obj.is_leaf() else 1,
             }
 
 

--- a/treebeard/static/treebeard/treebeard-admin.js
+++ b/treebeard/static/treebeard/treebeard-admin.js
@@ -102,8 +102,8 @@
                 return;
             }
 
-            const numChildren = parseInt($(this).data("children-num"));
-            if (numChildren) {
+            const hasChildren = parseInt($(this).data("has-children"));
+            if (hasChildren) {
                 $firstCell.prepend("<a href='#' class='treebeard-collapse treebeard-expanded'>-</a>");
             }
 

--- a/treebeard/templatetags/admin_tree.py
+++ b/treebeard/templatetags/admin_tree.py
@@ -28,7 +28,7 @@ def tree_context(cl):
             "node-id": str(obj.pk),
             "parent-id": _get_parent_id(obj),
             "level": obj.get_depth(),
-            "children-num": obj.get_children_count(),
+            "has-children": int(not obj.is_leaf()),
         }
         for obj in cl.result_list
     ]


### PR DESCRIPTION
This list is still horribly inefficient - fetching the parent for each node in an N+1 query, but that will require some more substantial refactoring to address. 