### PR TITLE
Reload NS and MP nodes after move, so that they have correct tree values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@ Release 5.0.2 (in development)
 
 Treebeard 5.0.2 is a bugfix release.
 
+* MP and NS nodes are refreshed from the database after a move, for a better developer experience.
+  Previously it was left to the developer to refresh manually if they needed to use the node, 
+  and this was the source of numerous issues.
 * Fix handling of reverse ordering in `node_order_by`.
 * Fix handling of inherited models in `TreeAdmin`.
 * Fix adding root nodes for inherited models.

--- a/docs/source/caveats.rst
+++ b/docs/source/caveats.rst
@@ -5,9 +5,11 @@ Updating objects
 ----------------
 
 The nature of tree data means that many operations (e.g., adding a child to a tree node)
-affect related objects (e.g., the parent node). ``django-treebeard`` updates these in the database, 
-but if you have a node in memory and plan to use it after a tree modification 
-(e.g., adding/removing/moving nodes), you may need to reload it with ``object_instance.refresh_from_db()``.
+affect related objects (e.g., the parent node). 
+
+For add/move operations, Treebeard will refresh the node being moved/created and its target. 
+If you have other potentially affected nodes (e.g., siblings) in memory and plan to use them 
+after a tree modification, you may need to reload them with ``object_instance.refresh_from_db()``.
 
 
 Inconsistent state

--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -386,6 +386,8 @@ class MP_MoveHandler(MP_ComplexAddMoveHandler):
         )
 
         self.update_parent_counts_after_move(oldpath, newpath)
+        self.node.refresh_from_db()  # Node path and depth will have changed
+        self.target.refresh_from_db()
 
     def update_parent_counts_after_move(self, oldpath, newpath):
         """

--- a/treebeard/ns_tree.py
+++ b/treebeard/ns_tree.py
@@ -305,6 +305,7 @@ class NS_Node(Node):
 
         pos = self._prepare_pos_var_for_move(pos)
         cls = get_result_class(self.__class__)
+        original_target = target
 
         parent = None
 
@@ -389,7 +390,7 @@ class NS_Node(Node):
                 newpos = target.lft
                 cls._move_right(target.tree_id, newpos, True, gap)
 
-        # we reload 'self' because lft/rgt may have changed
+        # we refresh 'self' because lft/rgt may have changed
         self.refresh_from_db()
 
         depthdiff = target.depth - self.depth
@@ -407,6 +408,8 @@ class NS_Node(Node):
 
         # close the gap
         cls._close_gap(self.lft, self.rgt, self.tree_id)
+        self.refresh_from_db()  # Tree params will have changed
+        original_target.refresh_from_db()
 
     @classmethod
     def _close_gap(cls, drop_lft, drop_rgt, tree_id):


### PR DESCRIPTION
The current behaviour of not refreshing a node after a move is counter-intuitive and has tripped up a lot of people: you have to have studied the documentation carefully to realise that the node in memory is out of date. 

It feels more friendly to just reload the node and its target, to ensure consistency. The extra database query is cheap since we are just fetching by PK.

Fixes #242