### PR TITLE
Fix handling of reverse ordering in node_order_by, and change failure mode for unsupported values.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,21 @@
+Release 5.0.2 (in development)
+------------------------------
+
+Treebeard 5.0.2 is a bugfix release.
+
+* Fix handling of reverse ordering in `node_order_by`.
+* Fix handling of inherited models in `TreeAdmin`.
+* Fix adding root nodes for inherited models.
+* Handle null values of fields specified in `node_order_by` more gracefully: ignore the field
+  for the purpose of ordering and log a warning to indicate that the value likely needs to be 
+  provided manually.
+
 Release 5.0.1 (Feb 11, 2026)
 ----------------------------
 
 Treebeard 5.0.1 is a bugfix release.
 
-* Fix count aggregations not working on MariaDB.
+* Fixed count aggregations not working on MariaDB.
 
 
 Release 5.0.0 (Feb 11, 2026)

--- a/docs/source/al_tree.rst
+++ b/docs/source/al_tree.rst
@@ -47,6 +47,13 @@ slow reads. If you read more than you write, use
 
          node_order_by = ['field1', 'field2', 'field3']
 
+      .. warning::
+         
+         ``node_order_by`` values are used to determine correct node ordering *before*
+         an object is inserted/moved. This means any fields that
+         are auto-populated at a database level, e.g., ``AutoField()``, or ``DateTimeField(auto_now=True)``
+         will be ignored for the purpose of ordering if a value isn't provided manually.
+
    .. attribute:: parent
 
       ``ForeignKey`` to itself. This attribute **MUST** be defined in the

--- a/docs/source/ltree.rst
+++ b/docs/source/ltree.rst
@@ -74,6 +74,13 @@ To use the ``ltree`` module, you need to create the extension in your database:
 
        node_order_by = ['field1', 'field2', 'field3']
 
+   .. warning::
+
+      ``node_order_by`` values are used to determine correct node ordering *before*
+         an object is inserted/moved. This means any fields that
+         are auto-populated at a database level, e.g., ``AutoField()``, or ``DateTimeField(auto_now=True)``
+         will be ignored for the purpose of ordering if a value isn't provided manually.
+
   .. attribute:: path
 
      ``ltree`` field, stores an ltree hierarchy for the node. The values are auto-generated

--- a/docs/source/mp_tree.rst
+++ b/docs/source/mp_tree.rst
@@ -158,6 +158,13 @@ extra steps, materialized path is more efficient than other approaches.
 
        node_order_by = ['field1', 'field2', 'field3']
 
+     .. warning::
+         ``node_order_by`` values are used to determine correct node ordering *before*
+         an object is inserted/moved. This means any fields that
+         are auto-populated at a database level, e.g., ``AutoField()``, or ``DateTimeField(auto_now=True)``
+         will be ignored for the purpose of ordering if a value isn't provided manually.
+
+
   .. attribute:: path
 
      ``CharField``, stores the full materialized path for each node. The

--- a/docs/source/ns_tree.rst
+++ b/docs/source/ns_tree.rst
@@ -42,6 +42,14 @@ write/delete operations.
 
         node_order_by = ['field1', 'field2', 'field3']
 
+     .. warning::
+         
+         ``node_order_by`` values are used to determine correct node ordering *before*
+         an object is inserted/moved. This means any fields that
+         are auto-populated at a database level, e.g., ``AutoField()``, or ``DateTimeField(auto_now=True)``
+         will be ignored for the purpose of ordering if a value isn't provided manually.
+
+
   .. attribute:: depth
 
      ``PositiveIntegerField``, depth of a node in the tree. A root node

--- a/tests/models.py
+++ b/tests/models.py
@@ -96,7 +96,7 @@ class AL_TestNodeInherited(AL_TestNode):
 
 class MP_TestNodeSorted(MP_Node, DescMixin):
     steplen = 1
-    node_order_by = ["val1", "val2", "desc"]
+    node_order_by = ["val1", "val2", "-desc"]
     val1 = models.IntegerField()
     val2 = models.IntegerField()
 
@@ -105,7 +105,7 @@ class MP_TestNodeInheritedSorted(MP_TestNodeSorted): ...
 
 
 class NS_TestNodeSorted(NS_Node, DescMixin):
-    node_order_by = ["val1", "val2", "desc"]
+    node_order_by = ["val1", "val2", "-desc"]
     val1 = models.IntegerField()
     val2 = models.IntegerField()
 
@@ -118,7 +118,7 @@ class AL_TestNodeSorted(AL_Node, DescMixin):
         db_index=True,
         on_delete=models.CASCADE,
     )
-    node_order_by = ["val1", "val2", "desc"]
+    node_order_by = ["val1", "val2", "-desc"]
     val1 = models.IntegerField()
     val2 = models.IntegerField()
 
@@ -214,7 +214,7 @@ if os.environ.get("DATABASE_ENGINE", "") == "psql":
             proxy = True
 
     class LT_TestNodeSorted(LT_Node, DescMixin):
-        node_order_by = ["val1", "val2", "desc"]
+        node_order_by = ["val1", "val2", "-desc"]
         val1 = models.IntegerField()
         val2 = models.IntegerField()
 


### PR DESCRIPTION
- Fix handling of reverse ordering in `node_order_by`, e.g., `-created`.
- Fail gracefully if no value is found for a field specified in `node_order_by`, instead of allowing Django to throw a ValueError. Treebeard will now log a warning instead.

Fixes #108, fixes #280.