### PR TITLE
Add signals for bulk updates on MP_Node, NS_Node, LT_Node

### DIFF
--- a/docs/source/ltree.rst
+++ b/docs/source/ltree.rst
@@ -112,5 +112,71 @@ To use the ``ltree`` module, you need to create the extension in your database:
 .. autoclass:: LT_NodeQuerySet
   :show-inheritance:
 
+Signals
+-------
+
+The :mod:`treebeard.ltree` module defines several signals that are sent when
+bulk updates are made to the tree. Along with the standard Django ``post_save``
+and ``post_delete`` signals that track changes to individual node instances,
+these can be used to keep external data stores such as search indexes in sync
+with the tree.
+
+.. attribute:: subtree_moved_right
+
+   Sent after a bulk update has been performed to increment existing path
+   values to allow inserting a sibling node, with the following arguments:
+
+   ``sender``
+      The model class where the update occurred.
+
+   ``path``
+      A :class:`treebeard.ltree.PathValue` indicating the first path updated.
+      The update operation applies to the node with this path, siblings after
+      it (i.e. nodes where all path elements are equal except the last, which
+      is greater), and all their descendants. For the targeted node and its
+      siblings, the update operation appends an 'A' to the last element of the
+      path; for example, the path ``A.C.B`` becomes ``A.C.BA``. For their
+      descendants, the path elements following the incremented one are
+      unchanged; for example, the path ``A.C.B.D`` becomes ``A.C.BA.D``.
+
+   ``using``
+      The database alias being used.
+
+.. attribute:: subtree_moved
+
+   Sent after a bulk update has been performed to update the paths of a node
+   and its descendants, with the following arguments:
+
+   ``sender``
+      The model class where the update occurred.
+
+   ``old_path``
+      A :class:`treebeard.ltree.PathValue` indicating the old path of the
+      topmost node before the update. The update operation applies to all nodes
+      with this path as a prefix.
+
+   ``new_path``
+      A :class:`treebeard.ltree.PathValue` indicating the new path of the
+      topmost node after the update. For all nodes in the update, the
+      prefix ``old_path`` is replaced with ``new_path``.
+
+   ``using``
+      The database alias being used.
+
+.. attribute:: nodes_deleted
+
+   Sent after one or more nodes are deleted, with the following arguments:
+
+   ``sender``
+      The model class where the deletion occurred.
+
+   ``paths_to_remove``
+      A list of :class:`treebeard.ltree.PathValue` instances indicating the
+      paths of the nodes that were deleted (along with their descendants). All
+      nodes that have any of these paths as a prefix were deleted.
+
+   ``using``
+      The database alias being used.
+
 
 .. _`ltree`: https://www.postgresql.org/docs/18/ltree.html

--- a/docs/source/mp_tree.rst
+++ b/docs/source/mp_tree.rst
@@ -266,7 +266,55 @@ extra steps, materialized path is more efficient than other approaches.
 .. autoclass:: MP_NodeQuerySet
   :show-inheritance:
 
+Signals
+-------
 
+The :mod:`treebeard.mp_tree` module defines several signals that are sent when
+bulk updates are made to the tree. Along with the standard Django ``post_save``
+and ``post_delete`` signals that track changes to individual node instances,
+these can be used to keep external data stores such as search indexes in sync
+with the tree.
+
+.. attribute:: path_updated
+
+   Sent after a bulk update has been performed to update the paths of a node
+   and its descendants, with the following arguments:
+
+   ``sender``
+      The model class where the update occurred.
+
+   ``old_path``
+      The old path of the topmost node before the update. The update operation
+      applies to all nodes whose path starts with this value.
+
+   ``new_path``
+      The new path of the topmost node after the update. All nodes in the
+      update operation have had the prefix ``old_path`` replaced with
+      ``new_path``. Note that if these paths are of different lengths, the
+      depth of the nodes has also been updated accordingly.
+
+   ``using``
+      The database alias being used.
+
+.. attribute:: nodes_deleted
+
+   Sent after one or more nodes are deleted, with the following arguments:
+
+   ``sender``
+      The model class where the deletion occurred.
+
+   ``pks_to_remove``
+      A list of primary keys of leaf nodes that were deleted. These are passed
+      as a separate list to the non-leaf nodes as it is more efficient to
+      delete these by primary key rather than by path.
+
+   ``paths_to_remove``
+      A list of paths of non-leaf nodes that were deleted (along with their
+      descendants). All nodes with a path that starts with any of these values
+      were deleted.
+
+   ``using``
+      The database alias being used.
 
 .. _`Vadim Tropashko`: http://vadimtropashko.wordpress.com/
 .. _`SQL Design Patterns`: http://www.rampant-books.com/book_2006_1_sql_coding_styles.htm

--- a/docs/source/ns_tree.rst
+++ b/docs/source/ns_tree.rst
@@ -100,7 +100,99 @@ write/delete operations.
 .. autoclass:: NS_NodeQuerySet
   :show-inheritance:
 
+Signals
+-------
 
+The :mod:`treebeard.ns_tree` module defines several signals that are sent when
+bulk updates are made to the tree. Along with the standard Django ``post_save``
+and ``post_delete`` signals that track changes to individual node instances,
+these can be used to keep external data stores such as search indexes in sync
+with the tree.
+
+.. attribute:: gap_altered
+
+   Sent after a bulk update has been performed to expand or shrink a gap in
+   the ``lft``/``rgt`` sequence, with the following arguments:
+
+   ``sender``
+      The model class where the update occurred.
+
+   ``tree_id``
+      The tree ID of the tree that was updated.
+
+   ``start_index``
+      The starting index of the update. All ``lft`` and ``rgt`` values greater
+      than or equal to this index, within the tree identified by ``tree_id``,
+      were incremented or decremented by ``offset``.
+
+   ``offset``
+      The amount by which the gap was expanded (positive) or shrunk (negative).
+
+   ``using``
+      The database alias being used.
+
+.. attribute:: tree_ids_incremented
+
+   Sent after a bulk update has been performed to increment tree IDs to allow a
+   new root-level node to be inserted, with the following arguments:
+
+   ``sender``
+      The model class where the update occurred.
+
+   ``min_tree_id``
+      The starting tree ID of the update. All tree IDs greater than or equal to
+      this value were incremented by 1.
+
+   ``using``
+      The database alias being used.
+
+.. attribute:: subtree_moved
+
+   Sent after a bulk update has been performed to move a subtree, with the
+   following arguments:
+
+   ``sender``
+      The model class where the update occurred.
+
+   ``tree_id``
+      The tree ID of the tree that the subtree was moved from.
+
+   ``lft``
+      The initial left value of the topmost node that was moved.
+
+   ``rgt``
+      The initial right value of the topmost node that was moved. The update
+      operation applies to all nodes in the tree ``tree_id`` with left values
+      greater than or equal to ``lft`` and right values less than or equal to
+      ``rgt``.
+
+   ``target_tree_id``
+      The tree ID of the target tree where the subtree was moved to.
+
+   ``index_offset``
+      The amount by which the left and right values of the moved nodes were
+      incremented (positive) or decremented (negative) during the move.
+
+   ``depth_offset``
+      The amount by which the ``depth`` of the moved nodes was changed during
+      the move.
+
+   ``using``
+      The database alias being used.
+
+.. attribute:: nodes_deleted
+
+   Sent after one or more nodes are deleted, with the following arguments:
+
+   ``sender``
+      The model class where the deletion occurred.
+
+   ``removed_ranges``
+      A list of tuples, each containing the tree ID, left value, and right
+      value of a contiguous range of nodes that were deleted.
+
+   ``using``
+      The database alias being used.
 
 .. _`Joe Celko`: http://en.wikipedia.org/wiki/Joe_Celko
 .. _`Trees and Hierarchies in SQL for Smarties`:

--- a/tests/test_treebeard.py
+++ b/tests/test_treebeard.py
@@ -34,7 +34,7 @@ from treebeard.exceptions import (
 )
 from treebeard.forms import movenodeform_factory
 from treebeard.mp_tree import MP_Node, path_updated
-from treebeard.ns_tree import NS_Node
+from treebeard.ns_tree import NS_Node, gap_altered, subtree_moved, tree_ids_incremented
 from treebeard.templatetags.admin_tree import tree_context
 
 admin_register_all()
@@ -152,11 +152,41 @@ def capture_signals():
     def path_updated_handler(sender, **kwargs):
         calls.append(("path_updated", sender, kwargs["old_path"], kwargs["new_path"], kwargs["using"]))
 
+    def gap_altered_handler(sender, **kwargs):
+        calls.append(
+            ("gap_altered", sender, kwargs["tree_id"], kwargs["start_index"], kwargs["offset"], kwargs["using"])
+        )
+
+    def tree_ids_incremented_handler(sender, **kwargs):
+        calls.append(("tree_ids_incremented", sender, kwargs["min_tree_id"], kwargs["using"]))
+
+    def subtree_moved_handler(sender, **kwargs):
+        calls.append(
+            (
+                "subtree_moved",
+                sender,
+                kwargs["tree_id"],
+                kwargs["lft"],
+                kwargs["rgt"],
+                kwargs["target_tree_id"],
+                kwargs["index_offset"],
+                kwargs["depth_offset"],
+                kwargs["using"],
+            )
+        )
+
     path_updated.connect(path_updated_handler)
+    gap_altered.connect(gap_altered_handler)
+    tree_ids_incremented.connect(tree_ids_incremented_handler)
+    subtree_moved.connect(subtree_moved_handler)
+
     try:
         yield calls
     finally:
         path_updated.disconnect(path_updated_handler)
+        gap_altered.disconnect(gap_altered_handler)
+        tree_ids_incremented.disconnect(tree_ids_incremented_handler)
+        subtree_moved.disconnect(subtree_moved_handler)
 
 
 class TestTreeBase:
@@ -802,7 +832,8 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
 @pytest.mark.django_db
 class TestAddChild(TestNonEmptyTree):
     def test_add_child_to_leaf(self, model):
