### PR TITLE
Fix node paths being incremented during noop move operations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+Next release (in development)
+-----------------------------
+
+* Fixed `MP_Node` paths being incremented unnecessarily when saving nodes with `node_order_by` in the admin.
+* Optimised `MoveNodeForm` to skip move logic if no treebeard-specific fields were modified.
+
+
 Release 5.1.0 (May 12, 2026)
 ----------------------------
 

--- a/tests/test_treebeard.py
+++ b/tests/test_treebeard.py
@@ -129,6 +129,11 @@ def mpsmallstep_model(request):
     return request.param
 
 
+@pytest.fixture(scope="function", params=[models.MP_TestSortedNodeShortPath])
+def mpsorted_model(request):
+    return request.param
+
+
 @pytest.fixture(scope="function", params=[models.NS_TestNode])
 def ns_model(request):
     return request.param
@@ -2240,6 +2245,44 @@ class TestHelpers(TestTreeBase):
 
 
 @pytest.mark.django_db
+class TestMP_Tree(TestTreeBase):
+    """
+    Tests specific to MP_Tree behaviour.
+    """
+
+    def test_sorted_sibling_move_noop_path_not_changed(self, mpsorted_model):
+        # Regression test for https://github.com/django-treebeard/django-treebeard/issues/389
+        # A noop on a sorted-sibling should not increment the path of siblings
+        node = mpsorted_model.add_root(desc="A")
+        old_path = node.path
+        node.move(node, "sorted-sibling")
+        assert node.path == old_path
+
+        node2 = mpsorted_model.add_root(desc="B")
+        node.move(node2, "sorted-sibling")
+        assert node.path == old_path
+
+    def test_sorted_sibling_path(self, mpsorted_model):
+        # Regression test for https://github.com/django-treebeard/django-treebeard/issues/389
+        node1 = mpsorted_model.add_root(desc="B")
+        node2 = mpsorted_model.add_root(desc="C")
+
+        # Update node2 sorted field and then move it
+        node2.desc = "A"
+        node2.save()
+        node2.move(node1, "sorted-sibling")
+        assert node2.path == "1"
+        assert node1.path == "2"
+
+    def test_short_path(self, mpshortnotsorted_model):
+        """Test a tree with a very small path field (max_length=4) and a steplen of 1"""
+        obj = mpshortnotsorted_model.add_root()
+        obj = obj.add_child().add_child().add_child()
+        with pytest.raises(PathOverflow):
+            obj.add_child()
+
+
+@pytest.mark.django_db
 class TestMP_TreeSortedAutoNow(TestTreeBase):
     """
     Auto-populated fields cannot be used with node_order_by, because we need
@@ -2305,19 +2348,6 @@ class TestMP_TreeStepOverflow(TestTreeBase):
             for pos in positions:
                 with pytest.raises(PathOverflow):
                     newroot.move(target, pos)
-
-
-@pytest.mark.django_db
-class TestMP_TreeShortPath(TestTreeBase):
-    """Test a tree with a very small path field (max_length=4) and a
-    steplen of 1
-    """
-
-    def test_short_path(self, mpshortnotsorted_model):
-        obj = mpshortnotsorted_model.add_root()
-        obj = obj.add_child().add_child().add_child()
-        with pytest.raises(PathOverflow):
-            obj.add_child()
 
 
 @pytest.mark.django_db

--- a/tests/test_treebeard.py
+++ b/tests/test_treebeard.py
@@ -2669,7 +2669,7 @@ class TestMP_TreeFix(TestTreeBase):
 
 
 @pytest.mark.django_db
-class TestMoveNodeForm(TestNonEmptyTree):
+class TestMoveNodeForm:
     def _get_nodes_list(self, nodes):
         return [(str(pk), f"{'&nbsp;' * 4 * (depth - 1)}{_str}") for pk, _str, depth in nodes]
 
@@ -2716,6 +2716,62 @@ class TestMoveNodeForm(TestNonEmptyTree):
             form = ma.get_form(request)()
             nodes = self._get_nodes_list(safe_parent_nodes)
             self._assert_nodes_in_choices(form, nodes)
+
+    def test_skips_move_if_no_change(self, model_without_data):
+        parent = model_without_data.add_root(desc="A")
+        child = parent.add_child(desc="B")
+        form_class = movenodeform_factory(model_without_data)
+        form = form_class(
+            instance=child, data={"desc": "B", "treebeard_position": "first-child", "treebeard_ref_node": parent.pk}
+        )
+        assert form.is_valid()
+        with mock.patch.object(model_without_data, "move") as mock_move:
+            form.save()
+            mock_move.assert_not_called()
+
+        # Now change the reference node - should trigger a move
+        form = form_class(
+            instance=child, data={"desc": "B", "treebeard_position": "first-child", "treebeard_ref_node": None}
+        )
+        assert form.is_valid()
+        with mock.patch.object(model_without_data, "move") as mock_move:
+            form.save()
+            mock_move.assert_called_once()
+
+    def test_skips_move_if_no_change_node_order_by(self, sorted_model):
+        parent = sorted_model.add_root(desc="A", val1=1, val2=1)
+        child = parent.add_child(desc="B", val1=3, val2=4)
+        form_class = movenodeform_factory(sorted_model)
+        form = form_class(
+            instance=child,
+            data={
+                "desc": "B",
+                "val1": 3,
+                "val2": 4,
+                "treebeard_position": "sorted-child",
+                "treebeard_ref_node": parent.pk,
+            },
+        )
+        assert form.is_valid()
+        with mock.patch.object(sorted_model, "move") as mock_move:
+            form.save()
+            mock_move.assert_not_called()
+
+        # Now change the reference node - should trigger a move
+        form = form_class(
+            instance=child,
+            data={
+                "desc": "B",
+                "val1": 10,
+                "val2": 4,
+                "treebeard_position": "sorted-child",
+                "treebeard_ref_node": parent.pk,
+            },
+        )
+        assert form.is_valid()
+        with mock.patch.object(sorted_model, "move") as mock_move:
+            form.save()
+            mock_move.assert_called_once()
 
 
 @pytest.mark.django_db

--- a/treebeard/forms.py
+++ b/treebeard/forms.py
@@ -160,6 +160,15 @@ class MoveNodeForm(forms.ModelForm):
         reference_node = self.cleaned_data.pop("treebeard_ref_node", None)
         position_type = self.cleaned_data.pop("treebeard_position")
 
+        # If no treebeard fields have been modified, skip treebeard-specific logic and delegate to parent class
+        treebeard_fields = {
+            "treebeard_ref_node",
+            "treebeard_position",
+            *(self.instance.tree_model().node_order_by or []),
+        }
+        if not set(self.changed_data) & treebeard_fields:
+            return super().save(commit=commit)
+
         if self.instance._state.adding:
             if reference_node:
                 self.instance = reference_node.add_child(instance=self.instance)

--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -351,8 +351,6 @@ class MP_MoveHandler(MP_ComplexAddMoveHandler):
     def process(self):
         self.pos = self.node._prepare_pos_var_for_move(self.pos)
 
-        oldpath = self.node.path
-
         # initialize variables and if moving to a child, updates "move to
         # child" to become a "move to sibling" if possible (if it can't
         # be done, it means that we are  adding the first child)
@@ -361,24 +359,35 @@ class MP_MoveHandler(MP_ComplexAddMoveHandler):
         if self.target.is_descendant_of(self.node):
             raise InvalidMoveToDescendant(_("Can't move node to a descendant."))
 
-        if oldpath == self.target.path and (
-            (self.pos == "left")
-            or (self.pos in ("right", "last-sibling") and self.target.path == self.target.get_last_sibling().path)
-            or (self.pos == "first-sibling" and self.target.path == self.target.get_first_sibling().path)
-        ):
-            # special cases, not actually moving the node so no need to UPDATE
-            return
-
         if self.pos == "sorted-sibling":
             siblings = self.node.get_sorted_pos_queryset(self.target.get_siblings(), self.node)
-            first = siblings.first()
-            newpos = first._get_lastpos_in_path() if first else None
-            if newpos is None:
+            if first := siblings.first():
+                newpos = first._get_lastpos_in_path()
+                if self.node._get_lastpos_in_path() == newpos - 1:
+                    # The node is already in the right place, nothing to do
+                    return
+            else:
+                newpos = None
                 self.pos = "last-sibling"
 
-        # generate the sql that will do the actual moving of nodes
+        # Handle special cases where nothing needs to be done
+        if newdepth == self.node.get_depth():
+            if self.pos == "first-sibling" and self.node == self.target.get_first_sibling():
+                return
+
+            if self.pos == "last-sibling" and self.node == self.target.get_last_sibling():
+                return
+
+        if self.node == self.target and (
+            # Moving a node to left/right of itself is a noop
+            self.pos == "left"
+            or (self.pos in ("right", "last-sibling") and self.target == self.target.get_last_sibling())
+        ):
+            return
+
+        # Move nodes
         oldpath, newpath = self.reorder_nodes_before_add_or_move(
-            self.pos, newpos, newdepth, self.target, siblings, oldpath, True
+            self.pos, newpos, newdepth, self.target, siblings, self.node.path, True
         )
 
         self.update_parent_counts_after_move(oldpath, newpath)


### PR DESCRIPTION
PR has two commits:

- First fixes handling of noop move operations for MP_Nodes with node_order_by so that the paths of these nodes are not incremented when the node doesn't require moving. Also cleans up logic for short-circuit during move to make it easier to understand. Some comments inline.

- Second modifies the form used in the admin to just skip all treebeard-specific logic entirely unless the fields treebeard cares about have changed. The queries for moving nodes are expensive and we shouldn't run them if we know nothing has changed.

Fixes #389