### PR TITLE
Make uniqueness constraint on LTree.path deferrable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@ Next release (in development)
 
 * Fixed `MP_Node` paths being incremented unnecessarily when saving nodes with `node_order_by` in the admin.
 * Optimised `MoveNodeForm` to skip move logic if no treebeard-specific fields were modified.
+* Changed the unique constraint for `LTree.path` to be deferrable, so that move operations do not fail. *This requires a database migration for projects using the experimental LTree implementation*.
 
 
 Release 5.1.0 (May 12, 2026)

--- a/tests/migrations/0001_initial.py
+++ b/tests/migrations/0001_initial.py
@@ -409,11 +409,18 @@ if os.environ.get("DATABASE_ENGINE") == "psql":
                         "id",
                         models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID"),
                     ),
-                    ("path", treebeard.ltree.fields.PathField(unique=True)),
+                    ("path", treebeard.ltree.fields.PathField()),
                     ("desc", models.CharField(max_length=255)),
                 ],
                 options={
                     "abstract": False,
+                    "constraints": [
+                        models.UniqueConstraint(
+                            name="tests_lt_testnode_deferred_unique_path",
+                            fields=["path"],
+                            deferrable=models.Deferrable.DEFERRED,
+                        )
+                    ],
                 },
             ),
             migrations.CreateModel(
@@ -464,13 +471,20 @@ if os.environ.get("DATABASE_ENGINE") == "psql":
                         "id",
                         models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID"),
                     ),
-                    ("path", treebeard.ltree.fields.PathField(unique=True)),
+                    ("path", treebeard.ltree.fields.PathField()),
                     ("val1", models.IntegerField()),
                     ("val2", models.IntegerField()),
                     ("desc", models.CharField(max_length=255)),
                 ],
                 options={
                     "abstract": False,
+                    "constraints": [
+                        models.UniqueConstraint(
+                            name="tests_lt_testnodesorted_deferred_unique_path",
+                            fields=["path"],
+                            deferrable=models.Deferrable.DEFERRED,
+                        )
+                    ],
                 },
             ),
             migrations.CreateModel(

--- a/tests/models.py
+++ b/tests/models.py
@@ -224,7 +224,12 @@ if os.environ.get("DATABASE_ENGINE", "") == "psql":
     class LT_TestNodeInherited(LT_TestNode):
         extra_desc = models.CharField(max_length=255)
 
-    class LT_TestNodeInheritedSorted(LT_TestNodeSorted): ...
+        class Meta:
+            constraints = []  # Override parent class constraints
+
+    class LT_TestNodeInheritedSorted(LT_TestNodeSorted):
+        class Meta:
+            constraints = []  # Override parent class constraints
 
     class LT_TestNodeSomeDep(models.Model):
         node = models.ForeignKey(LT_TestNode, on_delete=models.CASCADE)

--- a/treebeard/ltree/__init__.py
+++ b/treebeard/ltree/__init__.py
@@ -46,7 +46,9 @@ def generate_label(
 
     start = after or char_choices[0]
 
-    if before and before <= start:
+    if (
+        before and (before <= start) or before == f"{start}0"
+    ):  # If before == {start}0 there is no semantic gap in between
         raise InvalidLabelConstraints
 
     # Construct sets of characters for each position, appending one at the end if we need to extend the string
@@ -175,6 +177,7 @@ class LT_ComplexAddMoveHandler:
         """
         result_class = self.node_cls.tree_model()
         node_depth = len(start_node.path)
+
         if node_depth > 1:
             result_class.objects.filter(
                 path__descendants=start_node.path[:-1], path__gte=start_node.path, path__depth=node_depth
@@ -413,7 +416,7 @@ class LT_Node(Node):
     """Abstract model to create your own Postgres LTree trees."""
 
     node_order_by = []
-    path = PathField(unique=True)
+    path = PathField()
 
     TREEBEARD_IDENTIFYING_FIELD = "path"
     MOVENODE_FORM_EXCLUDED_FIELDS = ("path",)
@@ -656,3 +659,10 @@ class LT_Node(Node):
 
     class Meta:
         abstract = True
+        constraints = [
+            models.UniqueConstraint(
+                name="%(app_label)s_%(class)s_deferred_unique_path",
+                fields=["path"],
+                deferrable=models.Deferrable.DEFERRED,
+            )
+        ]


### PR DESCRIPTION
Makes the uniqueness constraint for ltree paths deferrable, so that operations like `_move_subtree_right` don't fail immediately. As per postgresql [documentation](https://www.postgresql.org/docs/current/sql-createtable.html#id-1.9.3.85.9.4):

> When a UNIQUE or PRIMARY KEY constraint is not deferrable, PostgreSQL checks for uniqueness immediately whenever a row is inserted or modified. The SQL standard says that uniqueness should be enforced only at the end of the statement; this makes a difference when, for example, a single command updates multiple key values. To obtain standard-compliant behavior, declare the constraint as DEFERRABLE but not deferred (i.e., INITIALLY IMMEDIATE). Be aware that this can be significantly slower than immediate uniqueness checking.

This does come at a performance cost, but it seems like it would be costlier to have to work around this manually.