### PR TITLE
[WIP] Move table-level methods into managers

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -8,30 +8,11 @@ API
   :show-inheritance:
 
   This is the base class that defines the API of all tree models in this
-  library:
-
-     - :class:`treebeard.mp_tree.MP_Node` (materialized path)
-     - :class:`treebeard.ns_tree.NS_Node` (nested sets)
-     - :class:`treebeard.al_tree.AL_Node` (adjacency list)
+  library.
 
   .. warning::
 
       Please be aware of the :doc:`caveats` when using this library.
-
-  .. automethod:: Node.add_root
-
-     Example:
-
-     .. code-block:: python
-
-        MyNode.add_root(numval=1, strval='abcd')
-
-     Or, to pass in an existing instance:
-
-     .. code-block:: python
-
-        new_node = MyNode(numval=1, strval='abcd')
-        MyNode.add_root(instance=new_node)
 
   .. automethod:: add_child
 
@@ -69,8 +50,6 @@ API
 
            Call our queryset's delete to handle children removal. Subclasses
            will handle extra maintenance.
-
-  .. automethod:: get_tree
 
   .. automethod:: get_depth
 
@@ -245,13 +224,39 @@ API
 
   .. automethod:: save
 
+  .. automethod:: find_problems
+
+  .. automethod:: fix_tree
+
+
+.. autoclass:: NodeManager
+
+  This is the base manager class for models subclassing ``Node``.
+
+  .. automethod:: NodeManager.add_root
+
+     Example:
+
+     .. code-block:: python
+
+        MyNode.objects.add_root(numval=1, strval='abcd')
+
+     Or, to pass in an existing instance:
+
+     .. code-block:: python
+
+        new_node = MyNode(numval=1, strval='abcd')
+        MyNode.objects.add_root(instance=new_node)
+
+  .. automethod:: get_tree
+
   .. automethod:: get_first_root_node
 
      Example:
 
      .. code-block:: python
 
-        MyNodeModel.get_first_root_node()
+        MyNodeModel.objects.get_first_root_node()
 
   .. automethod:: get_last_root_node
 
@@ -259,7 +264,7 @@ API
 
      .. code-block:: python
 
-        MyNodeModel.get_last_root_node()
+        MyNodeModel.objects.get_last_root_node()
 
   .. automethod:: get_root_nodes
 
@@ -267,7 +272,7 @@ API
 
      .. code-block:: python
 
-        MyNodeModel.get_root_nodes()
+        MyNodeModel.objects.get_root_nodes()
 
   .. automethod:: load_bulk
 
@@ -309,7 +314,7 @@ API
                     ]},
             ]
             # parent = None
-            MyNodeModel.load_bulk(data, None)
+            MyNodeModel.objects.load_bulk(data, None)
 
      Will create:
 
@@ -331,8 +336,8 @@ API
 
      .. code-block:: python
 
-        tree = MyNodeModel.dump_bulk()
-        branch = MyNodeModel.dump_bulk(node_obj)
+        tree = MyNodeModel.objects.dump_bulk()
+        branch = MyNodeModel.objects.dump_bulk(node_obj)
 
   .. automethod:: find_problems
 
@@ -353,12 +358,11 @@ API
 
   .. automethod:: get_annotated_list
 
-
      Example:
 
      .. code-block:: python
 
-        annotated_list = MyModel.get_annotated_list()
+        annotated_list = MyModel.objects.get_annotated_list()
 
      With data:
 
@@ -407,8 +411,6 @@ API
         This method was contributed originally by
         `Alexey Kinyov <rudi@05bit.com>`_, using an idea borrowed from
         `django-mptt`_.
-
-     .. versionadded:: 1.55
 
 
   .. automethod:: get_annotated_list_qs

--- a/docs/source/mp_tree.rst
+++ b/docs/source/mp_tree.rst
@@ -198,7 +198,6 @@ extra steps, materialized path is more efficient than other approaches.
 
         ``django-treebeard`` uses `numconv`_ for path encoding.
 
-
   .. attribute:: depth
 
      ``PositiveIntegerField``, depth of a node in the tree. A root node
@@ -207,10 +206,6 @@ extra steps, materialized path is more efficient than other approaches.
   .. attribute:: numchild
 
      ``PositiveIntegerField``, the number of children of the node.
-
-  .. automethod:: add_root
-
-     See: :meth:`treebeard.models.Node.add_root`
 
   .. automethod:: add_child
 
@@ -223,14 +218,22 @@ extra steps, materialized path is more efficient than other approaches.
   .. automethod:: move
 
      See: :meth:`treebeard.models.Node.move`
+  
+
+.. autoclass:: MP_NodeManager
+  :show-inheritance:
 
   .. automethod:: get_tree
 
-     See: :meth:`treebeard.models.Node.get_tree`
+     See: :meth:`treebeard.models.NodeManager.get_tree`
 
      .. note::
 
         This method returns a queryset.
+
+  .. automethod:: add_root
+
+     See: :meth:`treebeard.models.NodeManager.add_root`
 
   .. automethod:: find_problems
 
@@ -248,20 +251,15 @@ extra steps, materialized path is more efficient than other approaches.
 
      .. code-block:: python
 
