### PR TITLE
Drop workaround for Django serializer not handling proxy models, use iterator

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,12 +6,13 @@ Treebeard 5.0.2 is a bugfix release.
 * MP and NS nodes are refreshed from the database after a move, for a better developer experience.
   Previously it was left to the developer to refresh manually if they needed to use the node, 
   and this was the source of numerous issues.
-* Fix handling of reverse ordering in `node_order_by`.
-* Fix handling of inherited models in `TreeAdmin`.
-* Fix adding root nodes for inherited models.
-* Handle null values of fields specified in `node_order_by` more gracefully: ignore the field
+* Fixed handling of reverse ordering in `node_order_by`.
+* Fixed handling of inherited models in `TreeAdmin`.
+* Fixed adding root nodes for inherited models.
+* Handled null values of fields specified in `node_order_by` more gracefully: ignore the field
   for the purpose of ordering and log a warning to indicate that the value likely needs to be 
   provided manually.
+* Modified `dump_bulk()` methods to use a queryset iterator to avoid loading large datasets into memory.
 
 Release 5.0.1 (Feb 11, 2026)
 ----------------------------

--- a/treebeard/al_tree.py
+++ b/treebeard/al_tree.py
@@ -145,12 +145,8 @@ class AL_Node(Node):
     def dump_bulk(cls, parent=None, keep_ids=True):
         """Dumps a tree branch to a python data structure."""
 
-        serializable_cls = cls._get_serializable_model()
-        if parent and serializable_cls != cls and parent.__class__ != serializable_cls:
-            parent = serializable_cls.objects.get(pk=parent.pk)
-
         # a list of nodes: not really a queryset, but it works
-        objs = serializable_cls.get_tree(parent)
+        objs = cls.get_tree(parent)
 
         ret, lnk = [], {}
         pk_field = cls._meta.pk.attname

--- a/treebeard/ltree/__init__.py
+++ b/treebeard/ltree/__init__.py
@@ -414,12 +414,12 @@ class LT_Node(Node):
         # Because of fix_tree, this method assumes that the depth
         # and numchild properties in the nodes can be incorrect,
         # so no helper methods are used
-        qset = cls._get_serializable_model().objects.all()
+        qset = cls.objects.all()
         if parent:
             qset = qset.filter(path__descendants=parent.path)
         ret, lnk = [], {}
         pk_field = cls._meta.pk.attname
-        for pyobj in serializers.serialize("python", qset):
+        for pyobj in serializers.serialize("python", qset.iterator()):
             # django's serializer stores the attributes in 'fields'
             fields = pyobj["fields"]
             path = PathValue(fields["path"])

--- a/treebeard/models.py
+++ b/treebeard/models.py
@@ -617,20 +617,6 @@ class Node(models.Model):
         return cls.get_annotated_list_qs(qs)
 
     @classmethod
-    def _get_serializable_model(cls):
-        """
-        Returns a model with a valid _meta.local_fields (serializable).
-
-        Basically, this means the original model, not a proxied model.
-
-        (this is a workaround for a bug in django)
-        """
-        current_class = cls
-        while current_class._meta.proxy:
-            current_class = current_class._meta.proxy_for_model
-        return current_class
-
-    @classmethod
     @cache
     def tree_model(cls):
         """

--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -492,12 +492,12 @@ class MP_Node(Node):
         # Because of fix_tree, this method assumes that the depth
         # and numchild properties in the nodes can be incorrect,
         # so no helper methods are used
-        qset = cls._get_serializable_model().objects.all().order_by("depth", "path")
+        qset = cls.objects.all().order_by("depth", "path")
         if parent:
             qset = qset.filter(path__startswith=parent.path)
         ret, lnk = [], {}
         pk_field = cls._meta.pk.attname
-        for pyobj in serializers.serialize("python", qset):
+        for pyobj in serializers.serialize("python", qset.iterator()):
             # django's serializer stores the attributes in 'fields'
             fields = pyobj["fields"]
             path = fields["path"]

--- a/treebeard/ns_tree.py
+++ b/treebeard/ns_tree.py
@@ -489,10 +489,10 @@ class NS_Node(Node):
     @classmethod
     def dump_bulk(cls, parent=None, keep_ids=True):
         """Dumps a tree branch to a python data structure."""
-        qset = cls._get_serializable_model().get_tree(parent)
+        qset = cls.get_tree(parent)
         ret, lnk = [], {}
         pk_field = cls._meta.pk.attname
-        for pyobj in qset:
+        for pyobj in qset.iterator():
             serobj = serializers.serialize("python", [pyobj])[0]
             # django's serializer stores the attributes in 'fields'
             fields = serobj["fields"]


### PR DESCRIPTION
The upstream issue was fixed a long time ago: https://code.djangoproject.com/ticket/17717

Also uses an iterator to avoid loading large datasets into memory.