### PR TITLE
 Fix NS_Node.add_child and add_sibling on inherited models 

### DIFF
--- a/docs/source/ns_tree.rst
+++ b/docs/source/ns_tree.rst
@@ -75,6 +75,24 @@ write/delete operations.
 
             This method returns a queryset.
 
+  .. automethod:: find_problems
+
+     .. note::
+
+        A node won't appear in more than one list, even when it exhibits
+        more than one problem. This method stops checking a node when it
+        finds a problem and continues to the next node.
+
+     .. note::
+
+        These problems can't be solved automatically.
+
+     Example:
+
+     .. code-block:: python
+
+        MyNodeModel.find_problems()
+
 
 .. autoclass:: NS_NodeManager
   :show-inheritance:

--- a/tests/test_treebeard.py
+++ b/tests/test_treebeard.py
@@ -129,6 +129,11 @@ def mpsmallstep_model(request):
     return request.param
 
 
+@pytest.fixture(scope="function", params=[models.NS_TestNode])
+def ns_model(request):
+    return request.param
+
+
 class TestTreeBase:
     def got(self, model):
         if model in [models.NS_TestNode, models.NS_TestNode_Proxy]:
@@ -2363,6 +2368,71 @@ class TestMP_TreeFindProblems(TestTreeBase):
         assert "03" in got(wrong_numchild)
         # "030102" reports numchild=10 which is wrong
         assert "030102" in got(wrong_numchild)
+
+
+@pytest.mark.django_db
+class TestNS_TreeFindProblems(TestTreeBase):
+    def test_find_problems_all_ok(self, ns_model):
+        ns_model(tree_id=1, lft=1, rgt=8, depth=1).save()
+        ns_model(tree_id=1, lft=2, rgt=5, depth=2).save()
+        ns_model(tree_id=1, lft=3, rgt=4, depth=3).save()
+        ns_model(tree_id=1, lft=6, rgt=7, depth=2).save()
+        ns_model(tree_id=2, lft=1, rgt=2, depth=1).save()
+
+        result = ns_model.find_problems()
+        assert result == ([], [], [], [])
+
+    def test_find_problems_reversed_lft_rgt(self, ns_model):
+        bad_node = ns_model(tree_id=1, lft=2, rgt=1, depth=1)
+        bad_node.save()
+
+        result = ns_model.find_problems()
+        assert result == ([bad_node.pk], [], [], [])
+
+    def test_find_problems_overlapping_nodes(self, ns_model):
+        ns_model(tree_id=1, lft=1, rgt=6, depth=1).save()
+        ns_model(tree_id=1, lft=2, rgt=4, depth=2).save()
+        bad_node = ns_model(tree_id=1, lft=3, rgt=5, depth=3)
+        bad_node.save()
+
+        result = ns_model.find_problems()
+        assert result == ([], [bad_node.pk], [], [])
+
+    def test_find_problems_duplicate_root(self, ns_model):
+        ns_model(tree_id=1, lft=1, rgt=8, depth=1).save()
+        ns_model(tree_id=1, lft=2, rgt=5, depth=2).save()
+        ns_model(tree_id=1, lft=3, rgt=4, depth=3).save()
+        ns_model(tree_id=1, lft=6, rgt=7, depth=2).save()
+        bad_node = ns_model(tree_id=1, lft=9, rgt=12, depth=1)
+        bad_node.save()
+        ns_model(tree_id=1, lft=10, rgt=11, depth=2).save()
+
+        result = ns_model.find_problems()
+        assert result == ([], [], [bad_node.pk], [])
+
+    def test_find_problems_wrong_depth(self, ns_model):
+        ns_model(tree_id=1, lft=1, rgt=8, depth=1).save()
+        bad_node_1 = ns_model(tree_id=1, lft=2, rgt=5, depth=1)
+        bad_node_1.save()
+        ns_model(tree_id=1, lft=3, rgt=4, depth=3).save()
+        ns_model(tree_id=1, lft=6, rgt=7, depth=2).save()
+        bad_node_2 = ns_model(tree_id=2, lft=1, rgt=2, depth=2)
+        bad_node_2.save()
+
+        result = ns_model.find_problems()
+        assert result == ([], [], [], [bad_node_1.pk, bad_node_2.pk])
+
+    def test_find_problems_within_parent(self, ns_model):
+        ns_model(tree_id=1, lft=1, rgt=8, depth=99).save()  # ignored
+        parent_node = ns_model(tree_id=1, lft=2, rgt=5, depth=2)
+        parent_node.save()
+        bad_node = ns_model(tree_id=1, lft=3, rgt=4, depth=99)
+        bad_node.save()
+        ns_model(tree_id=1, lft=6, rgt=7, depth=2).save()
+        ns_model(tree_id=2, lft=1, rgt=2, depth=99).save()  # ignored
+
+        result = ns_model.find_problems(parent=parent_node)
+        assert result == ([], [], [], [bad_node.pk])
 
 
 @pytest.mark.django_db

