### PR TITLE
Add project urls to package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,11 @@ test = [
     "pytest-pythonpath>=0.7,<1.0",
 ]
 
+[project.urls]
+source = "https://github.com/django-treebeard/django-treebeard"
+documentation = "http://django-treebeard.readthedocs.io/"
+changelog = "https://github.com/django-treebeard/django-treebeard/blob/master/CHANGES.md"
+
 [tool.ruff]
 line-length = 120
 lint.select = [


### PR DESCRIPTION
These URLs will be displayed in the sidebar of [PyPI.org](https://pypi.org/project/django-treebeard/).
This makes it easier to find the repository and changelog.