### PR TITLE
Enable Finding Problems For A Given Tree

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@ Next release (in development)
 ------------------------------
 
 * Improved query efficiency for AL Trees, for several query operations.
+* Added a `parent` param to `MP_tree.find_problems` to allow inspecting only a portion of a tree.
 
 
 Release 5.0.5 (Feb 19, 2026)

--- a/tests/test_treebeard.py
+++ b/tests/test_treebeard.py
@@ -2307,6 +2307,63 @@ class TestMP_TreeFindProblems(TestTreeBase):
         assert ["03", "0301", "030102"] == got(wrong_numchild)
         assert ["04", "0401"] == got(wrong_depth)
 
+    def test_find_problems_with_root_clean(self, mpalphabet_model):
+        mpalphabet_model.alphabet = "01234"
+        mpalphabet_model(path="01", depth=1, numchild=1, numval=0).save()
+        mpalphabet_model(path="0101", depth=2, numchild=0, numval=0).save()
+        root = mpalphabet_model.objects.get(path="01")
+        result = mpalphabet_model.find_problems(parent=root)
+        assert all(not group for group in result)
+
+    def test_find_problems_with_root_scoped_to_single_tree(self, mpalphabet_model):
+        """Problems in one tree should not appear when checking another tree."""
+        mpalphabet_model.alphabet = "01234"
+        # Tree 1: clean
+        mpalphabet_model(path="01", depth=1, numchild=1, numval=0).save()
+        mpalphabet_model(path="0101", depth=2, numchild=0, numval=0).save()
+        # Tree 2: root is valid but children have problems (wrong depth, wrong numchild)
+        mpalphabet_model(path="02", depth=1, numchild=5, numval=0).save()
+        mpalphabet_model(path="0201", depth=20, numchild=0, numval=0).save()
+
+        root1 = mpalphabet_model.objects.get(path="01")
+        root2 = mpalphabet_model.objects.get(path="02")
+
+        # Tree 1 should be clean
+        result1 = mpalphabet_model.find_problems(parent=root1)
+        assert all(not group for group in result1)
+
+        # Tree 2 should have problems
+        result2 = mpalphabet_model.find_problems(parent=root2)
+        evil_chars, bad_steplen, orphans, wrong_depth, wrong_numchild = result2
+        assert not evil_chars
+        assert not bad_steplen
+        assert not orphans
+        # child "0201" has wrong depth (20 instead of 2)
+        assert len(wrong_depth) == 1
+        # root "02" reports numchild=5 but only has 1 child
+        assert len(wrong_numchild) == 1
+
+    def test_find_problems_with_root_detects_all_problem_types(self, mpalphabet_model):
+        """Verify all five problem categories are detected within a single tree."""
+        mpalphabet_model.alphabet = "01234"
+        # Another clean tree to ensure isolation
+        mpalphabet_model(path="01", depth=1, numchild=0, numval=0).save()
+
+        # Tree with various problems rooted at "03"
+        mpalphabet_model(path="03", depth=1, numchild=2, numval=0).save()
+        mpalphabet_model(path="0301", depth=2, numchild=0, numval=0).save()
+        mpalphabet_model(path="030102", depth=3, numchild=10, numval=0).save()
+
+        def got(ids):
+            return [o.path for o in mpalphabet_model.objects.filter(pk__in=ids)]
+
+        root = mpalphabet_model.objects.get(path="03")
+        evil_chars, bad_steplen, orphans, wrong_depth, wrong_numchild = mpalphabet_model.find_problems(parent=root)
+        # "03" reports numchild=2 but only has 1 direct child -> wrong_numchild
+        assert "03" in got(wrong_numchild)
+        # "030102" reports numchild=10 which is wrong
+        assert "030102" in got(wrong_numchild)
+
 
 @pytest.mark.django_db
 class TestMP_TreeFix(TestTreeBase):

--- a/treebeard/models.py
+++ b/treebeard/models.py
@@ -144,8 +144,14 @@ class Node(models.Model):
         return cls.get_root_nodes().last()
 
     @classmethod
-    def find_problems(cls):  # pragma: no cover
-        """Checks for problems in the tree structure."""
+    def find_problems(cls, parent=None):  # pragma: no cover
+        """Checks for problems in the tree structure.
+
+        :param parent:
+
+            If provided, limits the check to the descendants of this node.
+            If not provided, the entire tree will be checked.
+        """
         raise NotImplementedError
 
     @classmethod

--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -525,7 +525,7 @@ class MP_Node(Node):
         return ret
 
     @classmethod
-    def find_problems(cls):
+    def find_problems(cls, parent=None):
         """
         Checks for problems in the tree structure, problems can occur when:
 
@@ -534,6 +534,11 @@ class MP_Node(Node):
            2. changing the ``steplen`` value in a model (you must
               :meth:`dump_bulk` first, change ``steplen`` and then
               :meth:`load_bulk`
+
+        :param parent:
+
+            If provided, limits the check to the descendants of this node.
+            If not provided, the entire tree will be checked.
 
         :returns: A tuple of five lists:
 
@@ -548,9 +553,14 @@ class MP_Node(Node):
         """
         cls = cls.tree_model()
 
+        if parent is not None:
+            qs = cls.objects.filter(path__startswith=parent.path)
+        else:
+            qs = cls.objects.all()
+
         evil_chars, bad_steplen, orphans = [], [], []
         wrong_depth, wrong_numchild = [], []
-        for node in cls.objects.all():
+        for node in qs.iterator():
             found_error = False
             for char in node.path:
                 if char not in cls.alphabet:


### PR DESCRIPTION
# Context
The current implementation of `find_problems` operates at the model level, searching for problems across all trees known to the model. This works for small collections of trees, but does not scale well when there are thousands of collections of unrelated trees such as individual customers who each have their own folder/file structures represented by treebeard. Ideally we could search for problems for a given tree (such as a specific customer's folder/file structure) while ignoring the others, which in turn allows a more focused set of results that are specific to a given tree (*that* customer's folder/file structure only). Then we can more easily invoke `fix_tree` for just the broken tree by passing in the `parent` node for a specific tree.

# Changes
* ~Added a~ `find_problems_for_tree` ~function that accepts a~ `root` ~node~.
* ~Extracted the logic for finding problems into a shared~ `_find_problems_in_qs` ~that both~ `find_problems` and `find_problems_for_tree` ~invokes~.
* Added an optional `root` param to `find_problems` function to scope problem to a specific tree.
* Added tests to validate passing an optional root node to `find_problems` and insured there are no regressions. 