### PR TITLE
Refactor how movenodeform_factory determines fields to exclude

### DIFF
--- a/treebeard/al_tree.py
+++ b/treebeard/al_tree.py
@@ -28,6 +28,7 @@ class AL_Node(Node):
     node_order_by = None
 
     TREEBEARD_IDENTIFYING_FIELD = "parent"
+    MOVENODE_FORM_EXCLUDED_FIELDS = ("sib_order", "parent")
 
     _cached_attributes = (
         *Node._cached_attributes,

--- a/treebeard/forms.py
+++ b/treebeard/forms.py
@@ -7,9 +7,6 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 
 from treebeard.al_tree import AL_Node
-from treebeard.ltree import LT_Node
-from treebeard.mp_tree import MP_Node
-from treebeard.ns_tree import NS_Node
 
 
 class TreeNodeChoiceField(forms.ModelChoiceField):
@@ -199,20 +196,7 @@ def movenodeform_factory(model, form=MoveNodeForm, exclude=None, **kwargs):
 
     :return: A :py:class:`MoveNodeForm` subclass
     """
-    _exclude = _get_exclude_for_model(model, exclude)
-    return django_modelform_factory(model, form, exclude=_exclude, **kwargs)
-
-
-def _get_exclude_for_model(model, exclude):
-    if issubclass(model, AL_Node):
-        to_exclude = ("sib_order", "parent")
-    elif issubclass(model, MP_Node):
-        to_exclude = ("depth", "numchild", "path")
-    elif issubclass(model, NS_Node):
-        to_exclude = ("depth", "lft", "rgt", "tree_id")
-    elif issubclass(model, LT_Node):
-        to_exclude = ("path",)
-    else:
-        to_exclude = ()
-
-    return tuple(exclude or ()) + to_exclude
+    if exclude is None:
+        exclude = ()
+    exclude += getattr(model, "MOVENODE_FORM_EXCLUDED_FIELDS", ())
+    return django_modelform_factory(model, form, exclude=exclude, **kwargs)

--- a/treebeard/ltree/__init__.py
+++ b/treebeard/ltree/__init__.py
@@ -386,6 +386,7 @@ class LT_Node(Node):
     path = PathField(unique=True)
 
     TREEBEARD_IDENTIFYING_FIELD = "path"
+    MOVENODE_FORM_EXCLUDED_FIELDS = ("path",)
 
     objects = LT_NodeManager()
 

--- a/treebeard/models.py
+++ b/treebeard/models.py
@@ -17,6 +17,8 @@ class Node(models.Model):
     # Subclasses must override this to provide the name of a field
     # that identifies the model.
     TREEBEARD_IDENTIFYING_FIELD = None
+    # Fields to be excluded from MoveNodeForm
+    MOVENODE_FORM_EXCLUDED_FIELDS = ()
     _cached_attributes = ()
 
     @classmethod

--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -443,6 +443,7 @@ class MP_Node(Node):
     numchild = models.PositiveIntegerField(default=0)
 
     TREEBEARD_IDENTIFYING_FIELD = "path"
+    MOVENODE_FORM_EXCLUDED_FIELDS = ("path", "depth", "numchild")
 
     objects = MP_NodeManager()
 

--- a/treebeard/ns_tree.py
+++ b/treebeard/ns_tree.py
@@ -105,6 +105,7 @@ class NS_Node(Node):
     depth = models.PositiveIntegerField(db_index=True)
 
     TREEBEARD_IDENTIFYING_FIELD = "lft"
+    MOVENODE_FORM_EXCLUDED_FIELDS = ("depth", "lft", "rgt", "tree_id")
 
     objects = NS_NodeManager()
 


### PR DESCRIPTION
Move configuration into the node class. This avoids us having to import all treebeard modules into the forms module, given that a project will very likely be using only one of them.