### PR TITLE
ltree: Do not update non-sibling paths in _move_subtree_right

### DIFF
--- a/tests/models.py
+++ b/tests/models.py
@@ -205,6 +205,8 @@ INHERITED_MODELS_WITH_SORT = [
     (MP_TestNodeSorted, MP_TestNodeInheritedSorted),
 ]
 
+LT_BASE_MODELS = []
+
 if os.environ.get("DATABASE_ENGINE", "") == "psql":
 
     class LT_TestNode(LT_Node, DescMixin): ...
@@ -232,3 +234,4 @@ if os.environ.get("DATABASE_ENGINE", "") == "psql":
     INHERITED_MODELS.append((LT_TestNode, LT_TestNodeInherited))
     SORTED_MODELS.append(LT_TestNodeSorted)
     INHERITED_MODELS_WITH_SORT.append((LT_TestNodeSorted, LT_TestNodeInheritedSorted))
+    LT_BASE_MODELS.append(LT_TestNode)

--- a/tests/test_treebeard.py
+++ b/tests/test_treebeard.py
@@ -139,6 +139,11 @@ def ns_model(request):
     return request.param
 
 
+@pytest.fixture(scope="function", params=models.LT_BASE_MODELS)
+def lt_model(request):
+    return request.param
+
+
 class TestTreeBase:
     def got(self, model):
         if model in [models.NS_TestNode, models.NS_TestNode_Proxy]:
@@ -3372,3 +3377,35 @@ class TestMP_TreeDescendantsPerformance(TestTreeBase):
             with django_assert_num_queries(expected):
                 # converting to list to force queryset evaluation
                 list(node.get_descendants())
+
+
+@pytest.mark.django_db
+class TestLT_Insertion(TestTreeBase):
+    def test_move_right(self, lt_model):
+        node_a = lt_model.add_root(desc="A")
+        node_b = lt_model.add_root(desc="B")
+        node_a_a = node_a.add_child(desc="A.A")
+        node_a_a.add_child(desc="A.A.A")
+        node_b.add_child(desc="B.A")
+
+        expected_paths = ["A", "A.A", "A.A.A", "B", "B.A"]
+        actual_paths = [str(node.path) for node in lt_model.objects.all()]
+        assert actual_paths == expected_paths
+
+        # A sibling inserted before A.A gets path A.0; other paths are unchanged
+        node_a_0 = node_a_a.add_sibling("first-sibling", desc="A.0")
+        expected_paths = ["A", "A.0", "A.A", "A.A.A", "B", "B.A"]
+        actual_paths = [str(node.path) for node in lt_model.objects.all()]
+        assert actual_paths == expected_paths
+
+        # A sibling inserted before A.0 causes existing siblings to be moved right (i.e. 'A' appended to their labels)
+        new_node_a_0 = node_a_0.add_sibling("first-sibling", desc="new A.0")
+        assert str(new_node_a_0.path) == "A.0"
+        node_a_0.refresh_from_db()
+        assert str(node_a_0.path) == "A.0A"
+        node_a_a.refresh_from_db()
+        assert str(node_a_a.path) == "A.AA"
+
+        expected_paths = ["A", "A.0", "A.0A", "A.AA", "A.AA.A", "B", "B.A"]
+        actual_paths = [str(node.path) for node in lt_model.objects.all()]
+        assert actual_paths == expected_paths

--- a/treebeard/ltree/__init__.py
+++ b/treebeard/ltree/__init__.py
@@ -163,19 +163,23 @@ class LT_ComplexAddMoveHandler:
 
     def _move_subtree_right(self, start_node):
         """
-        Move the node and everything after it in the tree to the right. This is achieved simply by
+        Move the node and all siblings after it in the tree to the right. This is achieved simply by
         appending an extra character (A) to the topmost label in the path.
         """
         result_class = self.node_cls.tree_model()
         node_depth = len(start_node.path)
         if node_depth > 1:
-            result_class.objects.filter(path__gte=start_node.path, path__depth=node_depth).update(
+            result_class.objects.filter(
+                path__descendants=start_node.path[:-1], path__gte=start_node.path, path__depth=node_depth
+            ).update(
                 path=Concat(
                     Subpath(F("path"), 0, node_depth - 1),
                     Text2LTree(Concat(Ltree2Text(Subpath(F("path"), node_depth - 1, 1)), Value("A"))),
                 )
             )
-            result_class.objects.filter(path__gte=start_node.path, path__depth__gt=node_depth).update(
+            result_class.objects.filter(
+                path__descendants=start_node.path[:-1], path__gte=start_node.path, path__depth__gt=node_depth
+            ).update(
                 path=Concat(
                     Subpath(F("path"), 0, node_depth - 1),
                     Text2LTree(Concat(Ltree2Text(Subpath(F("path"), node_depth - 1, 1)), Value("A"))),


### PR DESCRIPTION
The `_move_subtree_right` method (which increments the path labels of nodes so that a sibling can be inserted before them where no gap exists in the lexicographic ordering) failed to limit the update to siblings of the new node; as a result, nodes at the same depth in entirely different subtrees were being redundantly updated.