--- a/tests/test_treebeard.py
+++ b/tests/test_treebeard.py
@@ -155,6 +155,10 @@ class TestTreeBase:
         assert expected == got
         assert all(isinstance(obj[0], model) for obj in results)
 
+    def _assert_no_tree_problems(self, model):
+        if issubclass(model, (MP_Node, NS_Node)):
+            assert not any(model.find_problems())
+
 
 @pytest.mark.django_db
 class TestEmptyTree(TestTreeBase):
@@ -2102,9 +2106,7 @@ class TestInheritedModels(TestTreeBase):
 
         assert [node.desc for node in node1.get_children()] == ["21"]
         assert [node.desc for node in node21.get_children()] == ["211", "212"]
-
-        if issubclass(inherited_model, (MP_Node, NS_Node)):
-            assert not any(base_model.find_problems())
+        self._assert_no_tree_problems(base_model)
 
     def test_get_descendants_group_count(self, inherited_model):
         base_model = inherited_model.__bases__[0]
@@ -2125,10 +2127,7 @@ class TestInheritedModels(TestTreeBase):
         inherited_model.add_root(val1=2, val2=3, desc="A")
         inherited_model.add_root(val1=2, val2=3, desc="B")
         assert list(inherited_model.objects.values_list("desc", flat=True)) == ["B", "A"]