-        MyNodeModel.find_problems()
-
+        MyNodeModel.objects.find_problems()
+  
   .. automethod:: fix_tree
 
      Example:
 
      .. code-block:: python
 
-        MyNodeModel.fix_tree()
-
-
-
-.. autoclass:: MP_NodeManager
-  :show-inheritance:
+        MyNodeModel.objects.fix_tree()
 
 .. autoclass:: MP_NodeQuerySet
   :show-inheritance:

--- a/docs/source/ns_tree.rst
+++ b/docs/source/ns_tree.rst
@@ -67,6 +67,12 @@ write/delete operations.
 
      ``PositiveIntegerField``
 
+.. autoclass:: NS_NodeManager
+  :show-inheritance:
+
+.. autoclass:: NS_NodeQuerySet
+  :show-inheritance:
+
   .. automethod:: get_tree
 
         See: :meth:`treebeard.models.Node.get_tree`
@@ -74,13 +80,6 @@ write/delete operations.
         .. note::
 
             This method returns a queryset.
-
-
-.. autoclass:: NS_NodeManager
-  :show-inheritance:
-
-.. autoclass:: NS_NodeQuerySet
-  :show-inheritance:
 
 
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -68,7 +68,7 @@ You can see the tree structure with code:
 
 .. code-block:: python
 
-    >>> Category.dump_bulk()
+    >>> Category.objects.dump_bulk()
     [{'id': 1, 'data': {'name': u'Computer Hardware'},
       'children': [
          {'id': 3, 'data': {'name': u'Hard Drives'}},
@@ -78,7 +78,7 @@ You can see the tree structure with code:
              {'id': 6, 'data': {'name': u'Laptop Memory'}},
              {'id': 7, 'data': {'name': u'Server Memory'}}]},
          {'id': 4, 'data': {'name': u'SSD'}}]}]
-    >>> Category.get_annotated_list()
+    >>> Category.objects.get_annotated_list()
     [(<Category: Category: Computer Hardware>,
       {'close': [], 'level': 0, 'open': True}),
      (<Category: Category: Hard Drives>,

--- a/treebeard/deprecation.py
+++ b/treebeard/deprecation.py
@@ -1,0 +1,2 @@
+class RemovedInTreebeard6Warning(PendingDeprecationWarning):
+    pass

--- a/treebeard/forms.py
+++ b/treebeard/forms.py
@@ -102,7 +102,7 @@ class MoveNodeForm(forms.ModelForm):
         Excludes the instance and its descendants since a move relative to those would be invalid
         """
         if issubclass(opts.model, AL_Node):
-            choices = opts.model.get_tree()
+            choices = opts.model.objects.get_tree()
             descendants = instance.get_descendants(include_self=True) if instance else []
             field = self.fields["treebeard_ref_node"]
             self.fields["treebeard_ref_node"]._choices = [("", "--------")] + [
@@ -116,7 +116,7 @@ class MoveNodeForm(forms.ModelForm):
             self.fields["treebeard_ref_node"].queryset = opts.model.objects.all()
             return
 
-        queryset = opts.model.get_tree()
+        queryset = opts.model.objects.get_tree()
         descendants = instance.get_descendants(include_self=True) if instance else None
         if descendants:
             queryset = queryset.exclude(pk__in=descendants.values_list("pk", flat=True))
@@ -165,14 +165,14 @@ class MoveNodeForm(forms.ModelForm):
                 self.instance = reference_node.add_child(instance=self.instance)
                 self.instance.move(reference_node, pos=position_type)
             else:
-                self.instance = self._meta.model.add_root(instance=self.instance)
+                self.instance = self._meta.model.objects.add_root(instance=self.instance)
         else:
             self.instance.save()
             if reference_node:
                 self.instance.move(reference_node, pos=position_type)
             else:
                 pos = "sorted-sibling" if self.is_sorted else "first-sibling"
-                self.instance.move(self._meta.model.get_first_root_node(), pos)
+                self.instance.move(self._meta.model.objects.get_first_root_node(), pos)
         # Reload the instance
         self.instance.refresh_from_db()
         super().save(commit=commit)

--- a/treebeard/templatetags/admin_tree_list.py
+++ b/treebeard/templatetags/admin_tree_list.py
@@ -38,6 +38,6 @@ def _subtree(context, node, request):
 @register.simple_tag(takes_context=True)
 def result_tree(context, cl, request):
     tree = ""
-    for root_node in cl.model.get_root_nodes():
+    for root_node in cl.model.objects.get_root_nodes():
         tree += format_html("<li>{}</li>", mark_safe(_subtree(context, root_node, request)))
     return format_html("<ul>{}</ul>", mark_safe(tree))


### PR DESCRIPTION
Move the following methods that are not specific to a single model instance into the manager:

- `add_root`
- `load_bulk`
- `dump_bulk`
- `get_root_nodes`
- `get_first_root_node`
- `get_last_root_node`
- `find_problems`
- `fix_tree`
- `get_tree`
- `get_descendants_group_count`

Having these methods on the manager, rather than as class methods on the model, is consistent with the approach that Django takes for models (e.g., `Model.objects.create()`), and aligns Treebeard more closely with that pattern.

Refs #44