### PR TITLE
Add a find_problems method for NS_Node

### DIFF
--- a/docs/source/ns_tree.rst
+++ b/docs/source/ns_tree.rst
@@ -75,6 +75,24 @@ write/delete operations.
 
             This method returns a queryset.
 
+  .. automethod:: find_problems
+
+     .. note::
+
+        A node won't appear in more than one list, even when it exhibits
+        more than one problem. This method stops checking a node when it
+        finds a problem and continues to the next node.
+
+     .. note::
+
+        These problems can't be solved automatically.
+
+     Example:
+
+     .. code-block:: python
+
+        MyNodeModel.find_problems()
+
 
 .. autoclass:: NS_NodeManager
   :show-inheritance:

--- a/tests/test_treebeard.py
+++ b/tests/test_treebeard.py
@@ -129,6 +129,11 @@ def mpsmallstep_model(request):
     return request.param
 
 
+@pytest.fixture(scope="function", params=[models.NS_TestNode])
+def ns_model(request):
+    return request.param
+
+
 class TestTreeBase:
     def got(self, model):
         if model in [models.NS_TestNode, models.NS_TestNode_Proxy]:
@@ -2363,6 +2368,71 @@ class TestMP_TreeFindProblems(TestTreeBase):
         assert "03" in got(wrong_numchild)
         # "030102" reports numchild=10 which is wrong
         assert "030102" in got(wrong_numchild)
+
+
+@pytest.mark.django_db
+class TestNS_TreeFindProblems(TestTreeBase):
+    def test_find_problems_all_ok(self, ns_model):
+        ns_model(tree_id=1, lft=1, rgt=8, depth=1).save()
+        ns_model(tree_id=1, lft=2, rgt=5, depth=2).save()
+        ns_model(tree_id=1, lft=3, rgt=4, depth=3).save()
+        ns_model(tree_id=1, lft=6, rgt=7, depth=2).save()
+        ns_model(tree_id=2, lft=1, rgt=2, depth=1).save()
+
+        result = ns_model.find_problems()
+        assert result == ([], [], [], [])
+
+    def test_find_problems_reversed_lft_rgt(self, ns_model):
+        bad_node = ns_model(tree_id=1, lft=2, rgt=1, depth=1)
+        bad_node.save()
+
+        result = ns_model.find_problems()
+        assert result == ([bad_node.pk], [], [], [])
+
+    def test_find_problems_overlapping_nodes(self, ns_model):
+        ns_model(tree_id=1, lft=1, rgt=6, depth=1).save()
+        ns_model(tree_id=1, lft=2, rgt=4, depth=2).save()
+        bad_node = ns_model(tree_id=1, lft=3, rgt=5, depth=3)
+        bad_node.save()
+
+        result = ns_model.find_problems()
+        assert result == ([], [bad_node.pk], [], [])
+
+    def test_find_problems_duplicate_root(self, ns_model):
+        ns_model(tree_id=1, lft=1, rgt=8, depth=1).save()
+        ns_model(tree_id=1, lft=2, rgt=5, depth=2).save()
+        ns_model(tree_id=1, lft=3, rgt=4, depth=3).save()
+        ns_model(tree_id=1, lft=6, rgt=7, depth=2).save()
+        bad_node = ns_model(tree_id=1, lft=9, rgt=12, depth=1)
+        bad_node.save()
+        ns_model(tree_id=1, lft=10, rgt=11, depth=2).save()
+
+        result = ns_model.find_problems()
+        assert result == ([], [], [bad_node.pk], [])
+
+    def test_find_problems_wrong_depth(self, ns_model):
+        ns_model(tree_id=1, lft=1, rgt=8, depth=1).save()
+        bad_node_1 = ns_model(tree_id=1, lft=2, rgt=5, depth=1)
+        bad_node_1.save()
+        ns_model(tree_id=1, lft=3, rgt=4, depth=3).save()
+        ns_model(tree_id=1, lft=6, rgt=7, depth=2).save()
+        bad_node_2 = ns_model(tree_id=2, lft=1, rgt=2, depth=2)
+        bad_node_2.save()
+
+        result = ns_model.find_problems()
+        assert result == ([], [], [], [bad_node_1.pk, bad_node_2.pk])
+
+    def test_find_problems_within_parent(self, ns_model):
+        ns_model(tree_id=1, lft=1, rgt=8, depth=99).save()  # ignored
+        parent_node = ns_model(tree_id=1, lft=2, rgt=5, depth=2)
+        parent_node.save()
+        bad_node = ns_model(tree_id=1, lft=3, rgt=4, depth=99)
+        bad_node.save()
+        ns_model(tree_id=1, lft=6, rgt=7, depth=2).save()
+        ns_model(tree_id=2, lft=1, rgt=2, depth=99).save()  # ignored
+
+        result = ns_model.find_problems(parent=parent_node)
+        assert result == ([], [], [], [bad_node.pk])
 
 
 @pytest.mark.django_db