-        model.objects.get(desc="231").add_child(desc="2311")
+        with capture_signals() as signals:
+            model.objects.get(desc="231").add_child(desc="2311")
         expected = [
             ("1", 1, 0),
             ("2", 1, 4),
@@ -817,9 +848,16 @@ class TestAddChild(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            assert signals == []
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("gap_altered", model, 2, 8, 2, "default"),
+            ]
 
     def test_add_child_to_node(self, model):
-        model.objects.get(desc="2").add_child(desc="25")
+        with capture_signals() as signals:
+            model.objects.get(desc="2").add_child(desc="25")
         expected = [
             ("1", 1, 0),
             ("2", 1, 5),
@@ -834,10 +872,17 @@ class TestAddChild(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            assert signals == []
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("gap_altered", model, 2, 12, 2, "default"),
+            ]
 
     def test_add_child_with_passed_instance(self, model):
         child = model(desc="2311")
-        result = model.objects.get(desc="231").add_child(instance=child)
+        with capture_signals() as signals:
+            result = model.objects.get(desc="231").add_child(instance=child)
         assert result == child
         expected = [
             ("1", 1, 0),
@@ -853,6 +898,12 @@ class TestAddChild(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            assert signals == []
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("gap_altered", model, 2, 8, 2, "default"),
+            ]
 
     def test_add_child_called_consecutively(self, model_without_data):
         # Regression test for https://github.com/django-treebeard/django-treebeard/issues/307
@@ -945,6 +996,8 @@ class TestAddSibling(TestNonEmptyTree):
         assert node_wchildren.get_last_sibling().desc == "5"
         if issubclass(model, MP_Node):
             assert signals == []
+        elif issubclass(model, NS_Node):
+            assert signals == []
 
     def test_add_sibling_last(self, model):
         node = model.objects.get(desc="231")
@@ -954,6 +1007,10 @@ class TestAddSibling(TestNonEmptyTree):
         assert node.get_last_sibling().desc == "232"
         if issubclass(model, MP_Node):
             assert signals == []
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("gap_altered", model, 2, 9, 2, "default"),
+            ]
 
     def test_add_sibling_first_root(self, model):
         node_wchildren = model.objects.get(desc="2")
@@ -992,6 +1049,10 @@ class TestAddSibling(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("tree_ids_incremented", model, 1, "default"),
+            ]
 
     def test_add_sibling_first(self, model):
         node_wchildren = model.objects.get(desc="23")
@@ -1030,6 +1091,10 @@ class TestAddSibling(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("gap_altered", model, 2, 2, 2, "default"),
+            ]
 
     def test_add_sibling_left_root(self, model):
         node_wchildren = model.objects.get(desc="2")
@@ -1066,6 +1131,10 @@ class TestAddSibling(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("tree_ids_incremented", model, 2, "default"),
+            ]
 
     def test_add_sibling_left(self, model):
         node_wchildren = model.objects.get(desc="23")
@@ -1100,6 +1169,10 @@ class TestAddSibling(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("gap_altered", model, 2, 6, 2, "default"),
+            ]
 
     def test_add_sibling_left_noleft_root(self, model):
         node = model.objects.get(desc="1")
@@ -1138,6 +1211,10 @@ class TestAddSibling(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("tree_ids_incremented", model, 1, "default"),
+            ]
 
     def test_add_sibling_left_noleft(self, model):
         node = model.objects.get(desc="231")
@@ -1170,6 +1247,10 @@ class TestAddSibling(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("gap_altered", model, 2, 7, 2, "default"),
+            ]
 
     def test_add_sibling_right_root(self, model):
         node_wchildren = model.objects.get(desc="2")
@@ -1204,6 +1285,10 @@ class TestAddSibling(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("tree_ids_incremented", model, 3, "default"),
+            ]
 
     def test_add_sibling_right(self, model):
         node_wchildren = model.objects.get(desc="23")
@@ -1237,6 +1322,10 @@ class TestAddSibling(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("gap_altered", model, 2, 10, 2, "default"),
+            ]
 
     def test_add_sibling_right_noright_root(self, model):
         node = model.objects.get(desc="4")
@@ -1258,6 +1347,8 @@ class TestAddSibling(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
         if issubclass(model, MP_Node):
+            assert signals == []
+        elif issubclass(model, NS_Node):
             assert signals == []
 
     def test_add_sibling_right_noright(self, model):
@@ -1281,6 +1372,10 @@ class TestAddSibling(TestNonEmptyTree):
         assert self.got(model) == expected
         if issubclass(model, MP_Node):
             assert signals == []
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("gap_altered", model, 2, 9, 2, "default"),
+            ]
 
     def test_add_sibling_with_passed_instance(self, model):
         node_wchildren = model.objects.get(desc="2")
@@ -1323,7 +1418,8 @@ class TestDelete(TestTreeBase):
 
     def test_delete_leaf(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
-        result = delete_model.objects.get(desc="231").delete()
+        with capture_signals() as signals:
+            result = delete_model.objects.get(desc="231").delete()
         expected = [
             ("1", 1, 0),
             ("2", 1, 4),
@@ -1337,10 +1433,17 @@ class TestDelete(TestTreeBase):
         ]
         assert self.got(delete_model) == expected
         assert result == (2, {delete_model._meta.label: 1, dep_model._meta.label: 1})
+        if issubclass(delete_model, MP_Node):
+            assert signals == []
+        elif issubclass(delete_model, NS_Node):
+            assert signals == [
+                ("gap_altered", delete_model, 2, 7, -2, "default"),
+            ]
 
     def test_delete_node(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
-        result = delete_model.objects.get(desc="23").delete()
+        with capture_signals() as signals:
+            result = delete_model.objects.get(desc="23").delete()
         expected = [
             ("1", 1, 0),
             ("2", 1, 3),
@@ -1353,52 +1456,93 @@ class TestDelete(TestTreeBase):
         ]
         assert self.got(delete_model) == expected
         assert result == (4, {delete_model._meta.label: 2, dep_model._meta.label: 2})
+        if issubclass(delete_model, MP_Node):
+            assert signals == []
+        elif issubclass(delete_model, NS_Node):
+            assert signals == [
+                ("gap_altered", delete_model, 2, 6, -4, "default"),
+            ]
 
     def test_delete_root(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
-        result = delete_model.objects.get(desc="2").delete()
+        with capture_signals() as signals:
+            result = delete_model.objects.get(desc="2").delete()
         expected = [("1", 1, 0), ("3", 1, 0), ("4", 1, 1), ("41", 2, 0)]
         assert self.got(delete_model) == expected
         assert result == (12, {delete_model._meta.label: 6, dep_model._meta.label: 6})
+        if issubclass(delete_model, MP_Node):
+            assert signals == []
+        elif issubclass(delete_model, NS_Node):
+            assert signals == []
 
     def test_delete_filter_root_nodes(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
-        result = delete_model.objects.filter(desc__in=("2", "3")).delete()
+        with capture_signals() as signals:
+            result = delete_model.objects.filter(desc__in=("2", "3")).delete()
         expected = [("1", 1, 0), ("4", 1, 1), ("41", 2, 0)]
         assert self.got(delete_model) == expected
         assert result == (14, {delete_model._meta.label: 7, dep_model._meta.label: 7})
+        if issubclass(delete_model, MP_Node):
+            assert signals == []
+        elif issubclass(delete_model, NS_Node):
+            assert signals == []
 
     def test_delete_filter_children(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
-        result = delete_model.objects.filter(desc__in=("2", "23", "231")).delete()
+        with capture_signals() as signals:
+            result = delete_model.objects.filter(desc__in=("2", "23", "231")).delete()
         expected = [("1", 1, 0), ("3", 1, 0), ("4", 1, 1), ("41", 2, 0)]
         assert self.got(delete_model) == expected
         assert result == (12, {delete_model._meta.label: 6, dep_model._meta.label: 6})
+        if issubclass(delete_model, MP_Node):
+            assert signals == []
+        elif issubclass(delete_model, NS_Node):
+            assert signals == []
 
     def test_delete_nonexistant_nodes(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
-        result = delete_model.objects.filter(desc__in=("ZZZ", "XXX")).delete()
+        with capture_signals() as signals:
+            result = delete_model.objects.filter(desc__in=("ZZZ", "XXX")).delete()
         assert self.got(delete_model) == UNCHANGED
         assert result == (0, {})
+        if issubclass(delete_model, MP_Node):
+            assert signals == []
+        elif issubclass(delete_model, NS_Node):
+            assert signals == []
 
     def test_delete_same_node_twice(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
-        result = delete_model.objects.filter(desc__in=("2", "2")).delete()
+        with capture_signals() as signals:
+            result = delete_model.objects.filter(desc__in=("2", "2")).delete()
         expected = [("1", 1, 0), ("3", 1, 0), ("4", 1, 1), ("41", 2, 0)]
         assert self.got(delete_model) == expected
         assert result == (12, {delete_model._meta.label: 6, dep_model._meta.label: 6})
+        if issubclass(delete_model, MP_Node):
+            assert signals == []
+        elif issubclass(delete_model, NS_Node):
+            assert signals == []
 
     def test_delete_all_root_nodes(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
-        result = delete_model.get_root_nodes().delete()
+        with capture_signals() as signals:
+            result = delete_model.get_root_nodes().delete()
         assert result == (20, {delete_model._meta.label: 10, dep_model._meta.label: 10})
         assert delete_model.objects.count() == 0
+        if issubclass(delete_model, MP_Node):
+            assert signals == []
+        elif issubclass(delete_model, NS_Node):
+            assert signals == []
 
     def test_delete_all_nodes(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
-        result = delete_model.objects.all().delete()
+        with capture_signals() as signals:
+            result = delete_model.objects.all().delete()
         assert result == (20, {delete_model._meta.label: 10, dep_model._meta.label: 10})
         assert delete_model.objects.count() == 0
+        if issubclass(delete_model, MP_Node):
+            assert signals == []
+        elif issubclass(delete_model, NS_Node):
+            assert signals == []
 
 
 @pytest.mark.django_db
@@ -1473,6 +1617,11 @@ class TestMoveLeafRoot(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("subtree_moved", model, 2, 7, 8, 5, -6, -2, "default"),
+                ("gap_altered", model, 2, 7, -2, "default"),
+            ]
 
     def test_move_leaf_first_sibling_root(self, model):
         target = model.objects.get(desc="2")
@@ -1511,6 +1660,12 @@ class TestMoveLeafRoot(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("tree_ids_incremented", model, 1, "default"),
+                ("subtree_moved", model, 3, 7, 8, 1, -6, -2, "default"),
+                ("gap_altered", model, 3, 7, -2, "default"),
+            ]
 
     def test_move_leaf_left_sibling_root(self, model):
         target = model.objects.get(desc="2")
@@ -1547,6 +1702,12 @@ class TestMoveLeafRoot(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("tree_ids_incremented", model, 2, "default"),
+                ("subtree_moved", model, 3, 7, 8, 2, -6, -2, "default"),
+                ("gap_altered", model, 3, 7, -2, "default"),
+            ]
 
     def test_move_leaf_right_sibling_root(self, model):
         target = model.objects.get(desc="2")
@@ -1581,6 +1742,12 @@ class TestMoveLeafRoot(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("tree_ids_incremented", model, 3, "default"),
+                ("subtree_moved", model, 2, 7, 8, 3, -6, -2, "default"),
+                ("gap_altered", model, 2, 7, -2, "default"),
+            ]
 
     def test_move_leaf_last_child_root(self, model):
         target = model.objects.get(desc="2")
@@ -1611,6 +1778,12 @@ class TestMoveLeafRoot(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("gap_altered", model, 2, 12, 2, "default"),
+                ("subtree_moved", model, 2, 7, 8, 2, 5, -1, "default"),
+                ("gap_altered", model, 2, 7, -2, "default"),
+            ]
 
     def test_move_leaf_first_child_root(self, model):
         target = model.objects.get(desc="2")
@@ -1649,6 +1822,12 @@ class TestMoveLeafRoot(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("gap_altered", model, 2, 2, 2, "default"),
+                ("subtree_moved", model, 2, 9, 10, 2, -7, -1, "default"),
+                ("gap_altered", model, 2, 9, -2, "default"),
+            ]
 
 
 @pytest.mark.django_db
@@ -1682,6 +1861,12 @@ class TestMoveLeaf(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("gap_altered", model, 2, 12, 2, "default"),
+                ("subtree_moved", model, 2, 7, 8, 2, 5, -1, "default"),
+                ("gap_altered", model, 2, 7, -2, "default"),
+            ]
 
     def test_move_leaf_first_sibling(self, model):
         target = model.objects.get(desc="22")
@@ -1720,6 +1905,12 @@ class TestMoveLeaf(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("gap_altered", model, 2, 2, 2, "default"),
+                ("subtree_moved", model, 2, 9, 10, 2, -7, -1, "default"),
+                ("gap_altered", model, 2, 9, -2, "default"),
+            ]
 
     def test_move_leaf_left_sibling(self, model):
         target = model.objects.get(desc="22")
@@ -1756,6 +1947,12 @@ class TestMoveLeaf(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("gap_altered", model, 2, 4, 2, "default"),
+                ("subtree_moved", model, 2, 9, 10, 2, -5, -1, "default"),
+                ("gap_altered", model, 2, 9, -2, "default"),
+            ]
 
     def test_move_leaf_right_sibling(self, model):
         target = model.objects.get(desc="22")
@@ -1790,6 +1987,12 @@ class TestMoveLeaf(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("gap_altered", model, 2, 6, 2, "default"),
+                ("subtree_moved", model, 2, 9, 10, 2, -3, -1, "default"),
+                ("gap_altered", model, 2, 9, -2, "default"),
+            ]
 
     def test_move_leaf_left_sibling_itself(self, model):
         target = model.objects.get(desc="231")
@@ -1797,6 +2000,8 @@ class TestMoveLeaf(TestNonEmptyTree):
             model.objects.get(desc="231").move(target, "left")
         assert self.got(model) == UNCHANGED
         if issubclass(model, MP_Node):
+            assert signals == []
+        elif issubclass(model, NS_Node):
             assert signals == []
 
     def test_move_leaf_last_child(self, model):
@@ -1828,6 +2033,12 @@ class TestMoveLeaf(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("gap_altered", model, 2, 5, 2, "default"),
+                ("subtree_moved", model, 2, 9, 10, 2, -4, 0, "default"),
+                ("gap_altered", model, 2, 9, -2, "default"),
+            ]
 
     def test_move_leaf_first_child(self, model):
         target = model.objects.get(desc="22")
@@ -1858,6 +2069,12 @@ class TestMoveLeaf(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("gap_altered", model, 2, 5, 2, "default"),
+                ("subtree_moved", model, 2, 9, 10, 2, -4, 0, "default"),
+                ("gap_altered", model, 2, 9, -2, "default"),
+            ]
 
 
 @pytest.mark.django_db
@@ -1899,6 +2116,11 @@ class TestMoveBranchRoot(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("tree_ids_incremented", model, 1, "default"),
+                ("subtree_moved", model, 5, 1, 4, 1, 0, 0, "default"),
+            ]
 
     def test_move_branch_last_sibling_root(self, model):
         target = model.objects.get(desc="2")
@@ -1919,6 +2141,10 @@ class TestMoveBranchRoot(TestNonEmptyTree):
         assert self.got(model) == expected
         if issubclass(model, MP_Node):
             assert signals == []
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("subtree_moved", model, 4, 1, 4, 5, 0, 0, "default"),
+            ]
 
     def test_move_branch_left_sibling_root(self, model):
         target = model.objects.get(desc="2")
@@ -1956,6 +2182,11 @@ class TestMoveBranchRoot(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("tree_ids_incremented", model, 2, "default"),
+                ("subtree_moved", model, 5, 1, 4, 2, 0, 0, "default"),
+            ]
 
     def test_move_branch_right_sibling_root(self, model):
         target = model.objects.get(desc="2")
@@ -1990,6 +2221,11 @@ class TestMoveBranchRoot(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("tree_ids_incremented", model, 3, "default"),
+                ("subtree_moved", model, 5, 1, 4, 3, 0, 0, "default"),
+            ]
 
     def test_move_branch_left_noleft_sibling_root(self, model):
         target = model.objects.get(desc="2").get_first_sibling()
@@ -2028,6 +2264,11 @@ class TestMoveBranchRoot(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("tree_ids_incremented", model, 1, "default"),
+                ("subtree_moved", model, 5, 1, 4, 1, 0, 0, "default"),
+            ]
 
     def test_move_branch_right_noright_sibling_root(self, model):
         target = model.objects.get(desc="2").get_last_sibling()
@@ -2047,6 +2288,8 @@ class TestMoveBranchRoot(TestNonEmptyTree):
         ]
         assert self.got(model) == expected
         if issubclass(model, MP_Node):
+            assert signals == []
+        elif issubclass(model, NS_Node):
             assert signals == []
 
     def test_move_branch_first_child_root(self, model):
@@ -2086,6 +2329,11 @@ class TestMoveBranchRoot(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("gap_altered", model, 2, 2, 4, "default"),
+                ("subtree_moved", model, 4, 1, 4, 2, 1, 1, "default"),
+            ]
 
     def test_move_branch_last_child_root(self, model):
         target = model.objects.get(desc="2")
@@ -2116,6 +2364,11 @@ class TestMoveBranchRoot(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("gap_altered", model, 2, 12, 4, "default"),
+                ("subtree_moved", model, 4, 1, 4, 2, 11, 1, "default"),
+            ]
 
 
 @pytest.mark.django_db
@@ -2157,6 +2410,11 @@ class TestMoveBranch(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("gap_altered", model, 2, 2, 4, "default"),
+                ("subtree_moved", model, 4, 1, 4, 2, 1, 1, "default"),
+            ]
 
     def test_move_branch_last_sibling(self, model):
         target = model.objects.get(desc="23")
@@ -2187,6 +2445,11 @@ class TestMoveBranch(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("gap_altered", model, 2, 12, 4, "default"),
+                ("subtree_moved", model, 4, 1, 4, 2, 11, 1, "default"),
+            ]
 
     def test_move_branch_left_sibling(self, model):
         target = model.objects.get(desc="23")
@@ -2221,6 +2484,11 @@ class TestMoveBranch(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("gap_altered", model, 2, 6, 4, "default"),
+                ("subtree_moved", model, 4, 1, 4, 2, 5, 1, "default"),
+            ]
 
     def test_move_branch_right_sibling(self, model):
         target = model.objects.get(desc="23")
@@ -2253,6 +2521,11 @@ class TestMoveBranch(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("gap_altered", model, 2, 10, 4, "default"),
+                ("subtree_moved", model, 4, 1, 4, 2, 9, 1, "default"),
+            ]
 
     def test_move_branch_left_noleft_sibling(self, model):
         target = model.objects.get(desc="23").get_first_sibling()
@@ -2291,6 +2564,11 @@ class TestMoveBranch(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("gap_altered", model, 2, 2, 4, "default"),
+                ("subtree_moved", model, 4, 1, 4, 2, 1, 1, "default"),
+            ]
 
     def test_move_branch_right_noright_sibling(self, model):
         target = model.objects.get(desc="23").get_last_sibling()
@@ -2321,6 +2599,11 @@ class TestMoveBranch(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("gap_altered", model, 2, 12, 4, "default"),
+                ("subtree_moved", model, 4, 1, 4, 2, 11, 1, "default"),
+            ]
 
     def test_move_branch_left_itself_sibling(self, model):
         target = model.objects.get(desc="4")
@@ -2328,6 +2611,8 @@ class TestMoveBranch(TestNonEmptyTree):
             model.objects.get(desc="4").move(target, "left")
         assert self.got(model) == UNCHANGED
         if issubclass(model, MP_Node):
+            assert signals == []
+        elif issubclass(model, NS_Node):
             assert signals == []
 
     def test_move_branch_first_child(self, model):
@@ -2362,6 +2647,11 @@ class TestMoveBranch(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("gap_altered", model, 2, 7, 4, "default"),
+                ("subtree_moved", model, 4, 1, 4, 2, 6, 2, "default"),
+            ]
 
         # Check that for MP, NS and LT nodes, the depth was updated on the in-memory instances
         assert node.get_depth() == 3
@@ -2397,6 +2687,11 @@ class TestMoveBranch(TestNonEmptyTree):
             else:
                 assert False, f"Unexpected steplen: {model.steplen}"
             assert signals == expected_signals
+        elif issubclass(model, NS_Node):
+            assert signals == [
+                ("gap_altered", model, 2, 9, 4, "default"),
+                ("subtree_moved", model, 4, 1, 4, 2, 8, 2, "default"),
+            ]
 
 
 @pytest.mark.django_db

--- a/tests/test_treebeard.py
+++ b/tests/test_treebeard.py
@@ -37,6 +37,7 @@ from treebeard.ltree import LT_Node
 from treebeard.ltree import subtree_moved as lt_subtree_moved
 from treebeard.ltree import subtree_moved_right as lt_subtree_moved_right
 from treebeard.mp_tree import MP_Node, path_updated
+from treebeard.mp_tree import nodes_deleted as mp_nodes_deleted
 from treebeard.ns_tree import NS_Node, gap_altered, tree_ids_incremented
 from treebeard.ns_tree import subtree_moved as ns_subtree_moved
 from treebeard.templatetags.admin_tree import tree_context
@@ -156,6 +157,9 @@ def capture_signals():
     def path_updated_handler(sender, **kwargs):
         calls.append(("path_updated", sender, kwargs["old_path"], kwargs["new_path"], kwargs["using"]))
 
+    def mp_nodes_deleted_handler(sender, **kwargs):
+        calls.append(("nodes_deleted", sender, kwargs["pks_to_remove"], kwargs["paths_to_remove"], kwargs["using"]))
+
     def gap_altered_handler(sender, **kwargs):
         calls.append(
             ("gap_altered", sender, kwargs["tree_id"], kwargs["start_index"], kwargs["offset"], kwargs["using"])
@@ -201,6 +205,7 @@ def capture_signals():
         )
 
     path_updated.connect(path_updated_handler)
+    mp_nodes_deleted.connect(mp_nodes_deleted_handler)
     gap_altered.connect(gap_altered_handler)
     tree_ids_incremented.connect(tree_ids_incremented_handler)
     ns_subtree_moved.connect(ns_subtree_moved_handler)
@@ -210,6 +215,7 @@ def capture_signals():
         yield calls
     finally:
         path_updated.disconnect(path_updated_handler)
+        mp_nodes_deleted.disconnect(mp_nodes_deleted_handler)
         gap_altered.disconnect(gap_altered_handler)
         tree_ids_incremented.disconnect(tree_ids_incremented_handler)
         ns_subtree_moved.disconnect(ns_subtree_moved_handler)
@@ -1476,8 +1482,9 @@ class TestDelete(TestTreeBase):
 
     def test_delete_leaf(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
+        node = delete_model.objects.get(desc="231")
         with capture_signals() as signals:
-            result = delete_model.objects.get(desc="231").delete()
+            result = node.delete()
         expected = [
             ("1", 1, 0),
             ("2", 1, 4),
@@ -1492,7 +1499,9 @@ class TestDelete(TestTreeBase):
         assert self.got(delete_model) == expected
         assert result == (2, {delete_model._meta.label: 1, dep_model._meta.label: 1})
         if issubclass(delete_model, MP_Node):
-            assert signals == []
+            assert signals == [
+                ("nodes_deleted", delete_model, [node.pk], [], "default"),
+            ]
         elif issubclass(delete_model, NS_Node):
             assert signals == [
                 ("gap_altered", delete_model, 2, 7, -2, "default"),
@@ -1517,7 +1526,17 @@ class TestDelete(TestTreeBase):
         assert self.got(delete_model) == expected
         assert result == (4, {delete_model._meta.label: 2, dep_model._meta.label: 2})
         if issubclass(delete_model, MP_Node):
-            assert signals == []
+            if delete_model.steplen == 1:
+                expected_signals = [
+                    ("nodes_deleted", delete_model, [], ["23"], "default"),
+                ]
+            elif delete_model.steplen == 3:
+                expected_signals = [
+                    ("nodes_deleted", delete_model, [], ["002003"], "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {delete_model.steplen}"
+            assert signals == expected_signals
         elif issubclass(delete_model, NS_Node):
             assert signals == [
                 ("gap_altered", delete_model, 2, 6, -4, "default"),
@@ -1533,7 +1552,17 @@ class TestDelete(TestTreeBase):
         assert self.got(delete_model) == expected
         assert result == (12, {delete_model._meta.label: 6, dep_model._meta.label: 6})
         if issubclass(delete_model, MP_Node):
-            assert signals == []
+            if delete_model.steplen == 1:
+                expected_signals = [
+                    ("nodes_deleted", delete_model, [], ["2"], "default"),
+                ]
+            elif delete_model.steplen == 3:
+                expected_signals = [
+                    ("nodes_deleted", delete_model, [], ["002"], "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {delete_model.steplen}"
+            assert signals == expected_signals
         elif issubclass(delete_model, NS_Node):
             assert signals == []
         elif issubclass(delete_model, LT_Node):
@@ -1541,13 +1570,24 @@ class TestDelete(TestTreeBase):
 
     def test_delete_filter_root_nodes(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
+        node3 = delete_model.objects.get(desc="3")
         with capture_signals() as signals:
             result = delete_model.objects.filter(desc__in=("2", "3")).delete()
         expected = [("1", 1, 0), ("4", 1, 1), ("41", 2, 0)]
         assert self.got(delete_model) == expected
         assert result == (14, {delete_model._meta.label: 7, dep_model._meta.label: 7})
         if issubclass(delete_model, MP_Node):
-            assert signals == []
+            if delete_model.steplen == 1:
+                expected_signals = [
+                    ("nodes_deleted", delete_model, [node3.pk], ["2"], "default"),
+                ]
+            elif delete_model.steplen == 3:
+                expected_signals = [
+                    ("nodes_deleted", delete_model, [node3.pk], ["002"], "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {delete_model.steplen}"
+            assert signals == expected_signals
         elif issubclass(delete_model, NS_Node):
             assert signals == []
         elif issubclass(delete_model, LT_Node):
@@ -1561,7 +1601,17 @@ class TestDelete(TestTreeBase):
         assert self.got(delete_model) == expected
         assert result == (12, {delete_model._meta.label: 6, dep_model._meta.label: 6})
         if issubclass(delete_model, MP_Node):
-            assert signals == []
+            if delete_model.steplen == 1:
+                expected_signals = [
+                    ("nodes_deleted", delete_model, [], ["2"], "default"),
+                ]
+            elif delete_model.steplen == 3:
+                expected_signals = [
+                    ("nodes_deleted", delete_model, [], ["002"], "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {delete_model.steplen}"
+            assert signals == expected_signals
         elif issubclass(delete_model, NS_Node):
             assert signals == []
 
@@ -1584,7 +1634,17 @@ class TestDelete(TestTreeBase):
         assert self.got(delete_model) == expected
         assert result == (12, {delete_model._meta.label: 6, dep_model._meta.label: 6})
         if issubclass(delete_model, MP_Node):
-            assert signals == []
+            if delete_model.steplen == 1:
+                expected_signals = [
+                    ("nodes_deleted", delete_model, [], ["2"], "default"),
+                ]
+            elif delete_model.steplen == 3:
+                expected_signals = [
+                    ("nodes_deleted", delete_model, [], ["002"], "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {delete_model.steplen}"
+            assert signals == expected_signals
         elif issubclass(delete_model, NS_Node):
             assert signals == []
         elif issubclass(delete_model, LT_Node):
@@ -1592,12 +1652,24 @@ class TestDelete(TestTreeBase):
 
     def test_delete_all_root_nodes(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
+        node1 = delete_model.objects.get(desc="1")
+        node3 = delete_model.objects.get(desc="3")
         with capture_signals() as signals:
             result = delete_model.get_root_nodes().delete()
         assert result == (20, {delete_model._meta.label: 10, dep_model._meta.label: 10})
         assert delete_model.objects.count() == 0
         if issubclass(delete_model, MP_Node):
-            assert signals == []
+            if delete_model.steplen == 1:
+                expected_signals = [
+                    ("nodes_deleted", delete_model, [node1.pk, node3.pk], ["2", "4"], "default"),
+                ]
+            elif delete_model.steplen == 3:
+                expected_signals = [
+                    ("nodes_deleted", delete_model, [node1.pk, node3.pk], ["002", "004"], "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {delete_model.steplen}"
+            assert signals == expected_signals
         elif issubclass(delete_model, NS_Node):
             assert signals == []
         elif issubclass(delete_model, LT_Node):
@@ -1605,12 +1677,24 @@ class TestDelete(TestTreeBase):
 
     def test_delete_all_nodes(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
+        node1 = delete_model.objects.get(desc="1")
+        node3 = delete_model.objects.get(desc="3")
         with capture_signals() as signals:
             result = delete_model.objects.all().delete()
         assert result == (20, {delete_model._meta.label: 10, dep_model._meta.label: 10})
         assert delete_model.objects.count() == 0
         if issubclass(delete_model, MP_Node):
-            assert signals == []
+            if delete_model.steplen == 1:
+                expected_signals = [
+                    ("nodes_deleted", delete_model, [node1.pk, node3.pk], ["2", "4"], "default"),
+                ]
+            elif delete_model.steplen == 3:
+                expected_signals = [
+                    ("nodes_deleted", delete_model, [node1.pk, node3.pk], ["002", "004"], "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {delete_model.steplen}"
+            assert signals == expected_signals
         elif issubclass(delete_model, NS_Node):
             assert signals == []
         elif issubclass(delete_model, LT_Node):

--- a/tests/test_treebeard.py
+++ b/tests/test_treebeard.py
@@ -33,8 +33,12 @@ from treebeard.exceptions import (
     PathOverflow,
 )
 from treebeard.forms import movenodeform_factory
+from treebeard.ltree import LT_Node
+from treebeard.ltree import subtree_moved as lt_subtree_moved
+from treebeard.ltree import subtree_moved_right as lt_subtree_moved_right
 from treebeard.mp_tree import MP_Node, path_updated
-from treebeard.ns_tree import NS_Node, gap_altered, subtree_moved, tree_ids_incremented
+from treebeard.ns_tree import NS_Node, gap_altered, tree_ids_incremented
+from treebeard.ns_tree import subtree_moved as ns_subtree_moved
 from treebeard.templatetags.admin_tree import tree_context
 
 admin_register_all()
@@ -160,7 +164,7 @@ def capture_signals():
     def tree_ids_incremented_handler(sender, **kwargs):
         calls.append(("tree_ids_incremented", sender, kwargs["min_tree_id"], kwargs["using"]))
 
-    def subtree_moved_handler(sender, **kwargs):
+    def ns_subtree_moved_handler(sender, **kwargs):
         calls.append(
             (
                 "subtree_moved",
@@ -175,18 +179,42 @@ def capture_signals():
             )
         )
 
+    def lt_subtree_moved_right_handler(sender, **kwargs):
+        calls.append(
+            (
+                "subtree_moved_right",
+                sender,
+                str(kwargs["path"]),
+                kwargs["using"],
+            )
+        )
+
+    def lt_subtree_moved_handler(sender, **kwargs):
+        calls.append(
+            (
+                "subtree_moved",
+                sender,
+                str(kwargs["old_path"]),
+                str(kwargs["new_path"]),
+                kwargs["using"],
+            )
+        )
+
     path_updated.connect(path_updated_handler)
     gap_altered.connect(gap_altered_handler)
     tree_ids_incremented.connect(tree_ids_incremented_handler)
-    subtree_moved.connect(subtree_moved_handler)
-
+    ns_subtree_moved.connect(ns_subtree_moved_handler)
+    lt_subtree_moved_right.connect(lt_subtree_moved_right_handler)
+    lt_subtree_moved.connect(lt_subtree_moved_handler)
     try:
         yield calls
     finally:
         path_updated.disconnect(path_updated_handler)
         gap_altered.disconnect(gap_altered_handler)
         tree_ids_incremented.disconnect(tree_ids_incremented_handler)
-        subtree_moved.disconnect(subtree_moved_handler)
+        ns_subtree_moved.disconnect(ns_subtree_moved_handler)
+        lt_subtree_moved_right.disconnect(lt_subtree_moved_right_handler)
+        lt_subtree_moved.disconnect(lt_subtree_moved_handler)
 
 
 class TestTreeBase:
@@ -854,6 +882,8 @@ class TestAddChild(TestNonEmptyTree):
             assert signals == [
                 ("gap_altered", model, 2, 8, 2, "default"),
             ]
+        elif issubclass(model, LT_Node):
+            assert signals == []
 
     def test_add_child_to_node(self, model):
         with capture_signals() as signals:
@@ -878,6 +908,8 @@ class TestAddChild(TestNonEmptyTree):
             assert signals == [
                 ("gap_altered", model, 2, 12, 2, "default"),
             ]
+        elif issubclass(model, LT_Node):
+            assert signals == []
 
     def test_add_child_with_passed_instance(self, model):
         child = model(desc="2311")
@@ -904,6 +936,8 @@ class TestAddChild(TestNonEmptyTree):
             assert signals == [
                 ("gap_altered", model, 2, 8, 2, "default"),
             ]
+        elif issubclass(model, LT_Node):
+            assert signals == []
 
     def test_add_child_called_consecutively(self, model_without_data):
         # Regression test for https://github.com/django-treebeard/django-treebeard/issues/307
@@ -998,6 +1032,8 @@ class TestAddSibling(TestNonEmptyTree):
             assert signals == []
         elif issubclass(model, NS_Node):
             assert signals == []
+        elif issubclass(model, LT_Node):
+            assert signals == []
 
     def test_add_sibling_last(self, model):
         node = model.objects.get(desc="231")
@@ -1011,6 +1047,8 @@ class TestAddSibling(TestNonEmptyTree):
             assert signals == [
                 ("gap_altered", model, 2, 9, 2, "default"),
             ]
+        elif issubclass(model, LT_Node):
+            assert signals == []
 
     def test_add_sibling_first_root(self, model):
         node_wchildren = model.objects.get(desc="2")
@@ -1053,6 +1091,8 @@ class TestAddSibling(TestNonEmptyTree):
             assert signals == [
                 ("tree_ids_incremented", model, 1, "default"),
             ]
+        elif issubclass(model, LT_Node):
+            assert signals == []
 
     def test_add_sibling_first(self, model):
         node_wchildren = model.objects.get(desc="23")
@@ -1095,6 +1135,8 @@ class TestAddSibling(TestNonEmptyTree):
             assert signals == [
                 ("gap_altered", model, 2, 2, 2, "default"),
             ]
+        elif issubclass(model, LT_Node):
+            assert signals == []
 
     def test_add_sibling_left_root(self, model):
         node_wchildren = model.objects.get(desc="2")
@@ -1135,6 +1177,8 @@ class TestAddSibling(TestNonEmptyTree):
             assert signals == [
                 ("tree_ids_incremented", model, 2, "default"),
             ]
+        elif issubclass(model, LT_Node):
+            assert signals == []
 
     def test_add_sibling_left(self, model):
         node_wchildren = model.objects.get(desc="23")
@@ -1173,6 +1217,8 @@ class TestAddSibling(TestNonEmptyTree):
             assert signals == [
                 ("gap_altered", model, 2, 6, 2, "default"),
             ]
+        elif issubclass(model, LT_Node):
+            assert signals == []
 
     def test_add_sibling_left_noleft_root(self, model):
         node = model.objects.get(desc="1")
@@ -1215,6 +1261,8 @@ class TestAddSibling(TestNonEmptyTree):
             assert signals == [
                 ("tree_ids_incremented", model, 1, "default"),
             ]
+        elif issubclass(model, LT_Node):
+            assert signals == []
 
     def test_add_sibling_left_noleft(self, model):
         node = model.objects.get(desc="231")
@@ -1251,6 +1299,8 @@ class TestAddSibling(TestNonEmptyTree):
             assert signals == [
                 ("gap_altered", model, 2, 7, 2, "default"),
             ]
+        elif issubclass(model, LT_Node):
+            assert signals == []
 
     def test_add_sibling_right_root(self, model):
         node_wchildren = model.objects.get(desc="2")
@@ -1289,6 +1339,8 @@ class TestAddSibling(TestNonEmptyTree):
             assert signals == [
                 ("tree_ids_incremented", model, 3, "default"),
             ]
+        elif issubclass(model, LT_Node):
+            assert signals == []
 
     def test_add_sibling_right(self, model):
         node_wchildren = model.objects.get(desc="23")
@@ -1326,6 +1378,8 @@ class TestAddSibling(TestNonEmptyTree):
             assert signals == [
                 ("gap_altered", model, 2, 10, 2, "default"),
             ]
+        elif issubclass(model, LT_Node):
+            assert signals == []
 
     def test_add_sibling_right_noright_root(self, model):
         node = model.objects.get(desc="4")
@@ -1349,6 +1403,8 @@ class TestAddSibling(TestNonEmptyTree):
         if issubclass(model, MP_Node):
             assert signals == []
         elif issubclass(model, NS_Node):
+            assert signals == []
+        elif issubclass(model, LT_Node):
             assert signals == []
 
     def test_add_sibling_right_noright(self, model):
@@ -1376,6 +1432,8 @@ class TestAddSibling(TestNonEmptyTree):
             assert signals == [
                 ("gap_altered", model, 2, 9, 2, "default"),
             ]
+        elif issubclass(model, LT_Node):
+            assert signals == []
 
     def test_add_sibling_with_passed_instance(self, model):
         node_wchildren = model.objects.get(desc="2")
@@ -1439,6 +1497,8 @@ class TestDelete(TestTreeBase):
             assert signals == [
                 ("gap_altered", delete_model, 2, 7, -2, "default"),
             ]
+        elif issubclass(delete_model, LT_Node):
+            assert signals == []
 
     def test_delete_node(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
@@ -1462,6 +1522,8 @@ class TestDelete(TestTreeBase):
             assert signals == [
                 ("gap_altered", delete_model, 2, 6, -4, "default"),
             ]
+        elif issubclass(delete_model, LT_Node):
+            assert signals == []
 
     def test_delete_root(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
@@ -1474,6 +1536,8 @@ class TestDelete(TestTreeBase):
             assert signals == []
         elif issubclass(delete_model, NS_Node):
             assert signals == []
+        elif issubclass(delete_model, LT_Node):
+            assert signals == []
 
     def test_delete_filter_root_nodes(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
@@ -1485,6 +1549,8 @@ class TestDelete(TestTreeBase):
         if issubclass(delete_model, MP_Node):
             assert signals == []
         elif issubclass(delete_model, NS_Node):
+            assert signals == []
+        elif issubclass(delete_model, LT_Node):
             assert signals == []
 
     def test_delete_filter_children(self, delete_dep_model_pair):
@@ -1521,6 +1587,8 @@ class TestDelete(TestTreeBase):
             assert signals == []
         elif issubclass(delete_model, NS_Node):
             assert signals == []
+        elif issubclass(delete_model, LT_Node):
+            assert signals == []
 
     def test_delete_all_root_nodes(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
@@ -1532,6 +1600,8 @@ class TestDelete(TestTreeBase):
             assert signals == []
         elif issubclass(delete_model, NS_Node):
             assert signals == []
+        elif issubclass(delete_model, LT_Node):
+            assert signals == []
 
     def test_delete_all_nodes(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
@@ -1542,6 +1612,8 @@ class TestDelete(TestTreeBase):
         if issubclass(delete_model, MP_Node):
             assert signals == []
         elif issubclass(delete_model, NS_Node):
+            assert signals == []
+        elif issubclass(delete_model, LT_Node):
             assert signals == []
 
 
@@ -1622,6 +1694,10 @@ class TestMoveLeafRoot(TestNonEmptyTree):
                 ("subtree_moved", model, 2, 7, 8, 5, -6, -2, "default"),
                 ("gap_altered", model, 2, 7, -2, "default"),
             ]
+        elif issubclass(model, LT_Node):
+            assert signals == [
+                ("subtree_moved", model, "B.C.A", "E", "default"),
+            ]
 
     def test_move_leaf_first_sibling_root(self, model):
         target = model.objects.get(desc="2")
@@ -1666,6 +1742,10 @@ class TestMoveLeafRoot(TestNonEmptyTree):
                 ("subtree_moved", model, 3, 7, 8, 1, -6, -2, "default"),
                 ("gap_altered", model, 3, 7, -2, "default"),
             ]
+        elif issubclass(model, LT_Node):
+            assert signals == [
+                ("subtree_moved", model, "B.C.A", "0", "default"),
+            ]
 
     def test_move_leaf_left_sibling_root(self, model):
         target = model.objects.get(desc="2")
@@ -1708,6 +1788,10 @@ class TestMoveLeafRoot(TestNonEmptyTree):
                 ("subtree_moved", model, 3, 7, 8, 2, -6, -2, "default"),
                 ("gap_altered", model, 3, 7, -2, "default"),
             ]
+        elif issubclass(model, LT_Node):
+            assert signals == [
+                ("subtree_moved", model, "B.C.A", "A0", "default"),
+            ]
 
     def test_move_leaf_right_sibling_root(self, model):
         target = model.objects.get(desc="2")
@@ -1748,6 +1832,10 @@ class TestMoveLeafRoot(TestNonEmptyTree):
                 ("subtree_moved", model, 2, 7, 8, 3, -6, -2, "default"),
                 ("gap_altered", model, 2, 7, -2, "default"),
             ]
+        elif issubclass(model, LT_Node):
+            assert signals == [
+                ("subtree_moved", model, "B.C.A", "B0", "default"),
+            ]
 
     def test_move_leaf_last_child_root(self, model):
         target = model.objects.get(desc="2")
@@ -1783,6 +1871,10 @@ class TestMoveLeafRoot(TestNonEmptyTree):
                 ("gap_altered", model, 2, 12, 2, "default"),
                 ("subtree_moved", model, 2, 7, 8, 2, 5, -1, "default"),
                 ("gap_altered", model, 2, 7, -2, "default"),
+            ]
+        elif issubclass(model, LT_Node):
+            assert signals == [
+                ("subtree_moved", model, "B.C.A", "B.E", "default"),
             ]
 
     def test_move_leaf_first_child_root(self, model):
@@ -1828,6 +1920,10 @@ class TestMoveLeafRoot(TestNonEmptyTree):
                 ("subtree_moved", model, 2, 9, 10, 2, -7, -1, "default"),
                 ("gap_altered", model, 2, 9, -2, "default"),
             ]
+        elif issubclass(model, LT_Node):
+            assert signals == [
+                ("subtree_moved", model, "B.C.A", "B.0", "default"),
+            ]
 
 
 @pytest.mark.django_db
@@ -1866,6 +1962,10 @@ class TestMoveLeaf(TestNonEmptyTree):
                 ("gap_altered", model, 2, 12, 2, "default"),
                 ("subtree_moved", model, 2, 7, 8, 2, 5, -1, "default"),
                 ("gap_altered", model, 2, 7, -2, "default"),
+            ]
+        elif issubclass(model, LT_Node):
+            assert signals == [
+                ("subtree_moved", model, "B.C.A", "B.E", "default"),
             ]
 
     def test_move_leaf_first_sibling(self, model):
@@ -1911,6 +2011,10 @@ class TestMoveLeaf(TestNonEmptyTree):
                 ("subtree_moved", model, 2, 9, 10, 2, -7, -1, "default"),
                 ("gap_altered", model, 2, 9, -2, "default"),
             ]
+        elif issubclass(model, LT_Node):
+            assert signals == [
+                ("subtree_moved", model, "B.C.A", "B.0", "default"),
+            ]
 
     def test_move_leaf_left_sibling(self, model):
         target = model.objects.get(desc="22")
@@ -1953,6 +2057,10 @@ class TestMoveLeaf(TestNonEmptyTree):
                 ("subtree_moved", model, 2, 9, 10, 2, -5, -1, "default"),
                 ("gap_altered", model, 2, 9, -2, "default"),
             ]
+        elif issubclass(model, LT_Node):
+            assert signals == [
+                ("subtree_moved", model, "B.C.A", "B.A0", "default"),
+            ]
 
     def test_move_leaf_right_sibling(self, model):
         target = model.objects.get(desc="22")
@@ -1993,6 +2101,10 @@ class TestMoveLeaf(TestNonEmptyTree):
                 ("subtree_moved", model, 2, 9, 10, 2, -3, -1, "default"),
                 ("gap_altered", model, 2, 9, -2, "default"),
             ]
+        elif issubclass(model, LT_Node):
+            assert signals == [
+                ("subtree_moved", model, "B.C.A", "B.B0", "default"),
+            ]
 
     def test_move_leaf_left_sibling_itself(self, model):
         target = model.objects.get(desc="231")
@@ -2003,6 +2115,10 @@ class TestMoveLeaf(TestNonEmptyTree):
             assert signals == []
         elif issubclass(model, NS_Node):
             assert signals == []
+        elif issubclass(model, LT_Node):
+            assert signals == [
+                ("subtree_moved", model, "B.C.A", "B.C.0", "default"),
+            ]
 
     def test_move_leaf_last_child(self, model):
         target = model.objects.get(desc="22")
@@ -2039,6 +2155,10 @@ class TestMoveLeaf(TestNonEmptyTree):
                 ("subtree_moved", model, 2, 9, 10, 2, -4, 0, "default"),
                 ("gap_altered", model, 2, 9, -2, "default"),
             ]
+        elif issubclass(model, LT_Node):
+            assert signals == [
+                ("subtree_moved", model, "B.C.A", "B.B.A", "default"),
+            ]
 
     def test_move_leaf_first_child(self, model):
         target = model.objects.get(desc="22")
@@ -2074,6 +2194,10 @@ class TestMoveLeaf(TestNonEmptyTree):
                 ("gap_altered", model, 2, 5, 2, "default"),
                 ("subtree_moved", model, 2, 9, 10, 2, -4, 0, "default"),
                 ("gap_altered", model, 2, 9, -2, "default"),
+            ]
+        elif issubclass(model, LT_Node):
+            assert signals == [
+                ("subtree_moved", model, "B.C.A", "B.B.A", "default"),
             ]
 
 
@@ -2121,6 +2245,10 @@ class TestMoveBranchRoot(TestNonEmptyTree):
                 ("tree_ids_incremented", model, 1, "default"),
                 ("subtree_moved", model, 5, 1, 4, 1, 0, 0, "default"),
             ]
+        elif issubclass(model, LT_Node):
+            assert signals == [
+                ("subtree_moved", model, "D", "0", "default"),
+            ]
 
     def test_move_branch_last_sibling_root(self, model):
         target = model.objects.get(desc="2")
@@ -2144,6 +2272,10 @@ class TestMoveBranchRoot(TestNonEmptyTree):
         elif issubclass(model, NS_Node):
             assert signals == [
                 ("subtree_moved", model, 4, 1, 4, 5, 0, 0, "default"),
+            ]
+        elif issubclass(model, LT_Node):
+            assert signals == [
+                ("subtree_moved", model, "D", "E", "default"),
             ]
 
     def test_move_branch_left_sibling_root(self, model):
@@ -2187,6 +2319,10 @@ class TestMoveBranchRoot(TestNonEmptyTree):
                 ("tree_ids_incremented", model, 2, "default"),
                 ("subtree_moved", model, 5, 1, 4, 2, 0, 0, "default"),
             ]
+        elif issubclass(model, LT_Node):
+            assert signals == [
+                ("subtree_moved", model, "D", "A0", "default"),
+            ]
 
     def test_move_branch_right_sibling_root(self, model):
         target = model.objects.get(desc="2")
@@ -2225,6 +2361,10 @@ class TestMoveBranchRoot(TestNonEmptyTree):
             assert signals == [
                 ("tree_ids_incremented", model, 3, "default"),
                 ("subtree_moved", model, 5, 1, 4, 3, 0, 0, "default"),
+            ]
+        elif issubclass(model, LT_Node):
+            assert signals == [
+                ("subtree_moved", model, "D", "B0", "default"),
             ]
 
     def test_move_branch_left_noleft_sibling_root(self, model):
@@ -2269,6 +2409,10 @@ class TestMoveBranchRoot(TestNonEmptyTree):
                 ("tree_ids_incremented", model, 1, "default"),
                 ("subtree_moved", model, 5, 1, 4, 1, 0, 0, "default"),
             ]
+        elif issubclass(model, LT_Node):
+            assert signals == [
+                ("subtree_moved", model, "D", "0", "default"),
+            ]
 
     def test_move_branch_right_noright_sibling_root(self, model):
         target = model.objects.get(desc="2").get_last_sibling()
@@ -2291,6 +2435,10 @@ class TestMoveBranchRoot(TestNonEmptyTree):
             assert signals == []
         elif issubclass(model, NS_Node):
             assert signals == []
+        elif issubclass(model, LT_Node):
+            assert signals == [
+                ("subtree_moved", model, "D", "E", "default"),
+            ]
 
     def test_move_branch_first_child_root(self, model):
         target = model.objects.get(desc="2")
@@ -2334,6 +2482,10 @@ class TestMoveBranchRoot(TestNonEmptyTree):
                 ("gap_altered", model, 2, 2, 4, "default"),
                 ("subtree_moved", model, 4, 1, 4, 2, 1, 1, "default"),
             ]
+        elif issubclass(model, LT_Node):
+            assert signals == [
+                ("subtree_moved", model, "D", "B.0", "default"),
+            ]
 
     def test_move_branch_last_child_root(self, model):
         target = model.objects.get(desc="2")
@@ -2368,6 +2520,10 @@ class TestMoveBranchRoot(TestNonEmptyTree):
             assert signals == [
                 ("gap_altered", model, 2, 12, 4, "default"),
                 ("subtree_moved", model, 4, 1, 4, 2, 11, 1, "default"),
+            ]
+        elif issubclass(model, LT_Node):
+            assert signals == [
+                ("subtree_moved", model, "D", "B.E", "default"),
             ]
 
 
@@ -2415,6 +2571,10 @@ class TestMoveBranch(TestNonEmptyTree):
                 ("gap_altered", model, 2, 2, 4, "default"),
                 ("subtree_moved", model, 4, 1, 4, 2, 1, 1, "default"),
             ]
+        elif issubclass(model, LT_Node):
+            assert signals == [
+                ("subtree_moved", model, "D", "B.0", "default"),
+            ]
 
     def test_move_branch_last_sibling(self, model):
         target = model.objects.get(desc="23")
@@ -2449,6 +2609,10 @@ class TestMoveBranch(TestNonEmptyTree):
             assert signals == [
                 ("gap_altered", model, 2, 12, 4, "default"),
                 ("subtree_moved", model, 4, 1, 4, 2, 11, 1, "default"),
+            ]
+        elif issubclass(model, LT_Node):
+            assert signals == [
+                ("subtree_moved", model, "D", "B.E", "default"),
             ]
 
     def test_move_branch_left_sibling(self, model):
@@ -2489,6 +2653,10 @@ class TestMoveBranch(TestNonEmptyTree):
                 ("gap_altered", model, 2, 6, 4, "default"),
                 ("subtree_moved", model, 4, 1, 4, 2, 5, 1, "default"),
             ]
+        elif issubclass(model, LT_Node):
+            assert signals == [
+                ("subtree_moved", model, "D", "B.B0", "default"),
+            ]
 
     def test_move_branch_right_sibling(self, model):
         target = model.objects.get(desc="23")
@@ -2525,6 +2693,10 @@ class TestMoveBranch(TestNonEmptyTree):
             assert signals == [
                 ("gap_altered", model, 2, 10, 4, "default"),
                 ("subtree_moved", model, 4, 1, 4, 2, 9, 1, "default"),
+            ]
+        elif issubclass(model, LT_Node):
+            assert signals == [
+                ("subtree_moved", model, "D", "B.C0", "default"),
             ]
 
     def test_move_branch_left_noleft_sibling(self, model):
@@ -2569,6 +2741,10 @@ class TestMoveBranch(TestNonEmptyTree):
                 ("gap_altered", model, 2, 2, 4, "default"),
                 ("subtree_moved", model, 4, 1, 4, 2, 1, 1, "default"),
             ]
+        elif issubclass(model, LT_Node):
+            assert signals == [
+                ("subtree_moved", model, "D", "B.0", "default"),
+            ]
 
     def test_move_branch_right_noright_sibling(self, model):
         target = model.objects.get(desc="23").get_last_sibling()
@@ -2604,6 +2780,10 @@ class TestMoveBranch(TestNonEmptyTree):
                 ("gap_altered", model, 2, 12, 4, "default"),
                 ("subtree_moved", model, 4, 1, 4, 2, 11, 1, "default"),
             ]
+        elif issubclass(model, LT_Node):
+            assert signals == [
+                ("subtree_moved", model, "D", "B.E", "default"),
+            ]
 
     def test_move_branch_left_itself_sibling(self, model):
         target = model.objects.get(desc="4")
@@ -2614,6 +2794,10 @@ class TestMoveBranch(TestNonEmptyTree):
             assert signals == []
         elif issubclass(model, NS_Node):
             assert signals == []
+        elif issubclass(model, LT_Node):
+            assert signals == [
+                ("subtree_moved", model, "D", "C0", "default"),
+            ]
 
     def test_move_branch_first_child(self, model):
         target = model.objects.get(desc="23")
@@ -2651,6 +2835,10 @@ class TestMoveBranch(TestNonEmptyTree):
             assert signals == [
                 ("gap_altered", model, 2, 7, 4, "default"),
                 ("subtree_moved", model, 4, 1, 4, 2, 6, 2, "default"),
+            ]
+        elif issubclass(model, LT_Node):
+            assert signals == [
+                ("subtree_moved", model, "D", "B.C.0", "default"),
             ]
 
         # Check that for MP, NS and LT nodes, the depth was updated on the in-memory instances
@@ -2691,6 +2879,10 @@ class TestMoveBranch(TestNonEmptyTree):
             assert signals == [
                 ("gap_altered", model, 2, 9, 4, "default"),
                 ("subtree_moved", model, 4, 1, 4, 2, 8, 2, "default"),
+            ]
+        elif issubclass(model, LT_Node):
+            assert signals == [
+                ("subtree_moved", model, "D", "B.C.B", "default"),
             ]
 
 
@@ -4299,24 +4491,29 @@ class TestMP_TreeDescendantsPerformance(TestTreeBase):
 @pytest.mark.django_db
 class TestLT_Insertion(TestTreeBase):
     def test_move_right(self, lt_model):
-        node_a = lt_model.add_root(desc="A")
-        node_b = lt_model.add_root(desc="B")
-        node_a_a = node_a.add_child(desc="A.A")
-        node_a_a.add_child(desc="A.A.A")
-        node_b.add_child(desc="B.A")
+        with capture_signals() as signals:
+            node_a = lt_model.add_root(desc="A")
+            node_b = lt_model.add_root(desc="B")
+            node_a_a = node_a.add_child(desc="A.A")
+            node_a_a.add_child(desc="A.A.A")
+            node_b.add_child(desc="B.A")
 
-        expected_paths = ["A", "A.A", "A.A.A", "B", "B.A"]
-        actual_paths = [str(node.path) for node in lt_model.objects.all()]
-        assert actual_paths == expected_paths
+            expected_paths = ["A", "A.A", "A.A.A", "B", "B.A"]
+            actual_paths = [str(node.path) for node in lt_model.objects.all()]
+            assert actual_paths == expected_paths
 
-        # A sibling inserted before A.A gets path A.0; other paths are unchanged
-        node_a_0 = node_a_a.add_sibling("first-sibling", desc="A.0")
-        expected_paths = ["A", "A.0", "A.A", "A.A.A", "B", "B.A"]
-        actual_paths = [str(node.path) for node in lt_model.objects.all()]
-        assert actual_paths == expected_paths
+            # A sibling inserted before A.A gets path A.0; other paths are unchanged
+            node_a_0 = node_a_a.add_sibling("first-sibling", desc="A.0")
+            expected_paths = ["A", "A.0", "A.A", "A.A.A", "B", "B.A"]
+            actual_paths = [str(node.path) for node in lt_model.objects.all()]
+            assert actual_paths == expected_paths
+
+        assert signals == []
 
         # A sibling inserted before A.0 causes existing siblings to be moved right (i.e. 'A' appended to their labels)
-        new_node_a_0 = node_a_0.add_sibling("first-sibling", desc="new A.0")
+        with capture_signals() as signals:
+            new_node_a_0 = node_a_0.add_sibling("first-sibling", desc="new A.0")
+
         assert str(new_node_a_0.path) == "A.0"
         node_a_0.refresh_from_db()
         assert str(node_a_0.path) == "A.0A"
@@ -4326,3 +4523,7 @@ class TestLT_Insertion(TestTreeBase):
         expected_paths = ["A", "A.0", "A.0A", "A.AA", "A.AA.A", "B", "B.A"]
         actual_paths = [str(node.path) for node in lt_model.objects.all()]
         assert actual_paths == expected_paths
+
+        assert signals == [
+            ("subtree_moved_right", lt_model, "A.0", "default"),
+        ]

--- a/tests/test_treebeard.py
+++ b/tests/test_treebeard.py
@@ -34,6 +34,7 @@ from treebeard.exceptions import (
 )
 from treebeard.forms import movenodeform_factory
 from treebeard.ltree import LT_Node
+from treebeard.ltree import nodes_deleted as lt_nodes_deleted
 from treebeard.ltree import subtree_moved as lt_subtree_moved
 from treebeard.ltree import subtree_moved_right as lt_subtree_moved_right
 from treebeard.mp_tree import MP_Node, path_updated
@@ -208,6 +209,11 @@ def capture_signals():
             )
         )
 
+    def lt_nodes_deleted_handler(sender, **kwargs):
+        calls.append(
+            ("nodes_deleted", sender, sorted([str(path) for path in kwargs["paths_to_remove"]]), kwargs["using"])
+        )
+
     path_updated.connect(path_updated_handler)
     mp_nodes_deleted.connect(mp_nodes_deleted_handler)
     gap_altered.connect(gap_altered_handler)
@@ -216,6 +222,7 @@ def capture_signals():
     ns_nodes_deleted.connect(ns_nodes_deleted_handler)
     lt_subtree_moved_right.connect(lt_subtree_moved_right_handler)
     lt_subtree_moved.connect(lt_subtree_moved_handler)
+    lt_nodes_deleted.connect(lt_nodes_deleted_handler)
     try:
         yield calls
     finally:
@@ -227,6 +234,7 @@ def capture_signals():
         ns_nodes_deleted.disconnect(ns_nodes_deleted_handler)
         lt_subtree_moved_right.disconnect(lt_subtree_moved_right_handler)
         lt_subtree_moved.disconnect(lt_subtree_moved_handler)
+        lt_nodes_deleted.disconnect(lt_nodes_deleted_handler)
 
 
 class TestTreeBase:
@@ -1514,7 +1522,9 @@ class TestDelete(TestTreeBase):
                 ("gap_altered", delete_model, 2, 7, -2, "default"),
             ]
         elif issubclass(delete_model, LT_Node):
-            assert signals == []
+            assert signals == [
+                ("nodes_deleted", delete_model, ["B.C.A"], "default"),
+            ]
 
     def test_delete_node(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
@@ -1550,7 +1560,9 @@ class TestDelete(TestTreeBase):
                 ("gap_altered", delete_model, 2, 6, -4, "default"),
             ]
         elif issubclass(delete_model, LT_Node):
-            assert signals == []
+            assert signals == [
+                ("nodes_deleted", delete_model, ["B.C"], "default"),
+            ]
 
     def test_delete_root(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
@@ -1576,7 +1588,9 @@ class TestDelete(TestTreeBase):
                 ("nodes_deleted", delete_model, [(2, 1, 12)], "default"),
             ]
         elif issubclass(delete_model, LT_Node):
-            assert signals == []
+            assert signals == [
+                ("nodes_deleted", delete_model, ["B"], "default"),
+            ]
 
     def test_delete_filter_root_nodes(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
@@ -1603,7 +1617,9 @@ class TestDelete(TestTreeBase):
                 ("nodes_deleted", delete_model, [(2, 1, 12), (3, 1, 2)], "default"),
             ]
         elif issubclass(delete_model, LT_Node):
-            assert signals == []
+            assert signals == [
+                ("nodes_deleted", delete_model, ["B", "C"], "default"),
+            ]
 
     def test_delete_filter_children(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
@@ -1627,6 +1643,10 @@ class TestDelete(TestTreeBase):
         elif issubclass(delete_model, NS_Node):
             assert signals == [
                 ("nodes_deleted", delete_model, [(2, 1, 12)], "default"),
+            ]
+        elif issubclass(delete_model, LT_Node):
+            assert signals == [
+                ("nodes_deleted", delete_model, ["B"], "default"),
             ]
 
     def test_delete_nonexistant_nodes(self, delete_dep_model_pair):
@@ -1664,7 +1684,9 @@ class TestDelete(TestTreeBase):
                 ("nodes_deleted", delete_model, [(2, 1, 12)], "default"),
             ]
         elif issubclass(delete_model, LT_Node):
-            assert signals == []
+            assert signals == [
+                ("nodes_deleted", delete_model, ["B"], "default"),
+            ]
 
     def test_delete_all_root_nodes(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
@@ -1691,7 +1713,9 @@ class TestDelete(TestTreeBase):
                 ("nodes_deleted", delete_model, [(1, 1, 2), (2, 1, 12), (3, 1, 2), (4, 1, 4)], "default"),
             ]
         elif issubclass(delete_model, LT_Node):
-            assert signals == []
+            assert signals == [
+                ("nodes_deleted", delete_model, ["A", "B", "C", "D"], "default"),
+            ]
 
     def test_delete_all_nodes(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
@@ -1718,7 +1742,9 @@ class TestDelete(TestTreeBase):
                 ("nodes_deleted", delete_model, [(1, 1, 2), (2, 1, 12), (3, 1, 2), (4, 1, 4)], "default"),
             ]
         elif issubclass(delete_model, LT_Node):
-            assert signals == []
+            assert signals == [
+                ("nodes_deleted", delete_model, ["A", "B", "C", "D"], "default"),
+            ]
 
 
 @pytest.mark.django_db

--- a/tests/test_treebeard.py
+++ b/tests/test_treebeard.py
@@ -39,6 +39,7 @@ from treebeard.ltree import subtree_moved_right as lt_subtree_moved_right
 from treebeard.mp_tree import MP_Node, path_updated
 from treebeard.mp_tree import nodes_deleted as mp_nodes_deleted
 from treebeard.ns_tree import NS_Node, gap_altered, tree_ids_incremented
+from treebeard.ns_tree import nodes_deleted as ns_nodes_deleted
 from treebeard.ns_tree import subtree_moved as ns_subtree_moved
 from treebeard.templatetags.admin_tree import tree_context
 
@@ -183,6 +184,9 @@ def capture_signals():
             )
         )
 
+    def ns_nodes_deleted_handler(sender, **kwargs):
+        calls.append(("nodes_deleted", sender, kwargs["removed_ranges"], kwargs["using"]))
+
     def lt_subtree_moved_right_handler(sender, **kwargs):
         calls.append(
             (
@@ -209,6 +213,7 @@ def capture_signals():
     gap_altered.connect(gap_altered_handler)
     tree_ids_incremented.connect(tree_ids_incremented_handler)
     ns_subtree_moved.connect(ns_subtree_moved_handler)
+    ns_nodes_deleted.connect(ns_nodes_deleted_handler)
     lt_subtree_moved_right.connect(lt_subtree_moved_right_handler)
     lt_subtree_moved.connect(lt_subtree_moved_handler)
     try:
@@ -219,6 +224,7 @@ def capture_signals():
         gap_altered.disconnect(gap_altered_handler)
         tree_ids_incremented.disconnect(tree_ids_incremented_handler)
         ns_subtree_moved.disconnect(ns_subtree_moved_handler)
+        ns_nodes_deleted.disconnect(ns_nodes_deleted_handler)
         lt_subtree_moved_right.disconnect(lt_subtree_moved_right_handler)
         lt_subtree_moved.disconnect(lt_subtree_moved_handler)
 
@@ -1504,6 +1510,7 @@ class TestDelete(TestTreeBase):
             ]
         elif issubclass(delete_model, NS_Node):
             assert signals == [
+                ("nodes_deleted", delete_model, [(2, 7, 8)], "default"),
                 ("gap_altered", delete_model, 2, 7, -2, "default"),
             ]
         elif issubclass(delete_model, LT_Node):
@@ -1539,6 +1546,7 @@ class TestDelete(TestTreeBase):
             assert signals == expected_signals
         elif issubclass(delete_model, NS_Node):
             assert signals == [
+                ("nodes_deleted", delete_model, [(2, 6, 9)], "default"),
                 ("gap_altered", delete_model, 2, 6, -4, "default"),
             ]
         elif issubclass(delete_model, LT_Node):
@@ -1564,7 +1572,9 @@ class TestDelete(TestTreeBase):
                 assert False, f"Unexpected steplen: {delete_model.steplen}"
             assert signals == expected_signals
         elif issubclass(delete_model, NS_Node):
-            assert signals == []
+            assert signals == [
+                ("nodes_deleted", delete_model, [(2, 1, 12)], "default"),
+            ]
         elif issubclass(delete_model, LT_Node):
             assert signals == []
 
@@ -1589,7 +1599,9 @@ class TestDelete(TestTreeBase):
                 assert False, f"Unexpected steplen: {delete_model.steplen}"
             assert signals == expected_signals
         elif issubclass(delete_model, NS_Node):
-            assert signals == []
+            assert signals == [
+                ("nodes_deleted", delete_model, [(2, 1, 12), (3, 1, 2)], "default"),
+            ]
         elif issubclass(delete_model, LT_Node):
             assert signals == []
 
@@ -1613,7 +1625,9 @@ class TestDelete(TestTreeBase):
                 assert False, f"Unexpected steplen: {delete_model.steplen}"
             assert signals == expected_signals
         elif issubclass(delete_model, NS_Node):
-            assert signals == []
+            assert signals == [
+                ("nodes_deleted", delete_model, [(2, 1, 12)], "default"),
+            ]
 
     def test_delete_nonexistant_nodes(self, delete_dep_model_pair):
         delete_model, dep_model = delete_dep_model_pair
@@ -1646,7 +1660,9 @@ class TestDelete(TestTreeBase):
                 assert False, f"Unexpected steplen: {delete_model.steplen}"
             assert signals == expected_signals
         elif issubclass(delete_model, NS_Node):
-            assert signals == []
+            assert signals == [
+                ("nodes_deleted", delete_model, [(2, 1, 12)], "default"),
+            ]
         elif issubclass(delete_model, LT_Node):
             assert signals == []
 
@@ -1671,7 +1687,9 @@ class TestDelete(TestTreeBase):
                 assert False, f"Unexpected steplen: {delete_model.steplen}"
             assert signals == expected_signals
         elif issubclass(delete_model, NS_Node):
-            assert signals == []
+            assert signals == [
+                ("nodes_deleted", delete_model, [(1, 1, 2), (2, 1, 12), (3, 1, 2), (4, 1, 4)], "default"),
+            ]
         elif issubclass(delete_model, LT_Node):
             assert signals == []
 
@@ -1696,7 +1714,9 @@ class TestDelete(TestTreeBase):
                 assert False, f"Unexpected steplen: {delete_model.steplen}"
             assert signals == expected_signals
         elif issubclass(delete_model, NS_Node):
-            assert signals == []
+            assert signals == [
+                ("nodes_deleted", delete_model, [(1, 1, 2), (2, 1, 12), (3, 1, 2), (4, 1, 4)], "default"),
+            ]
         elif issubclass(delete_model, LT_Node):
             assert signals == []
 

--- a/tests/test_treebeard.py
+++ b/tests/test_treebeard.py
@@ -2,6 +2,7 @@
 
 import os
 import threading
+from contextlib import contextmanager
 from unittest import mock
 from unittest.mock import patch
 
@@ -32,7 +33,7 @@ from treebeard.exceptions import (
     PathOverflow,
 )
 from treebeard.forms import movenodeform_factory
-from treebeard.mp_tree import MP_Node
+from treebeard.mp_tree import MP_Node, path_updated
 from treebeard.ns_tree import NS_Node
 from treebeard.templatetags.admin_tree import tree_context
 
@@ -142,6 +143,20 @@ def ns_model(request):
 @pytest.fixture(scope="function", params=models.LT_BASE_MODELS)
 def lt_model(request):
     return request.param
+
+
+@contextmanager
+def capture_signals():
+    calls = []
+
+    def path_updated_handler(sender, **kwargs):
+        calls.append(("path_updated", sender, kwargs["old_path"], kwargs["new_path"], kwargs["using"]))
+
+    path_updated.connect(path_updated_handler)
+    try:
+        yield calls
+    finally:
+        path_updated.disconnect(path_updated_handler)
 
 
 class TestTreeBase:
@@ -924,19 +939,26 @@ class TestAddSibling(TestNonEmptyTree):
 
     def test_add_sibling_last_root(self, model):
         node_wchildren = model.objects.get(desc="2")
-        obj = node_wchildren.add_sibling("last-sibling", desc="5")
+        with capture_signals() as signals:
+            obj = node_wchildren.add_sibling("last-sibling", desc="5")
         assert obj.get_depth() == 1
         assert node_wchildren.get_last_sibling().desc == "5"
+        if issubclass(model, MP_Node):
+            assert signals == []
 
     def test_add_sibling_last(self, model):
         node = model.objects.get(desc="231")
-        obj = node.add_sibling("last-sibling", desc="232")
+        with capture_signals() as signals:
+            obj = node.add_sibling("last-sibling", desc="232")
         assert obj.get_depth() == 3
         assert node.get_last_sibling().desc == "232"
+        if issubclass(model, MP_Node):
+            assert signals == []
 
     def test_add_sibling_first_root(self, model):
         node_wchildren = model.objects.get(desc="2")
-        obj = node_wchildren.add_sibling("first-sibling", desc="new")
+        with capture_signals() as signals:
+            obj = node_wchildren.add_sibling("first-sibling", desc="new")
         assert obj.get_depth() == 1
         expected = [
             ("new", 1, 0),
@@ -952,10 +974,29 @@ class TestAddSibling(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "4", "5", "default"),
+                    ("path_updated", model, "3", "4", "default"),
+                    ("path_updated", model, "2", "3", "default"),
+                    ("path_updated", model, "1", "2", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "004", "005", "default"),
+                    ("path_updated", model, "003", "004", "default"),
+                    ("path_updated", model, "002", "003", "default"),
+                    ("path_updated", model, "001", "002", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
     def test_add_sibling_first(self, model):
         node_wchildren = model.objects.get(desc="23")
-        obj = node_wchildren.add_sibling("first-sibling", desc="new")
+        with capture_signals() as signals:
+            obj = node_wchildren.add_sibling("first-sibling", desc="new")
         assert obj.get_depth() == 2
         expected = [
             ("1", 1, 0),
@@ -971,10 +1012,29 @@ class TestAddSibling(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "24", "25", "default"),
+                    ("path_updated", model, "23", "24", "default"),
+                    ("path_updated", model, "22", "23", "default"),
+                    ("path_updated", model, "21", "22", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "002004", "002005", "default"),
+                    ("path_updated", model, "002003", "002004", "default"),
+                    ("path_updated", model, "002002", "002003", "default"),
+                    ("path_updated", model, "002001", "002002", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
     def test_add_sibling_left_root(self, model):
         node_wchildren = model.objects.get(desc="2")
-        obj = node_wchildren.add_sibling("left", desc="new")
+        with capture_signals() as signals:
+            obj = node_wchildren.add_sibling("left", desc="new")
         assert obj.get_depth() == 1
         expected = [
             ("1", 1, 0),
@@ -990,10 +1050,27 @@ class TestAddSibling(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "4", "5", "default"),
+                    ("path_updated", model, "3", "4", "default"),
+                    ("path_updated", model, "2", "3", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "004", "005", "default"),
+                    ("path_updated", model, "003", "004", "default"),
+                    ("path_updated", model, "002", "003", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
     def test_add_sibling_left(self, model):
         node_wchildren = model.objects.get(desc="23")
-        obj = node_wchildren.add_sibling("left", desc="new")
+        with capture_signals() as signals:
+            obj = node_wchildren.add_sibling("left", desc="new")
         assert obj.get_depth() == 2
         expected = [
             ("1", 1, 0),
@@ -1009,10 +1086,25 @@ class TestAddSibling(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "24", "25", "default"),
+                    ("path_updated", model, "23", "24", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "002004", "002005", "default"),
+                    ("path_updated", model, "002003", "002004", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
     def test_add_sibling_left_noleft_root(self, model):
         node = model.objects.get(desc="1")
-        obj = node.add_sibling("left", desc="new")
+        with capture_signals() as signals:
+            obj = node.add_sibling("left", desc="new")
         assert obj.get_depth() == 1
         expected = [
             ("new", 1, 0),
@@ -1028,10 +1120,29 @@ class TestAddSibling(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "4", "5", "default"),
+                    ("path_updated", model, "3", "4", "default"),
+                    ("path_updated", model, "2", "3", "default"),
+                    ("path_updated", model, "1", "2", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "004", "005", "default"),
+                    ("path_updated", model, "003", "004", "default"),
+                    ("path_updated", model, "002", "003", "default"),
+                    ("path_updated", model, "001", "002", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
     def test_add_sibling_left_noleft(self, model):
         node = model.objects.get(desc="231")
-        obj = node.add_sibling("left", desc="new")
+        with capture_signals() as signals:
+            obj = node.add_sibling("left", desc="new")
         assert obj.get_depth() == 3
         expected = [
             ("1", 1, 0),
@@ -1047,10 +1158,23 @@ class TestAddSibling(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "231", "232", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "002003001", "002003002", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
     def test_add_sibling_right_root(self, model):
         node_wchildren = model.objects.get(desc="2")
-        obj = node_wchildren.add_sibling("right", desc="new")
+        with capture_signals() as signals:
+            obj = node_wchildren.add_sibling("right", desc="new")
         assert obj.get_depth() == 1
         expected = [
             ("1", 1, 0),
@@ -1066,10 +1190,25 @@ class TestAddSibling(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "4", "5", "default"),
+                    ("path_updated", model, "3", "4", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "004", "005", "default"),
+                    ("path_updated", model, "003", "004", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
     def test_add_sibling_right(self, model):
         node_wchildren = model.objects.get(desc="23")
-        obj = node_wchildren.add_sibling("right", desc="new")
+        with capture_signals() as signals:
+            obj = node_wchildren.add_sibling("right", desc="new")
         assert obj.get_depth() == 2
         expected = [
             ("1", 1, 0),
@@ -1085,10 +1224,24 @@ class TestAddSibling(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+        assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "24", "25", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "002004", "002005", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
     def test_add_sibling_right_noright_root(self, model):
         node = model.objects.get(desc="4")
-        obj = node.add_sibling("right", desc="new")
+        with capture_signals() as signals:
+            obj = node.add_sibling("right", desc="new")
         assert obj.get_depth() == 1
         expected = [
             ("1", 1, 0),
@@ -1104,10 +1257,13 @@ class TestAddSibling(TestNonEmptyTree):
             ("new", 1, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            assert signals == []
 
     def test_add_sibling_right_noright(self, model):
         node = model.objects.get(desc="231")
-        obj = node.add_sibling("right", desc="new")
+        with capture_signals() as signals:
+            obj = node.add_sibling("right", desc="new")
         assert obj.get_depth() == 3
         expected = [
             ("1", 1, 0),
@@ -1123,6 +1279,8 @@ class TestAddSibling(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            assert signals == []
 
     def test_add_sibling_with_passed_instance(self, model):
         node_wchildren = model.objects.get(desc="2")
@@ -1288,7 +1446,8 @@ class TestMoveSortedErrors(TestTreeBase):
 class TestMoveLeafRoot(TestNonEmptyTree):
     def test_move_leaf_last_sibling_root(self, model):
         target = model.objects.get(desc="2")
-        model.objects.get(desc="231").move(target, "last-sibling")
+        with capture_signals() as signals:
+            model.objects.get(desc="231").move(target, "last-sibling")
         expected = [
             ("1", 1, 0),
             ("2", 1, 4),
@@ -1302,10 +1461,23 @@ class TestMoveLeafRoot(TestNonEmptyTree):
             ("231", 1, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "231", "5", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "002003001", "005", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
     def test_move_leaf_first_sibling_root(self, model):
         target = model.objects.get(desc="2")
-        model.objects.get(desc="231").move(target, "first-sibling")
+        with capture_signals() as signals:
+            model.objects.get(desc="231").move(target, "first-sibling")
         expected = [
             ("231", 1, 0),
             ("1", 1, 0),
@@ -1319,10 +1491,31 @@ class TestMoveLeafRoot(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "4", "5", "default"),
+                    ("path_updated", model, "3", "4", "default"),
+                    ("path_updated", model, "2", "3", "default"),
+                    ("path_updated", model, "1", "2", "default"),
+                    ("path_updated", model, "331", "1", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "004", "005", "default"),
+                    ("path_updated", model, "003", "004", "default"),
+                    ("path_updated", model, "002", "003", "default"),
+                    ("path_updated", model, "001", "002", "default"),
+                    ("path_updated", model, "003003001", "001", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
     def test_move_leaf_left_sibling_root(self, model):
         target = model.objects.get(desc="2")
-        model.objects.get(desc="231").move(target, "left")
+        with capture_signals() as signals:
+            model.objects.get(desc="231").move(target, "left")
         expected = [
             ("1", 1, 0),
             ("231", 1, 0),
@@ -1336,10 +1529,29 @@ class TestMoveLeafRoot(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "4", "5", "default"),
+                    ("path_updated", model, "3", "4", "default"),
+                    ("path_updated", model, "2", "3", "default"),
+                    ("path_updated", model, "331", "2", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "004", "005", "default"),
+                    ("path_updated", model, "003", "004", "default"),
+                    ("path_updated", model, "002", "003", "default"),
+                    ("path_updated", model, "003003001", "002", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
     def test_move_leaf_right_sibling_root(self, model):
         target = model.objects.get(desc="2")
-        model.objects.get(desc="231").move(target, "right")
+        with capture_signals() as signals:
+            model.objects.get(desc="231").move(target, "right")
         expected = [
             ("1", 1, 0),
             ("2", 1, 4),
@@ -1353,10 +1565,27 @@ class TestMoveLeafRoot(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "4", "5", "default"),
+                    ("path_updated", model, "3", "4", "default"),
+                    ("path_updated", model, "231", "3", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "004", "005", "default"),
+                    ("path_updated", model, "003", "004", "default"),
+                    ("path_updated", model, "002003001", "003", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
     def test_move_leaf_last_child_root(self, model):
         target = model.objects.get(desc="2")
-        model.objects.get(desc="231").move(target, "last-child")
+        with capture_signals() as signals:
+            model.objects.get(desc="231").move(target, "last-child")
         expected = [
             ("1", 1, 0),
             ("2", 1, 5),
@@ -1370,10 +1599,23 @@ class TestMoveLeafRoot(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "231", "25", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "002003001", "002005", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
     def test_move_leaf_first_child_root(self, model):
         target = model.objects.get(desc="2")
-        model.objects.get(desc="231").move(target, "first-child")
+        with capture_signals() as signals:
+            model.objects.get(desc="231").move(target, "first-child")
         expected = [
             ("1", 1, 0),
             ("2", 1, 5),
@@ -1387,13 +1629,34 @@ class TestMoveLeafRoot(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "24", "25", "default"),
+                    ("path_updated", model, "23", "24", "default"),
+                    ("path_updated", model, "22", "23", "default"),
+                    ("path_updated", model, "21", "22", "default"),
+                    ("path_updated", model, "241", "21", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "002004", "002005", "default"),
+                    ("path_updated", model, "002003", "002004", "default"),
+                    ("path_updated", model, "002002", "002003", "default"),
+                    ("path_updated", model, "002001", "002002", "default"),
+                    ("path_updated", model, "002004001", "002001", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
 
 @pytest.mark.django_db
 class TestMoveLeaf(TestNonEmptyTree):
     def test_move_leaf_last_sibling(self, model):
         target = model.objects.get(desc="22")
-        model.objects.get(desc="231").move(target, "last-sibling")
+        with capture_signals() as signals:
+            model.objects.get(desc="231").move(target, "last-sibling")
         expected = [
             ("1", 1, 0),
             ("2", 1, 5),
@@ -1407,10 +1670,23 @@ class TestMoveLeaf(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "231", "25", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "002003001", "002005", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
     def test_move_leaf_first_sibling(self, model):
         target = model.objects.get(desc="22")
-        model.objects.get(desc="231").move(target, "first-sibling")
+        with capture_signals() as signals:
+            model.objects.get(desc="231").move(target, "first-sibling")
         expected = [
             ("1", 1, 0),
             ("2", 1, 5),
@@ -1424,10 +1700,31 @@ class TestMoveLeaf(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "24", "25", "default"),
+                    ("path_updated", model, "23", "24", "default"),
+                    ("path_updated", model, "22", "23", "default"),
+                    ("path_updated", model, "21", "22", "default"),
+                    ("path_updated", model, "241", "21", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "002004", "002005", "default"),
+                    ("path_updated", model, "002003", "002004", "default"),
+                    ("path_updated", model, "002002", "002003", "default"),
+                    ("path_updated", model, "002001", "002002", "default"),
+                    ("path_updated", model, "002004001", "002001", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
     def test_move_leaf_left_sibling(self, model):
         target = model.objects.get(desc="22")
-        model.objects.get(desc="231").move(target, "left")
+        with capture_signals() as signals:
+            model.objects.get(desc="231").move(target, "left")
         expected = [
             ("1", 1, 0),
             ("2", 1, 5),
@@ -1441,10 +1738,29 @@ class TestMoveLeaf(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "24", "25", "default"),
+                    ("path_updated", model, "23", "24", "default"),
+                    ("path_updated", model, "22", "23", "default"),
+                    ("path_updated", model, "241", "22", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "002004", "002005", "default"),
+                    ("path_updated", model, "002003", "002004", "default"),
+                    ("path_updated", model, "002002", "002003", "default"),
+                    ("path_updated", model, "002004001", "002002", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
     def test_move_leaf_right_sibling(self, model):
         target = model.objects.get(desc="22")
-        model.objects.get(desc="231").move(target, "right")
+        with capture_signals() as signals:
+            model.objects.get(desc="231").move(target, "right")
         expected = [
             ("1", 1, 0),
             ("2", 1, 5),
@@ -1458,15 +1774,35 @@ class TestMoveLeaf(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "24", "25", "default"),
+                    ("path_updated", model, "23", "24", "default"),
+                    ("path_updated", model, "241", "23", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "002004", "002005", "default"),
+                    ("path_updated", model, "002003", "002004", "default"),
+                    ("path_updated", model, "002004001", "002003", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
     def test_move_leaf_left_sibling_itself(self, model):
         target = model.objects.get(desc="231")
-        model.objects.get(desc="231").move(target, "left")
+        with capture_signals() as signals:
+            model.objects.get(desc="231").move(target, "left")
         assert self.got(model) == UNCHANGED
+        if issubclass(model, MP_Node):
+            assert signals == []
 
     def test_move_leaf_last_child(self, model):
         target = model.objects.get(desc="22")
-        model.objects.get(desc="231").move(target, "last-child")
+        with capture_signals() as signals:
+            model.objects.get(desc="231").move(target, "last-child")
         expected = [
             ("1", 1, 0),
             ("2", 1, 4),
@@ -1480,10 +1816,23 @@ class TestMoveLeaf(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "231", "221", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "002003001", "002002001", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
     def test_move_leaf_first_child(self, model):
         target = model.objects.get(desc="22")
-        model.objects.get(desc="231").move(target, "first-child")
+        with capture_signals() as signals:
+            model.objects.get(desc="231").move(target, "first-child")
         expected = [
             ("1", 1, 0),
             ("2", 1, 4),
@@ -1497,13 +1846,26 @@ class TestMoveLeaf(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "231", "221", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "002003001", "002002001", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
 
 @pytest.mark.django_db
 class TestMoveBranchRoot(TestNonEmptyTree):
     def test_move_branch_first_sibling_root(self, model):
         target = model.objects.get(desc="2")
-        model.objects.get(desc="4").move(target, "first-sibling")
+        with capture_signals() as signals:
+            model.objects.get(desc="4").move(target, "first-sibling")
         expected = [
             ("4", 1, 1),
             ("41", 2, 0),
@@ -1517,10 +1879,31 @@ class TestMoveBranchRoot(TestNonEmptyTree):
             ("3", 1, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "4", "6", "default"),
+                    ("path_updated", model, "3", "4", "default"),
+                    ("path_updated", model, "2", "3", "default"),
+                    ("path_updated", model, "1", "2", "default"),
+                    ("path_updated", model, "6", "1", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "004", "006", "default"),
+                    ("path_updated", model, "003", "004", "default"),
+                    ("path_updated", model, "002", "003", "default"),
+                    ("path_updated", model, "001", "002", "default"),
+                    ("path_updated", model, "006", "001", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
     def test_move_branch_last_sibling_root(self, model):
         target = model.objects.get(desc="2")
-        model.objects.get(desc="4").move(target, "last-sibling")
+        with capture_signals() as signals:
+            model.objects.get(desc="4").move(target, "last-sibling")
         expected = [
             ("1", 1, 0),
             ("2", 1, 4),
@@ -1534,10 +1917,13 @@ class TestMoveBranchRoot(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            assert signals == []
 
     def test_move_branch_left_sibling_root(self, model):
         target = model.objects.get(desc="2")
-        model.objects.get(desc="4").move(target, "left")
+        with capture_signals() as signals:
+            model.objects.get(desc="4").move(target, "left")
         expected = [
             ("1", 1, 0),
             ("4", 1, 1),
@@ -1551,10 +1937,30 @@ class TestMoveBranchRoot(TestNonEmptyTree):
             ("3", 1, 0),
         ]
         assert self.got(model) == expected
+        assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "4", "6", "default"),
+                    ("path_updated", model, "3", "4", "default"),
+                    ("path_updated", model, "2", "3", "default"),
+                    ("path_updated", model, "6", "2", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "004", "006", "default"),
+                    ("path_updated", model, "003", "004", "default"),
+                    ("path_updated", model, "002", "003", "default"),
+                    ("path_updated", model, "006", "002", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
     def test_move_branch_right_sibling_root(self, model):
         target = model.objects.get(desc="2")
-        model.objects.get(desc="4").move(target, "right")
+        with capture_signals() as signals:
+            model.objects.get(desc="4").move(target, "right")
         expected = [
             ("1", 1, 0),
             ("2", 1, 4),
@@ -1568,10 +1974,27 @@ class TestMoveBranchRoot(TestNonEmptyTree):
             ("3", 1, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "4", "6", "default"),
+                    ("path_updated", model, "3", "4", "default"),
+                    ("path_updated", model, "6", "3", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "004", "006", "default"),
+                    ("path_updated", model, "003", "004", "default"),
+                    ("path_updated", model, "006", "003", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
     def test_move_branch_left_noleft_sibling_root(self, model):
         target = model.objects.get(desc="2").get_first_sibling()
-        model.objects.get(desc="4").move(target, "left")
+        with capture_signals() as signals:
+            model.objects.get(desc="4").move(target, "left")
         expected = [
             ("4", 1, 1),
             ("41", 2, 0),
@@ -1585,10 +2008,31 @@ class TestMoveBranchRoot(TestNonEmptyTree):
             ("3", 1, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "4", "6", "default"),
+                    ("path_updated", model, "3", "4", "default"),
+                    ("path_updated", model, "2", "3", "default"),
+                    ("path_updated", model, "1", "2", "default"),
+                    ("path_updated", model, "6", "1", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "004", "006", "default"),
+                    ("path_updated", model, "003", "004", "default"),
+                    ("path_updated", model, "002", "003", "default"),
+                    ("path_updated", model, "001", "002", "default"),
+                    ("path_updated", model, "006", "001", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
     def test_move_branch_right_noright_sibling_root(self, model):
         target = model.objects.get(desc="2").get_last_sibling()
-        model.objects.get(desc="4").move(target, "right")
+        with capture_signals() as signals:
+            model.objects.get(desc="4").move(target, "right")
         expected = [
             ("1", 1, 0),
             ("2", 1, 4),
@@ -1602,10 +2046,13 @@ class TestMoveBranchRoot(TestNonEmptyTree):
             ("41", 2, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            assert signals == []
 
     def test_move_branch_first_child_root(self, model):
         target = model.objects.get(desc="2")
-        model.objects.get(desc="4").move(target, "first-child")
+        with capture_signals() as signals:
+            model.objects.get(desc="4").move(target, "first-child")
         expected = [
             ("1", 1, 0),
             ("2", 1, 5),
@@ -1619,10 +2066,31 @@ class TestMoveBranchRoot(TestNonEmptyTree):
             ("3", 1, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "24", "25", "default"),
+                    ("path_updated", model, "23", "24", "default"),
+                    ("path_updated", model, "22", "23", "default"),
+                    ("path_updated", model, "21", "22", "default"),
+                    ("path_updated", model, "4", "21", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "002004", "002005", "default"),
+                    ("path_updated", model, "002003", "002004", "default"),
+                    ("path_updated", model, "002002", "002003", "default"),
+                    ("path_updated", model, "002001", "002002", "default"),
+                    ("path_updated", model, "004", "002001", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
     def test_move_branch_last_child_root(self, model):
         target = model.objects.get(desc="2")
-        model.objects.get(desc="4").move(target, "last-child")
+        with capture_signals() as signals:
+            model.objects.get(desc="4").move(target, "last-child")
         expected = [
             ("1", 1, 0),
             ("2", 1, 5),
@@ -1636,13 +2104,26 @@ class TestMoveBranchRoot(TestNonEmptyTree):
             ("3", 1, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "4", "25", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "004", "002005", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
 
 @pytest.mark.django_db
 class TestMoveBranch(TestNonEmptyTree):
     def test_move_branch_first_sibling(self, model):
         target = model.objects.get(desc="23")
-        model.objects.get(desc="4").move(target, "first-sibling")
+        with capture_signals() as signals:
+            model.objects.get(desc="4").move(target, "first-sibling")
         expected = [
             ("1", 1, 0),
             ("2", 1, 5),
@@ -1656,10 +2137,31 @@ class TestMoveBranch(TestNonEmptyTree):
             ("3", 1, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "24", "25", "default"),
+                    ("path_updated", model, "23", "24", "default"),
+                    ("path_updated", model, "22", "23", "default"),
+                    ("path_updated", model, "21", "22", "default"),
+                    ("path_updated", model, "4", "21", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "002004", "002005", "default"),
+                    ("path_updated", model, "002003", "002004", "default"),
+                    ("path_updated", model, "002002", "002003", "default"),
+                    ("path_updated", model, "002001", "002002", "default"),
+                    ("path_updated", model, "004", "002001", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
     def test_move_branch_last_sibling(self, model):
         target = model.objects.get(desc="23")
-        model.objects.get(desc="4").move(target, "last-sibling")
+        with capture_signals() as signals:
+            model.objects.get(desc="4").move(target, "last-sibling")
         expected = [
             ("1", 1, 0),
             ("2", 1, 5),
@@ -1673,10 +2175,23 @@ class TestMoveBranch(TestNonEmptyTree):
             ("3", 1, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "4", "25", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "004", "002005", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
     def test_move_branch_left_sibling(self, model):
         target = model.objects.get(desc="23")
-        model.objects.get(desc="4").move(target, "left")
+        with capture_signals() as signals:
+            model.objects.get(desc="4").move(target, "left")
         expected = [
             ("1", 1, 0),
             ("2", 1, 5),
@@ -1690,10 +2205,27 @@ class TestMoveBranch(TestNonEmptyTree):
             ("3", 1, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "24", "25", "default"),
+                    ("path_updated", model, "23", "24", "default"),
+                    ("path_updated", model, "4", "23", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "002004", "002005", "default"),
+                    ("path_updated", model, "002003", "002004", "default"),
+                    ("path_updated", model, "004", "002003", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
     def test_move_branch_right_sibling(self, model):
         target = model.objects.get(desc="23")
-        model.objects.get(desc="4").move(target, "right")
+        with capture_signals() as signals:
+            model.objects.get(desc="4").move(target, "right")
         expected = [
             ("1", 1, 0),
             ("2", 1, 5),
@@ -1707,10 +2239,25 @@ class TestMoveBranch(TestNonEmptyTree):
             ("3", 1, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "24", "25", "default"),
+                    ("path_updated", model, "4", "24", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "002004", "002005", "default"),
+                    ("path_updated", model, "004", "002004", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
     def test_move_branch_left_noleft_sibling(self, model):
         target = model.objects.get(desc="23").get_first_sibling()
-        model.objects.get(desc="4").move(target, "left")
+        with capture_signals() as signals:
+            model.objects.get(desc="4").move(target, "left")
         expected = [
             ("1", 1, 0),
             ("2", 1, 5),
@@ -1724,10 +2271,31 @@ class TestMoveBranch(TestNonEmptyTree):
             ("3", 1, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "24", "25", "default"),
+                    ("path_updated", model, "23", "24", "default"),
+                    ("path_updated", model, "22", "23", "default"),
+                    ("path_updated", model, "21", "22", "default"),
+                    ("path_updated", model, "4", "21", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "002004", "002005", "default"),
+                    ("path_updated", model, "002003", "002004", "default"),
+                    ("path_updated", model, "002002", "002003", "default"),
+                    ("path_updated", model, "002001", "002002", "default"),
+                    ("path_updated", model, "004", "002001", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
     def test_move_branch_right_noright_sibling(self, model):
         target = model.objects.get(desc="23").get_last_sibling()
-        model.objects.get(desc="4").move(target, "right")
+        with capture_signals() as signals:
+            model.objects.get(desc="4").move(target, "right")
         expected = [
             ("1", 1, 0),
             ("2", 1, 5),
@@ -1741,16 +2309,32 @@ class TestMoveBranch(TestNonEmptyTree):
             ("3", 1, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "4", "25", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "004", "002005", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
     def test_move_branch_left_itself_sibling(self, model):
         target = model.objects.get(desc="4")
-        model.objects.get(desc="4").move(target, "left")
+        with capture_signals() as signals:
+            model.objects.get(desc="4").move(target, "left")
         assert self.got(model) == UNCHANGED
+        if issubclass(model, MP_Node):
+            assert signals == []
 
     def test_move_branch_first_child(self, model):
         target = model.objects.get(desc="23")
         node = model.objects.get(desc="4")
-        node.move(target, "first-child")
+        with capture_signals() as signals:
+            node.move(target, "first-child")
         expected = [
             ("1", 1, 0),
             ("2", 1, 4),
@@ -1763,6 +2347,21 @@ class TestMoveBranch(TestNonEmptyTree):
             ("24", 2, 0),
             ("3", 1, 0),
         ]
+
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "231", "232", "default"),
+                    ("path_updated", model, "4", "231", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "002003001", "002003002", "default"),
+                    ("path_updated", model, "004", "002003001", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
         # Check that for MP, NS and LT nodes, the depth was updated on the in-memory instances
         assert node.get_depth() == 3
@@ -1771,7 +2370,8 @@ class TestMoveBranch(TestNonEmptyTree):
 
     def test_move_branch_last_child(self, model):
         target = model.objects.get(desc="23")
-        model.objects.get(desc="4").move(target, "last-child")
+        with capture_signals() as signals:
+            model.objects.get(desc="4").move(target, "last-child")
         expected = [
             ("1", 1, 0),
             ("2", 1, 4),
@@ -1785,6 +2385,18 @@ class TestMoveBranch(TestNonEmptyTree):
             ("3", 1, 0),
         ]
         assert self.got(model) == expected
+        if issubclass(model, MP_Node):
+            if model.steplen == 1:
+                expected_signals = [
+                    ("path_updated", model, "4", "232", "default"),
+                ]
+            elif model.steplen == 3:
+                expected_signals = [
+                    ("path_updated", model, "004", "002003002", "default"),
+                ]
+            else:
+                assert False, f"Unexpected steplen: {model.steplen}"
+            assert signals == expected_signals
 
 
 @pytest.mark.django_db
@@ -2611,11 +3223,16 @@ class TestMP_TreeFix(TestTreeBase):
 
     def test_fix_tree_fix_paths(self, mpshort_model):
         self.add_broken_test_data(mpshort_model)
-        mpshort_model.fix_tree(fix_paths=True)
+        with capture_signals() as signals:
+            mpshort_model.fix_tree(fix_paths=True)
         got = self.got(mpshort_model)
         expected = self.expected_no_holes[mpshort_model]
         assert got == expected
         assert all(not group for group in mpshort_model.find_problems())
+        if issubclass(mpshort_model, MP_Node):
+            # Confirm that path_updated signals were fired for any path moves -
+            # enumerating the exact sequence of updates would be too brittle
+            assert any(signal[0] == "path_updated" for signal in signals)
 
     def test_fix_tree_with_parent(self, mpshort_model):
         """
@@ -2644,7 +3261,8 @@ class TestMP_TreeFix(TestTreeBase):
         # Fix the depth on the parent - we need a valid parent to operate on only part of a tree
         parent.depth = 1
         parent.save()
-        mpshort_model.fix_tree(parent=parent, fix_paths=True)
+        with capture_signals() as signals:
+            mpshort_model.fix_tree(parent=parent, fix_paths=True)
         got = self.got(mpshort_model)
         expected_partial = {
             models.MP_TestNodeShortPath: [
@@ -2671,6 +3289,10 @@ class TestMP_TreeFix(TestTreeBase):
         problems = mpshort_model.find_problems()
         assert not any([problems[0], problems[1], problems[2], problems[4]])
         assert set(problems[3]) == set(mpshort_model.objects.exclude(path__startswith="4").values_list("pk", flat=True))
+        if issubclass(mpshort_model, MP_Node):
+            # Confirm that path_updated signals were fired for any path moves -
+            # enumerating the exact sequence of updates would be too brittle
+            assert any(signal[0] == "path_updated" for signal in signals)
 
 
 @pytest.mark.django_db

--- a/treebeard/ltree/__init__.py
+++ b/treebeard/ltree/__init__.py
@@ -11,12 +11,16 @@ from django.core import serializers
 from django.db import models, transaction
 from django.db.models import F, Func, OuterRef, Q, Subquery, Value
 from django.db.models.functions import Concat
+from django.dispatch import Signal
 from django.utils.translation import gettext_noop as _
 
 from treebeard.exceptions import InvalidMoveToDescendant, NodeAlreadySaved, PathOverflow
 from treebeard.models import Node
 
 from .fields import Ltree2Text, PathField, PathValue, Subpath, Text2LTree
+
+subtree_moved_right = Signal()
+subtree_moved = Signal()
 
 
 class InvalidLabelConstraints(Exception): ...
@@ -177,9 +181,10 @@ class LT_ComplexAddMoveHandler:
                     Text2LTree(Concat(Ltree2Text(Subpath(F("path"), node_depth - 1, 1)), Value("A"))),
                 )
             )
-            result_class.objects.filter(
+            queryset = result_class.objects.filter(
                 path__descendants=start_node.path[:-1], path__gte=start_node.path, path__depth__gt=node_depth
-            ).update(
+            )
+            queryset.update(
                 path=Concat(
                     Subpath(F("path"), 0, node_depth - 1),
                     Text2LTree(Concat(Ltree2Text(Subpath(F("path"), node_depth - 1, 1)), Value("A"))),
@@ -191,9 +196,16 @@ class LT_ComplexAddMoveHandler:
             result_class.objects.filter(path__gte=start_node.path, path__depth=1).update(
                 path=Text2LTree(Concat(Ltree2Text(Subpath(F("path"), 0, 1)), Value("A")))
             )
-            result_class.objects.filter(path__gte=start_node.path, path__depth__gt=1).update(
+            queryset = result_class.objects.filter(path__gte=start_node.path, path__depth__gt=1)
+            queryset.update(
                 path=Concat(Text2LTree(Concat(Ltree2Text(Subpath(F("path"), 0, 1)), Value("A"))), Subpath(F("path"), 1))
             )
+
+        subtree_moved_right.send(
+            sender=result_class,
+            path=start_node.path,
+            using=queryset.db,
+        )
 
 
 class LT_AddRootHandler:
@@ -374,15 +386,24 @@ class LT_MoveHandler(LT_ComplexAddMoveHandler):
 
         # Update the path for all the descendants of the node
         result_class = self.node_cls.tree_model()
-        result_class.objects.filter(path__descendants=self.node.path, path__depth__gt=len(self.node.path)).update(
+        old_path = self.node.path
+        queryset = result_class.objects.filter(path__descendants=old_path, path__depth__gt=len(old_path))
+        queryset.update(
             path=Concat(
                 Value(new_path, output_field=PathField()),
-                Subpath(F("path"), len(self.node.path)),
+                Subpath(F("path"), len(old_path)),
             )
         )
         # And update the path for the node itself
         self.node.path = new_path
         self.node.save()
+
+        subtree_moved.send(
+            sender=result_class,
+            old_path=old_path,
+            new_path=new_path,
+            using=queryset.db,
+        )
 
 
 class LT_Node(Node):

--- a/treebeard/ltree/__init__.py
+++ b/treebeard/ltree/__init__.py
@@ -21,6 +21,7 @@ from .fields import Ltree2Text, PathField, PathValue, Subpath, Text2LTree
 
 subtree_moved_right = Signal()
 subtree_moved = Signal()
+nodes_deleted = Signal()
 
 
 class InvalidLabelConstraints(Exception): ...
@@ -120,7 +121,9 @@ class LT_NodeQuerySet(models.query.QuerySet):
             return super(LT_NodeQuerySet, model.objects.none()).delete(*args, **kwargs)
 
         query = functools.reduce(operator.or_, [Q(path__descendants=path) for path in paths_to_remove])
-        return super(LT_NodeQuerySet, model.objects.filter(query)).delete(*args, **kwargs)
+        result = super(LT_NodeQuerySet, model.objects.filter(query)).delete(*args, **kwargs)
+        nodes_deleted.send(sender=model, paths_to_remove=paths_to_remove, using=self.db)
+        return result
 
     delete.alters_data = True
     delete.queryset_only = True

--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -8,6 +8,7 @@ from django.core import serializers
 from django.db import connections, models, router, transaction
 from django.db.models import F, Func, OuterRef, Q, Subquery, Value
 from django.db.models.functions import Concat, Greatest, Length, Substr
+from django.dispatch import Signal
 from django.utils.translation import gettext_noop as _
 
 from treebeard.exceptions import InvalidMoveToDescendant, NodeAlreadySaved, PathOverflow
@@ -83,6 +84,9 @@ class MP_NodeManager(models.Manager):
     def get_queryset(self):
         """Sets the custom queryset as the default."""
         return MP_NodeQuerySet(self.model).order_by("path")
+
+
+path_updated = Signal()
 
 
 class MP_ComplexAddMoveHandler:
@@ -193,7 +197,11 @@ class MP_ComplexAddMoveHandler:
             update_kwargs["depth"] = Length(new_path_value) / self.node_cls.steplen
         update_kwargs["path"] = new_path_value
 
-        self.node_cls.tree_model().objects.filter(path__startswith=oldpath).update(**update_kwargs)
+        model = self.node_cls.tree_model()
+        queryset = model.objects.filter(path__startswith=oldpath)
+        update_count = queryset.update(**update_kwargs)
+        if update_count > 0:
+            path_updated.send(sender=model, old_path=oldpath, new_path=newpath, using=queryset.db)
 
 
 class MP_AddRootHandler:
@@ -746,9 +754,10 @@ class MP_Node(Node):
 
     @classmethod
     def _rewrite_node_path(cls, old_path, new_path):
-        cls.objects.filter(path__startswith=old_path).update(
-            path=Concat(Value(new_path), Substr("path", len(old_path) + 1))
-        )
+        queryset = cls.objects.filter(path__startswith=old_path)
+        update_count = queryset.update(path=Concat(Value(new_path), Substr("path", len(old_path) + 1)))
+        if update_count > 0:
+            path_updated.send(sender=cls, old_path=old_path, new_path=new_path, using=queryset.db)
 
     @classmethod
     def get_tree(cls, parent=None):

--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -15,6 +15,9 @@ from treebeard.exceptions import InvalidMoveToDescendant, NodeAlreadySaved, Path
 from treebeard.models import Node
 from treebeard.numconv import NumConv
 
+path_updated = Signal()
+nodes_deleted = Signal()
+
 
 class MP_NodeQuerySet(models.query.QuerySet):
     """
@@ -72,7 +75,12 @@ class MP_NodeQuerySet(models.query.QuerySet):
         query = Q(pk__in=pks_to_remove)
         for path in paths_to_remove:
             query |= Q(path__startswith=path)
-        return super(MP_NodeQuerySet, model.objects.filter(query)).delete(*args, **kwargs)
+        count, deletion_map = super(MP_NodeQuerySet, model.objects.filter(query)).delete(*args, **kwargs)
+        if count > 0:
+            nodes_deleted.send(
+                sender=model, pks_to_remove=pks_to_remove, paths_to_remove=paths_to_remove, using=self.db
+            )
+        return count, deletion_map
 
     delete.alters_data = True
     delete.queryset_only = True
@@ -84,9 +92,6 @@ class MP_NodeManager(models.Manager):
     def get_queryset(self):
         """Sets the custom queryset as the default."""
         return MP_NodeQuerySet(self.model).order_by("path")
-
-
-path_updated = Signal()
 
 
 class MP_ComplexAddMoveHandler:

--- a/treebeard/ns_tree.py
+++ b/treebeard/ns_tree.py
@@ -7,6 +7,7 @@ from itertools import groupby
 from django.core import serializers
 from django.db import models, transaction
 from django.db.models import Case, F, Q, When
+from django.dispatch import Signal
 from django.utils.translation import gettext_noop as _
 
 from treebeard.exceptions import InvalidMoveToDescendant, NodeAlreadySaved
@@ -76,6 +77,11 @@ class NS_NodeManager(models.Manager):
         return NS_NodeQuerySet(self.model).order_by("tree_id", "lft")
 
 
+gap_altered = Signal()
+tree_ids_incremented = Signal()
+subtree_moved = Signal()
+
+
 class NS_Node(Node):
     """Abstract model to create your own Nested Sets Trees."""
 
@@ -140,14 +146,20 @@ class NS_Node(Node):
         start_index within the given tree by the given offset.
         """
         output_field = models.PositiveIntegerField()
-        cls.objects.filter(rgt__gte=start_index, tree_id=tree_id).update(
+        queryset = cls.objects.filter(rgt__gte=start_index, tree_id=tree_id)
+        update_count = queryset.update(
             lft=Case(When(lft__gte=start_index, then=F("lft") + offset), default=F("lft"), output_field=output_field),
             rgt=F("rgt") + offset,
         )
+        if update_count > 0:
+            gap_altered.send(sender=cls, tree_id=tree_id, start_index=start_index, offset=offset, using=queryset.db)
 
     @classmethod
     def _move_tree_right(cls, tree_id):
-        cls.objects.filter(tree_id__gte=tree_id).update(tree_id=F("tree_id") + 1)
+        queryset = cls.objects.filter(tree_id__gte=tree_id)
+        update_count = queryset.update(tree_id=F("tree_id") + 1)
+        if update_count > 0:
+            tree_ids_incremented.send(sender=cls, min_tree_id=tree_id, using=queryset.db)
 
     @transaction.atomic
     def add_child(self, **kwargs):
@@ -383,12 +395,24 @@ class NS_Node(Node):
 
         # move the tree to the hole
         jump = newpos - self.lft
-        cls.objects.filter(tree_id=self.tree_id, lft__range=(self.lft, self.rgt)).update(
+        queryset = cls.objects.filter(tree_id=self.tree_id, lft__range=(self.lft, self.rgt))
+        update_count = queryset.update(
             tree_id=target_tree,
             lft=F("lft") + jump,
             rgt=F("rgt") + jump,
             depth=F("depth") + depthdiff,
         )
+        if update_count > 0:
+            subtree_moved.send(
+                sender=cls,
+                tree_id=self.tree_id,
+                lft=self.lft,
+                rgt=self.rgt,
+                target_tree_id=target_tree,
+                index_offset=jump,
+                depth_offset=depthdiff,
+                using=queryset.db,
+            )
 
         # close the gap
         cls._close_gap(self.lft, self.rgt, self.tree_id)

--- a/treebeard/ns_tree.py
+++ b/treebeard/ns_tree.py
@@ -13,6 +13,11 @@ from django.utils.translation import gettext_noop as _
 from treebeard.exceptions import InvalidMoveToDescendant, NodeAlreadySaved
 from treebeard.models import Node
 
+gap_altered = Signal()
+tree_ids_incremented = Signal()
+subtree_moved = Signal()
+nodes_deleted = Signal()
+
 
 class NS_NodeQuerySet(models.query.QuerySet):
     """
@@ -54,6 +59,7 @@ class NS_NodeQuerySet(models.query.QuerySet):
         # call the default django delete method with the full set of nodes and descendants to delete,
         # and let it handle the removal of the user's foreign keys
         result = super(NS_NodeQuerySet, model.objects.filter(reduce(operator.or_, toremove))).delete(*args, **kwargs)
+        nodes_deleted.send(sender=model, removed_ranges=ranges, using=self.db)
 
         # Now closing the gap (Celko's trees book, page 62)
         # We do this for every gap that was left in the tree when the nodes
@@ -75,11 +81,6 @@ class NS_NodeManager(models.Manager):
     def get_queryset(self):
         """Sets the custom queryset as the default."""
         return NS_NodeQuerySet(self.model).order_by("tree_id", "lft")
-
-
-gap_altered = Signal()
-tree_ids_incremented = Signal()
-subtree_moved = Signal()
 
 
 class NS_Node(Node):

--- a/treebeard/ns_tree.py
+++ b/treebeard/ns_tree.py
@@ -134,12 +134,15 @@ class NS_Node(Node):
         return newobj
 
     @classmethod
-    def _move_right(cls, tree_id, rgt, lftmove=False, incdec=2):
-        lftop = "lft__gte" if lftmove else "lft__gt"
+    def _alter_gap(cls, tree_id, start_index, offset):
+        """
+        Open or close a gap in the lft/rgt sequence by changing all lft/rgt values greater than or equal to
+        start_index within the given tree by the given offset.
+        """
         output_field = models.PositiveIntegerField()
-        cls.objects.filter(rgt__gte=rgt, tree_id=tree_id).update(
-            lft=Case(When(**{lftop: rgt}, then=F("lft") + incdec), default=F("lft"), output_field=output_field),
-            rgt=Case(When(rgt__gte=rgt, then=F("rgt") + incdec), default=F("rgt"), output_field=output_field),
+        cls.objects.filter(rgt__gte=start_index, tree_id=tree_id).update(
+            lft=Case(When(lft__gte=start_index, then=F("lft") + offset), default=F("lft"), output_field=output_field),
+            rgt=F("rgt") + offset,
         )
 
     @classmethod
@@ -168,7 +171,7 @@ class NS_Node(Node):
             return new_sibling
 
         # we're adding the first child of this node
-        cls._move_right(node.tree_id, node.rgt, False, 2)
+        cls._alter_gap(node.tree_id, node.rgt, 2)
 
         if len(kwargs) == 1 and "instance" in kwargs:
             # adding the passed (unsaved) instance to the tree
@@ -265,17 +268,12 @@ class NS_Node(Node):
                 if pos == "first-sibling":
                     target = siblings[0]
 
-            move_right = cls._move_right
-
             if pos == "last-sibling":
                 newpos = target.get_parent().rgt
-                move_right(target.tree_id, newpos, False, 2)
-            elif pos == "first-sibling":
+                cls._alter_gap(target.tree_id, newpos, 2)
+            elif pos == "first-sibling" or pos == "left":
                 newpos = target.lft
-                move_right(target.tree_id, newpos - 1, False, 2)
-            elif pos == "left":
-                newpos = target.lft
-                move_right(target.tree_id, newpos, True, 2)
+                cls._alter_gap(target.tree_id, newpos, 2)
 
             newobj.lft = newpos
             newobj.rgt = newpos + 1
@@ -358,7 +356,7 @@ class NS_Node(Node):
         # first make a hole
         if pos == "last-child":
             newpos = parent.rgt
-            cls._move_right(target.tree_id, newpos, False, gap)
+            cls._alter_gap(target.tree_id, newpos, gap)
         elif target.is_root():
             newpos = 1
             if pos == "last-sibling":
@@ -371,13 +369,10 @@ class NS_Node(Node):
         else:
             if pos == "last-sibling":
                 newpos = target.get_parent().rgt
-                cls._move_right(target.tree_id, newpos, False, gap)
-            elif pos == "first-sibling":
+                cls._alter_gap(target.tree_id, newpos, gap)
+            elif pos == "first-sibling" or pos == "left":
                 newpos = target.lft
-                cls._move_right(target.tree_id, newpos - 1, False, gap)
-            elif pos == "left":
-                newpos = target.lft
-                cls._move_right(target.tree_id, newpos, True, gap)
+                cls._alter_gap(target.tree_id, newpos, gap)
 
         # we refresh 'self' because lft/rgt may have changed
         self.refresh_from_db()
@@ -403,11 +398,7 @@ class NS_Node(Node):
     @classmethod
     def _close_gap(cls, drop_lft, drop_rgt, tree_id):
         gapsize = drop_rgt - drop_lft + 1
-        output_field = models.PositiveIntegerField()
-        cls.objects.filter(Q(tree_id=tree_id) & (Q(lft__gt=drop_lft) | Q(rgt__gt=drop_lft))).update(
-            lft=Case(When(lft__gt=drop_lft, then=F("lft") - gapsize), default=F("lft"), output_field=output_field),
-            rgt=Case(When(rgt__gt=drop_lft, then=F("rgt") - gapsize), default=F("rgt"), output_field=output_field),
-        )
+        cls._alter_gap(tree_id, drop_lft, -gapsize)
 
     def get_children(self):
         """:returns: A queryset of all the node's children"""


### PR DESCRIPTION
Fixes #381; built on top of #395.

Implement the following signals that are fired after performing bulk updates or deletions on a tree:

* `MP_Node`: `path_updated`, `nodes_deleted`
* `NS_Node`: `gap_altered`, `tree_ids_incremented`, `subtree_moved`, `nodes_deleted`
* `LT_Node`: `subtree_moved_right`, `subtree_moved`, `nodes_deleted`

These should be sufficient to keep an external data store such as a search index in sync with the database.