### PR TITLE
Add bulk_create option to MP_Node.load_bulk()

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -279,14 +279,6 @@ API
 
      .. note::
 
-            If your node model has a ForeignKey this method will try to load
-            the related object before loading the data. If the related object
-            doesn't exist it won't load anything and will raise a DoesNotExist
-            exception. This is done because the dump_data method uses integers
-            to dump related objects.
-
-     .. note::
-
             If your node model has :attr:`node_order_by` enabled, it will
             take precedence over the order in the structure.
 

--- a/docs/source/mp_tree.rst
+++ b/docs/source/mp_tree.rst
@@ -258,7 +258,7 @@ extra steps, materialized path is more efficient than other approaches.
 
         MyNodeModel.fix_tree()
 
-
+  .. automethod:: load_bulk
 
 .. autoclass:: MP_NodeManager
   :show-inheritance:

--- a/tests/models.py
+++ b/tests/models.py
@@ -188,6 +188,7 @@ BASE_MODELS = [
 
 PROXY_MODELS = [AL_TestNode_Proxy, MP_TestNode_Proxy, NS_TestNode_Proxy]
 SORTED_MODELS = [AL_TestNodeSorted, MP_TestNodeSorted, NS_TestNodeSorted]
+MP_MODELS = [MP_TestNode, MP_TestNodeUuid, MP_TestNodeCustomId]
 MP_SHORTPATH_MODELS = [MP_TestNodeShortPath, MP_TestSortedNodeShortPath]
 RELATED_MODELS = [AL_TestNodeRelated, MP_TestNodeRelated, NS_TestNodeRelated]
 

--- a/tests/test_treebeard.py
+++ b/tests/test_treebeard.py
@@ -112,6 +112,12 @@ def related_model(request):
     return request.param
 
 
+@pytest.fixture(scope="function", params=models.MP_MODELS)
+def mp_model(request):
+    request.param.load_bulk(BASE_DATA)
+    return request.param
+
+
 @pytest.fixture(scope="function", params=models.MP_SHORTPATH_MODELS)
 def mpshort_model(request):
     return request.param
@@ -3514,6 +3520,52 @@ class TestMP_Tree(TestTreeBase):
         obj = obj.add_child().add_child().add_child()
         with pytest.raises(PathOverflow):
             obj.add_child()
+
+
+@pytest.mark.skipif(os.getenv("DATABASE_ENGINE") in ["mysql", "mssql"], reason="Unsupported database backend")
+@pytest.mark.django_db
+class TestMP_TreeLoadBulk(TestTreeBase):
+    def test_load_bulk_existing_with_bulk_create(self, mp_model, django_assert_max_num_queries):
+        # inserting on an existing node
+        node = mp_model.objects.get(desc="231")
+        with django_assert_max_num_queries(26):
+            ids = mp_model.load_bulk(BASE_DATA, node, bulk_create=True)
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 4),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 1),
+            ("231", 3, 4),
+            ("1", 4, 0),
+            ("2", 4, 4),
+            ("21", 5, 0),
+            ("22", 5, 0),
+            ("23", 5, 1),
+            ("231", 6, 0),
+            ("24", 5, 0),
+            ("3", 4, 0),
+            ("4", 4, 1),
+            ("41", 5, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        expected_descs = ["1", "2", "21", "22", "23", "231", "24", "3", "4", "41"]
+        got_descs = [obj.desc for obj in mp_model.objects.filter(pk__in=ids)]
+        assert sorted(got_descs) == sorted(expected_descs)
+        assert self.got(mp_model) == expected
+
+    def test_load_bulk_keeping_ids_with_bulk_create(self, mp_model):
+        exp = mp_model.dump_bulk(keep_ids=True)
+        mp_model.objects.all().delete()
+        mp_model.load_bulk(exp, parent=None, keep_ids=True, bulk_create=True)
+        got = mp_model.dump_bulk(keep_ids=True)
+        assert got == exp
+        # do we really have an unchanged tree after the dump/delete/load?
+        got = [(o.desc, o.get_depth(), o.get_children_count()) for o in mp_model.get_tree()]
+        assert got == UNCHANGED
 
 
 @pytest.mark.django_db

--- a/treebeard/models.py
+++ b/treebeard/models.py
@@ -9,6 +9,7 @@ from django.db import models, transaction
 from django.db.models import Q
 
 from treebeard.exceptions import InvalidPosition, MissingNodeOrderBy
+from treebeard.utils import prepare_dumpdata_for_loading
 
 
 class Node(models.Model):
@@ -77,27 +78,16 @@ class Node(models.Model):
 
         # tree, iterative preorder
         added = []
+        bulk_data = prepare_dumpdata_for_loading(cls, data=bulk_data, keep_ids=keep_ids)
         # stack of nodes to analyze
         stack = [(parent, node) for node in bulk_data[::-1]]
-        foreign_key_fields = {field.name for field in cls._meta.fields if (field.one_to_one or field.many_to_one)}
-        pk_field = cls._meta.pk.attname
 
         while stack:
             parent, node_struct = stack.pop()
-            # shallow copy of the data structure so it doesn't persist...
-            node_data = node_struct["data"].copy()
-            for field in foreign_key_fields:
-                # Append _id to field name, so that we don't need to load the foreign objects into memory
-                node_data[f"{field}_id"] = node_data.pop(field, None)
-            if keep_ids:
-                node_data["pk"] = node_struct[pk_field]
-
-            node_obj = parent.add_child(**node_data) if parent else cls.add_root(**node_data)
+            node_obj = parent.add_child(**node_struct["data"]) if parent else cls.add_root(**node_struct["data"])
             added.append(node_obj.pk)
-            if "children" in node_struct:
-                # extending the stack with the current node as the parent of
-                # the new nodes
-                stack.extend([(node_obj, node) for node in node_struct["children"][::-1]])
+            # extending the stack with the current node as the parent of the new nodes
+            stack.extend([(node_obj, node) for node in node_struct["children"][::-1]])
         return added
 
     @classmethod

--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -14,6 +14,7 @@ from django.utils.translation import gettext_noop as _
 from treebeard.exceptions import InvalidMoveToDescendant, NodeAlreadySaved, PathOverflow
 from treebeard.models import Node
 from treebeard.numconv import NumConv
+from treebeard.utils import prepare_dumpdata_for_loading
 
 path_updated = Signal()
 nodes_deleted = Signal()
@@ -1028,6 +1029,100 @@ class MP_Node(Node):
     def _get_children_path_interval(cls, path):
         """:returns: An interval of all possible children paths for a node."""
         return (path + cls.alphabet[0] * cls.steplen, path + cls.alphabet[-1] * cls.steplen)
+
+    @classmethod
+    @transaction.atomic
+    def load_bulk(
+        cls,
+        bulk_data,
+        parent=None,
+        keep_ids=False,
+        bulk_create=False,
+        batch_size=1000,
+    ) -> list:
+        """
+        Loads a list/dictionary structure to the tree.
+
+        :param bulk_data:
+
+            The data that will be loaded, the structure is a list of
+            dictionaries with 2 keys:
+
+            - ``data``: will store arguments that will be passed for object
+                creation, and
+
+            - ``children``: a list of dictionaries, each one has it's own
+                ``data`` and ``children`` keys (a recursive structure)
+
+        :param parent:
+
+            The node that will receive the structure as children, if not
+            specified the first level of the structure will be loaded as root
+            nodes
+
+        :param keep_ids:
+
+            If enabled, loads the nodes with the same primary keys that are
+            given in the structure. Will error if there are nodes without
+            primary key info or if the primary keys are already used.
+
+        :param bulk_create:
+
+            Whether to bulk create objects using Django's ``bulk_create()`` method. Only works
+            for models without multi-table inheritance. Also does not work with
+            MySQL and MSSQL database backends.
+
+        :param batch_size:
+
+            The batch size for ``bulk_create()`` when creating descendant nodes.
+            Default is 1000.
+
+        :returns: A list of the added node ids.
+
+        The ordering of nodes in the loaded data is preserved. If this
+        needs to be corrected (e.g., to cater for a new `node_order_by`)
+        then `fix_tree()` can be run separately on the imported subtree.
+        """
+
+        if not bulk_create:
+            return super().load_bulk(bulk_data, parent=parent, keep_ids=keep_ids)
+
+        conn = connections[router.db_for_write(cls)]
+        if not conn.features.can_return_rows_from_bulk_insert or conn.vendor == "microsoft":
+            raise ValueError("Database backend does not support bulk load. Use load_bulk without bulk_create=True.")
+
+        added = []
+        bulk_data = prepare_dumpdata_for_loading(cls, data=bulk_data, keep_ids=keep_ids)
+        children_to_create = []
+
+        def _build_children(parent_node, children) -> None:
+            child_depth = parent_node.depth + 1
+
+            for i, child in enumerate(children):
+                child_obj = cls(
+                    depth=child_depth,
+                    numchild=len(child["children"]),
+                    path=cls._get_path(parent_node.path, child_depth, i + 1),
+                    **child["data"],
+                )
+
+                children_to_create.append(child_obj)
+
+                # Recursively process grandchildren
+                _build_children(child_obj, child["children"])
+
+        # Create first level of the bulk data using standard operations, since there may be existing siblings
+        for node_struct in bulk_data:
+            node_struct["data"]["numchild"] = len(node_struct["children"])  # Set numchild manually
+            node_obj = parent.add_child(**node_struct["data"]) if parent else cls.add_root(**node_struct["data"])
+            added.append(node_obj.pk)
+            _build_children(node_obj, node_struct["children"])
+
+        # Bulk create descendants
+        created = cls.objects.bulk_create(children_to_create, batch_size=batch_size)
+        added.extend([obj.pk for obj in created])
+
+        return added
 
     class Meta:
         """Abstract model."""

--- a/treebeard/utils.py
+++ b/treebeard/utils.py
@@ -1,0 +1,46 @@
+from copy import deepcopy
+from functools import cache
+from typing import Any, NotRequired, TypedDict
+
+from django.db import models
+
+
+class DumpData(TypedDict):
+    data: dict[str, Any]
+    children: NotRequired[list["DumpData"]]
+
+
+class PreparedDumpData(DumpData):
+    children: list["DumpData"]
+    pk: NotRequired[Any]
+
+
+@cache
+def get_foreign_key_fields(cls: type[models.Model]) -> set[str]:
+    return {field.name for field in cls._meta.fields if (field.one_to_one or field.many_to_one)}
+
+
+def prepare_dumpdata_for_loading(
+    cls: type[models.Model], *, data: list[DumpData], keep_ids: bool
+) -> list[PreparedDumpData]:
+    """
+    Given data previously dumped using dump_data, prepares the data for use with load_data.
+
+    - Modifies foreign key field names to append an `_id` suffix
+    - Adds a pk field if `keep_ids` is True.
+    """
+    foreign_key_fields = get_foreign_key_fields(cls)
+    pk_field = cls._meta.pk.attname
+    output = []
+    for item in data:
+        prepared = deepcopy(item)
+        for field in foreign_key_fields:
+            # Append _id to field name, so that we don't need to load the foreign objects into memory
+            prepared["data"][f"{field}_id"] = prepared["data"].pop(field, None)
+        if keep_ids:
+            prepared["data"]["pk"] = item[pk_field]
+
+        prepared["children"] = prepare_dumpdata_for_loading(cls, data=item.get("children", []), keep_ids=keep_ids)
+        output.append(prepared)
+
+    return output


### PR DESCRIPTION
Supports bulk creation with the following limitations:

- Multi-table inheritance isn't supported by Django's bulk_create;
- MySQL isn't supported because it doesn't return a list of bulk-created
  object PKs;
- MSSQL isn't supported because django-mssql doesn't properly set
  IDENTITY_INSERT when doing bulk inserts.

Closes https://github.com/django-treebeard/django-treebeard/issues/328.