--- a/treebeard/ns_tree.py
+++ b/treebeard/ns_tree.py
@@ -2,6 +2,7 @@
 
 import operator
 from functools import reduce
+from itertools import groupby
 
 from django.core import serializers
 from django.db import models, transaction
@@ -560,6 +561,82 @@ class NS_Node(Node):
     def get_root_nodes(cls):
         """:returns: A queryset containing the root nodes in the tree."""
         return cls.tree_model().objects.filter(lft=1)
+
+    @classmethod
+    def find_problems(cls, parent=None):
+        """
+        Checks for inconsistencies in the tree structure.
+
+        :param parent:
+
+            If provided, limits the check to the descendants of this node.
+            If not provided, the entire tree will be checked.
+
+        :returns: A tuple of four lists:
+
+                  1. a list of ids of nodes where ``rgt`` is not strictly
+                     greater than ``lft``
+                  2. a list of ids of nodes where the ``lft`` and ``rgt``
+                     values partially overlap with another node (i.e. they are
+                     not properly nested)
+                  3. a list of ids of root-level nodes that have the same
+                     ``tree_id`` as another root-level node
+                  4. a list of ids of nodes with the wrong depth value for
+                     their nesting level as defined by ``lft`` and ``rgt``
+        """
+        cls = cls.tree_model()
+
+        if parent is not None:
+            qs = cls.objects.filter(tree_id=parent.tree_id, lft__gte=parent.lft, rgt__lte=parent.rgt)
+            initial_depth = parent.get_ancestors().count()
+        else:
+            qs = cls.objects.all()
+            initial_depth = 0
+
+        reversed_lft_rgt, overlapping_nodes, duplicate_tree_ids, wrong_depth = [], [], [], []
+
+        # Iterate over the nodes in order of tree_id and lft
+        qs = qs.order_by("tree_id", "lft").values("pk", "tree_id", "lft", "rgt", "depth")
+
+        # Consider each tree individually
+        for tree_id, nodes in groupby(qs, lambda x: x["tree_id"]):
+            stack = []
+            has_seen_root_node = False
+
+            for node in nodes:
+                if node["rgt"] <= node["lft"]:
+                    reversed_lft_rgt.append(node["pk"])
+                    continue
+
+                # pop any nodes from the stack that are strictly to the left of the current node
+                while stack and stack[-1]["rgt"] < node["lft"]:
+                    stack.pop()
+
+                if not stack:
+                    # this is a root node
+                    if has_seen_root_node:
+                        # we've already seen a root node with this tree_id, so this is a duplicate
+                        duplicate_tree_ids.append(node["pk"])
+                        # add this to stack so that we can check subsequent nodes,
+                        # but skip further checks for this node
+                        stack.append(node)
+                        continue
+                    else:
+                        has_seen_root_node = True
+                        stack.append(node)
+                else:
+                    # this is a child node; check that it is properly nested within its parent
+                    if node["lft"] <= stack[-1]["lft"] or stack[-1]["rgt"] <= node["rgt"]:
+                        overlapping_nodes.append(node["pk"])
+                        continue
+
+                    stack.append(node)
+
+                expected_depth = initial_depth + len(stack)
+                if node["depth"] != expected_depth:
+                    wrong_depth.append(node["pk"])
+
+        return reversed_lft_rgt, overlapping_nodes, duplicate_tree_ids, wrong_depth
 
     class Meta:
         """Abstract model."""


### PR DESCRIPTION
Add a `find_problems` method to `NS_Node`, similar to the existing one for `MP_Node`. This catches badly-nested `lft`/`rgt` ranges, incorrect `depth` values, and multiple root nodes with the same `tree_id`. Note that gaps in the `lft`/`rgt` sequence are _not_ considered a problem here.