### PR TITLE
Revert change to lock all root nodes when adding a new root

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+Release 5.0.5 (Feb 19, 2026)
+------------------------------
+
+Treebeard 5.0.5 is a bugfix release.
+
+* Reverted change to lock root nodes when adding a new root, which had unwanted performance implications.
+
+
 Release 5.0.4 (Feb 19, 2026)
 ------------------------------
 

--- a/tests/test_treebeard.py
+++ b/tests/test_treebeard.py
@@ -417,37 +417,6 @@ class TestClassMethods(TestNonEmptyTree):
         with pytest.raises(NodeAlreadySaved):
             model.add_root(instance=obj)
 
-    @pytest.mark.django_db(transaction=True)
-    @pytest.mark.skipif(
-        os.getenv("DATABASE_ENGINE", "sqlite") == "sqlite",
-        reason="SQLite doesn't support row-level locking",
-    )
-    def test_add_root_concurrent(self, model_without_data):
-        """
-        Tests adding multiple root nodes, *after* one root node already exists.
-        """
-        num_threads = 3
-        per_thread = 5
-        errors = []
-        model_without_data.add_root(desc="first")
-
-        def add_root(thread_id):
-            try:
-                for i in range(per_thread):
-                    model_without_data.add_root(desc=f"t{thread_id}-{i}")
-            except Exception as e:
-                errors.append(e)
-
-        threads = [threading.Thread(target=add_root, args=(t,)) for t in range(num_threads)]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join()
-        if errors:
-            raise errors[0]
-
-        assert model_without_data.get_root_nodes().count() == num_threads * per_thread + 1
-
 
 @pytest.mark.django_db
 class TestSimpleNodeMethods(TestNonEmptyTree):

--- a/treebeard/__init__.py
+++ b/treebeard/__init__.py
@@ -18,4 +18,4 @@ Release logic:
 14. git push
 """
 
-__version__ = "5.0.4"
+__version__ = "5.0.5"

--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -203,9 +203,6 @@ class MP_AddRootHandler:
         self.kwargs = kwargs
 
     def process(self):
-        # Lock all root node rows to avoid integrity errors. We must force evaluation of the queryset
-        list(self.cls.get_root_nodes().select_for_update().only("pk"))
-
         # do we have a root node already?
         last_root = self.cls.get_last_root_node()
 


### PR DESCRIPTION
As noted in #377 locking *all* root nodes can potentially cause a very large performance penalty. Reverting for now, until we can come up with a safer strategy -- or guidance for how to add locking for those projects that need it.

Fixes #377