-
-        if issubclass(inherited_model, (MP_Node, NS_Node)):
-            base_model = inherited_model.__bases__[0]
-            assert not any(base_model.find_problems())
+        self._assert_no_tree_problems(inherited_model)
 
     def test_add_child(self, inherited_model):
         """
@@ -2145,9 +2144,7 @@ class TestInheritedModels(TestTreeBase):
         node213.add_child(desc="2131")
 
         assert [node.desc for node in node213.get_children()] == ["2131"]
-
-        if issubclass(inherited_model, (MP_Node, NS_Node)):
-            assert not any(base_model.find_problems())
+        self._assert_no_tree_problems(base_model)
 
     def test_add_sibling_to_root(self, inherited_model):
         base_model = inherited_model.__bases__[0]
@@ -2156,9 +2153,7 @@ class TestInheritedModels(TestTreeBase):
         node3.add_sibling("first-sibling", desc="0")
 
         assert [node.desc for node in base_model.get_root_nodes()] == ["0", "1", "2", "3"]
-
-        if issubclass(inherited_model, (MP_Node, NS_Node)):
-            assert not any(base_model.find_problems())
+        self._assert_no_tree_problems(base_model)
 
     def test_add_sibling_to_nonroot(self, inherited_model):
         base_model = inherited_model.__bases__[0]
@@ -2167,9 +2162,7 @@ class TestInheritedModels(TestTreeBase):
         node21.add_sibling("first-sibling", desc="20")
 
         assert [node.desc for node in base_model.objects.get(desc="2").get_children()] == ["20", "21", "22"]
-
-        if issubclass(inherited_model, (MP_Node, NS_Node)):
-            assert not any(base_model.find_problems())
+        self._assert_no_tree_problems(base_model)
 
 
 @pytest.mark.django_db

--- a/tests/test_treebeard.py
+++ b/tests/test_treebeard.py
@@ -2103,6 +2103,9 @@ class TestInheritedModels(TestTreeBase):
         assert [node.desc for node in node1.get_children()] == ["21"]
         assert [node.desc for node in node21.get_children()] == ["211", "212"]
 
+        if issubclass(inherited_model, (MP_Node, NS_Node)):
+            assert not any(base_model.find_problems())
+
     def test_get_descendants_group_count(self, inherited_model):
         base_model = inherited_model.__bases__[0]
         for node in base_model.get_descendants_group_count():
@@ -2122,6 +2125,51 @@ class TestInheritedModels(TestTreeBase):
         inherited_model.add_root(val1=2, val2=3, desc="A")
         inherited_model.add_root(val1=2, val2=3, desc="B")
         assert list(inherited_model.objects.values_list("desc", flat=True)) == ["B", "A"]
+
+        if issubclass(inherited_model, (MP_Node, NS_Node)):
+            base_model = inherited_model.__bases__[0]
+            assert not any(base_model.find_problems())
+
+    def test_add_child(self, inherited_model):
+        """
+        Calling add_child on an inherited model should update tree-related fields across all
+        nodes of the tree, not just ones that match the inherited model.
+        """
+        base_model = inherited_model.__bases__[0]
+
+        # We need a leaf node of inherited_model to test against, as non-leaves will delegate to add_sibling instead
+        node21 = inherited_model.objects.get(desc="21")
+        node213 = inherited_model(desc="213")
+        node21.add_child(instance=node213)
+
+        node213.add_child(desc="2131")
+
+        assert [node.desc for node in node213.get_children()] == ["2131"]
+
+        if issubclass(inherited_model, (MP_Node, NS_Node)):
+            assert not any(base_model.find_problems())
+
+    def test_add_sibling_to_root(self, inherited_model):
+        base_model = inherited_model.__bases__[0]
+
+        node3 = inherited_model.objects.get(desc="3")
+        node3.add_sibling("first-sibling", desc="0")
+
+        assert [node.desc for node in base_model.get_root_nodes()] == ["0", "1", "2", "3"]
+
+        if issubclass(inherited_model, (MP_Node, NS_Node)):
+            assert not any(base_model.find_problems())
+
+    def test_add_sibling_to_nonroot(self, inherited_model):
+        base_model = inherited_model.__bases__[0]
+
+        node21 = inherited_model.objects.get(desc="21")
+        node21.add_sibling("first-sibling", desc="20")
+
+        assert [node.desc for node in base_model.objects.get(desc="2").get_children()] == ["20", "21", "22"]
+
+        if issubclass(inherited_model, (MP_Node, NS_Node)):
+            assert not any(base_model.find_problems())
 
 
 @pytest.mark.django_db

--- a/treebeard/ns_tree.py
+++ b/treebeard/ns_tree.py
@@ -599,10 +599,10 @@ class NS_Node(Node):
         reversed_lft_rgt, overlapping_nodes, duplicate_tree_ids, wrong_depth = [], [], [], []
 
         # Iterate over the nodes in order of tree_id and lft
-        qs = qs.order_by("tree_id", "lft").values("pk", "tree_id", "lft", "rgt", "depth")
+        qs = qs.order_by("tree_id", "lft").values("pk", "tree_id", "lft", "rgt", "depth").iterator()
 
         # Consider each tree individually
-        for tree_id, nodes in groupby(qs, lambda x: x["tree_id"]):
+        for tree_id, nodes in groupby(qs, operator.itemgetter("tree_id")):
             stack = []
             has_seen_root_node = False
 

--- a/treebeard/ns_tree.py
+++ b/treebeard/ns_tree.py
@@ -169,8 +169,10 @@ class NS_Node(Node):
     def add_child(self, **kwargs):
         """Adds a child to the node."""
         # Fetch the parent afresh from the database and lock the row
-        # This guards against race conditions and state drift when adding multiple children
-        node = self.__class__.objects.filter(pk=self.pk).select_for_update().get()
+        # This guards against race conditions and state drift when adding multiple children,
+        # and also ensures that we're working with the base tree model in the case of inherited models
+        cls = self.tree_model()
+        node = cls.objects.filter(pk=self.pk).select_for_update().get()
         if not node.is_leaf():
             # there are child nodes, delegate insertion to add_sibling
             if self.node_order_by:
@@ -185,7 +187,7 @@ class NS_Node(Node):
             return new_sibling
 
         # we're adding the first child of this node
-        node.__class__._move_right(node.tree_id, node.rgt, False, 2)
+        cls._move_right(node.tree_id, node.rgt, False, 2)
 
         if len(kwargs) == 1 and "instance" in kwargs:
             # adding the passed (unsaved) instance to the tree
@@ -194,7 +196,7 @@ class NS_Node(Node):
                 raise NodeAlreadySaved("Attempted to add a tree node that is already in the database")
         else:
             # creating a new object
-            newobj = node.tree_model()(**kwargs)
+            newobj = cls(**kwargs)
 
         newobj.tree_id = node.tree_id
         newobj.depth = node.depth + 1
@@ -216,6 +218,7 @@ class NS_Node(Node):
         """Adds a new node as a sibling to the current node object."""
 
         pos = self._prepare_pos_var_for_add_sibling(pos)
+        cls = self.tree_model()
 
         if len(kwargs) == 1 and "instance" in kwargs:
             # adding the passed (unsaved) instance to the tree
@@ -224,7 +227,7 @@ class NS_Node(Node):
                 raise NodeAlreadySaved("Attempted to add a tree node that is already in the database")
         else:
             # creating a new object
-            newobj = self.tree_model()(**kwargs)
+            newobj = cls(**kwargs)
 
         newobj.depth = self.depth
 
@@ -241,12 +244,12 @@ class NS_Node(Node):
                 else:
                     pos = "last-sibling"
 
-            last_root = target.__class__.get_last_root_node()
+            last_root = cls.get_last_root_node()
             if (pos == "last-sibling") or (pos == "right" and target == last_root):
                 newobj.tree_id = last_root.tree_id + 1
             else:
                 newpos = {"first-sibling": 1, "left": target.tree_id, "right": target.tree_id + 1}[pos]
-                target.__class__._move_tree_right(newpos)
+                cls._move_tree_right(newpos)
 
                 newobj.tree_id = newpos
         else:
@@ -281,7 +284,7 @@ class NS_Node(Node):
                 if pos == "first-sibling":
                     target = siblings[0]
 
-            move_right = self.__class__._move_right
+            move_right = cls._move_right
 
             if pos == "last-sibling":
                 newpos = target.get_parent().rgt

--- a/treebeard/ns_tree.py
+++ b/treebeard/ns_tree.py
@@ -2,6 +2,7 @@
 
 import operator
 from functools import reduce
+from itertools import groupby
 
 from django.core import serializers
 from django.db import models, transaction
@@ -560,6 +561,82 @@ class NS_Node(Node):
     def get_root_nodes(cls):
         """:returns: A queryset containing the root nodes in the tree."""
         return cls.tree_model().objects.filter(lft=1)
+
+    @classmethod
+    def find_problems(cls, parent=None):
+        """
+        Checks for inconsistencies in the tree structure.
+
+        :param parent:
+
+            If provided, limits the check to the descendants of this node.
+            If not provided, the entire tree will be checked.
+
+        :returns: A tuple of four lists:
+
+                  1. a list of ids of nodes where ``rgt`` is not strictly
+                     greater than ``lft``
+                  2. a list of ids of nodes where the ``lft`` and ``rgt``
+                     values partially overlap with another node (i.e. they are
+                     not properly nested)
+                  3. a list of ids of root-level nodes that have the same
+                     ``tree_id`` as another root-level node
+                  4. a list of ids of nodes with the wrong depth value for
+                     their nesting level as defined by ``lft`` and ``rgt``
+        """
+        cls = cls.tree_model()
+
+        if parent is not None:
+            qs = cls.objects.filter(tree_id=parent.tree_id, lft__gte=parent.lft, rgt__lte=parent.rgt)
+            initial_depth = parent.get_ancestors().count()
+        else:
+            qs = cls.objects.all()
+            initial_depth = 0
+
+        reversed_lft_rgt, overlapping_nodes, duplicate_tree_ids, wrong_depth = [], [], [], []
+
+        # Iterate over the nodes in order of tree_id and lft
+        qs = qs.order_by("tree_id", "lft").values("pk", "tree_id", "lft", "rgt", "depth")
+
+        # Consider each tree individually
+        for tree_id, nodes in groupby(qs, lambda x: x["tree_id"]):
+            stack = []
+            has_seen_root_node = False
+
+            for node in nodes:
+                if node["rgt"] <= node["lft"]:
+                    reversed_lft_rgt.append(node["pk"])
+                    continue
+
+                # pop any nodes from the stack that are strictly to the left of the current node
+                while stack and stack[-1]["rgt"] < node["lft"]:
+                    stack.pop()
+
+                if not stack:
+                    # this is a root node
+                    if has_seen_root_node:
+                        # we've already seen a root node with this tree_id, so this is a duplicate
+                        duplicate_tree_ids.append(node["pk"])
+                        # add this to stack so that we can check subsequent nodes,
+                        # but skip further checks for this node
+                        stack.append(node)
+                        continue
+                    else:
+                        has_seen_root_node = True
+                        stack.append(node)
+                else:
+                    # this is a child node; check that it is properly nested within its parent
+                    if node["lft"] <= stack[-1]["lft"] or stack[-1]["rgt"] <= node["rgt"]:
+                        overlapping_nodes.append(node["pk"])
+                        continue
+
+                    stack.append(node)
+
+                expected_depth = initial_depth + len(stack)
+                if node["depth"] != expected_depth:
+                    wrong_depth.append(node["pk"])
+
+        return reversed_lft_rgt, overlapping_nodes, duplicate_tree_ids, wrong_depth
 
     class Meta:
         """Abstract model."""


### PR DESCRIPTION
The `add_child` and `add_sibling` methods on `NS_Node` did not properly account for model inheritance, as the queries for updating `lft`/`rgt`/`tree_id` across the tree were being run against the class of the initial instance, rather than the base model. As a result, `some_node.add_child(...)` will fail to update those fields on nodes that do not match the specific class of `some_node`.

Incorporates #387 for testing.