### PR TITLE
Add checks to ensure manager methods subclass Treebeard managers

### DIFF
--- a/tests/test_treebeard.py
+++ b/tests/test_treebeard.py
@@ -7,12 +7,15 @@ from unittest import mock
 from unittest.mock import patch
 
 import pytest
+from django.apps import apps
 from django.contrib.admin.options import TO_FIELD_VAR
 from django.contrib.admin.sites import AdminSite
 from django.contrib.admin.views.main import ChangeList
 from django.contrib.auth.models import AnonymousUser, User
 from django.contrib.messages.storage.fallback import FallbackStorage
+from django.core.checks.model_checks import check_all_models
 from django.core.exceptions import PermissionDenied
+from django.db.models import Manager
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.forms import ValidationError
@@ -4709,3 +4712,15 @@ class TestLT_Insertion(TestTreeBase):
         assert signals == [
             ("subtree_moved_right", lt_model, "A.0", "default"),
         ]
+
+
+@pytest.mark.django_db
+class TestChecks:
+    def test_checks_warning_if_model_manager_doesnt_subclass_treebeard_manager(self, model, monkeypatch):
+        configs = [apps.get_app_config("tests")]
+        assert not check_all_models(configs)
+        # Monkey-patch default manager
+        monkeypatch.setattr(model._meta, "default_manager", Manager())
+        errors = check_all_models(configs)
+        assert len(errors) == 1
+        assert "does not subclass treebeard" in errors[0].msg

--- a/treebeard/al_tree.py
+++ b/treebeard/al_tree.py
@@ -1,6 +1,6 @@
 """Adjacency List"""
 
-from django.core import serializers
+from django.core import checks, serializers
 from django.db import models, transaction
 from django.db.models import Exists, Max, Min, OuterRef
 from django.utils.translation import gettext_noop as _
@@ -352,6 +352,23 @@ class AL_Node(Node):
             self.sib_order = sib_order or self.__class__._get_new_sibling_order(pos, target)
 
         self.save()
+
+    @classmethod
+    def check(cls, **kwargs):
+        errors = super().check(**kwargs)
+        manager_cls = cls._default_manager.__class__
+        # Raise a warning if the default manager for the model doesn't subclass AL_NodeManager
+        # This will allow us to move class-level methods into the manager in future (see issue #44)
+        if not issubclass(manager_cls, AL_NodeManager):
+            errors.append(
+                checks.Warning(
+                    f"{manager_cls.__module__}.{manager_cls.__name__} does not subclass "
+                    "treebeard.al_tree.AL_NodeManager. This will cause an error in Treebeard 6.",
+                    obj=manager_cls,
+                    id="treebeard.E001",
+                )
+            )
+        return errors
 
     class Meta:
         """Abstract model."""

--- a/treebeard/ltree/__init__.py
+++ b/treebeard/ltree/__init__.py
@@ -7,7 +7,7 @@ import string
 from collections.abc import Iterable
 from typing import Any
 
-from django.core import serializers
+from django.core import checks, serializers
 from django.db import models, transaction
 from django.db.models import F, Func, OuterRef, Q, Subquery, Value
 from django.db.models.functions import Concat
@@ -136,7 +136,7 @@ class LT_NodeManager(models.Manager):
 
     def get_queryset(self):
         """Sets the custom queryset as the default."""
-        return LT_NodeQuerySet(self.model).order_by("path")
+        return LT_NodeQuerySet(self.model, using=self._db).order_by("path")
 
 
 class LT_ComplexAddMoveHandler:
@@ -656,6 +656,23 @@ class LT_Node(Node):
         relative to another node.
         """
         return LT_MoveHandler(self, target, pos).process()
+
+    @classmethod
+    def check(cls, **kwargs):
+        errors = super().check(**kwargs)
+        manager_cls = cls._default_manager.__class__
+        # Raise a warning if the default manager for the model doesn't subclass LT_NodeManager
+        # This will allow us to move class-level methods into the manager in future (see issue #44)
+        if not issubclass(manager_cls, LT_NodeManager):
+            errors.append(
+                checks.Warning(
+                    f"{manager_cls.__module__}.{manager_cls.__name__} does not subclass "
+                    "treebeard.ltree.LT_NodeManager. This will cause an error in Treebeard 6.",
+                    obj=manager_cls,
+                    id="treebeard.E001",
+                )
+            )
+        return errors
 
     class Meta:
         abstract = True

--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -4,7 +4,7 @@ import collections
 from functools import cache
 from typing import Any
 
-from django.core import serializers
+from django.core import checks, serializers
 from django.db import connections, models, router, transaction
 from django.db.models import F, Func, OuterRef, Q, Subquery, Value
 from django.db.models.functions import Concat, Greatest, Length, Substr
@@ -92,7 +92,7 @@ class MP_NodeManager(models.Manager):
 
     def get_queryset(self):
         """Sets the custom queryset as the default."""
-        return MP_NodeQuerySet(self.model).order_by("path")
+        return MP_NodeQuerySet(self.model, using=self._db).order_by("path")
 
 
 class MP_ComplexAddMoveHandler:
@@ -1129,6 +1129,23 @@ class MP_Node(Node):
         added.extend([obj.pk for obj in created])
 
         return added
+
+    @classmethod
+    def check(cls, **kwargs):
+        errors = super().check(**kwargs)
+        manager_cls = cls._default_manager.__class__
+        # Raise a warning if the default manager for the model doesn't subclass MP_NodeManager
+        # This will allow us to move class-level methods into the manager in future (see issue #44)
+        if not issubclass(manager_cls, MP_NodeManager):
+            errors.append(
+                checks.Warning(
+                    f"{manager_cls.__module__}.{manager_cls.__name__} does not subclass "
+                    "treebeard.mp_tree.MP_NodeManager. This will cause an error in Treebeard 6.",
+                    obj=manager_cls,
+                    id="treebeard.E001",
+                )
+            )
+        return errors
 
     class Meta:
         """Abstract model."""

--- a/treebeard/ns_tree.py
+++ b/treebeard/ns_tree.py
@@ -4,7 +4,7 @@ import operator
 from functools import reduce
 from itertools import groupby
 
-from django.core import serializers
+from django.core import checks, serializers
 from django.db import models, transaction
 from django.db.models import Case, F, Q, When
 from django.dispatch import Signal
@@ -80,7 +80,7 @@ class NS_NodeManager(models.Manager):
 
     def get_queryset(self):
         """Sets the custom queryset as the default."""
-        return NS_NodeQuerySet(self.model).order_by("tree_id", "lft")
+        return NS_NodeQuerySet(self.model, using=self._db).order_by("tree_id", "lft")
 
 
 class NS_Node(Node):
@@ -637,6 +637,23 @@ class NS_Node(Node):
                     wrong_depth.append(node["pk"])
 
         return reversed_lft_rgt, overlapping_nodes, duplicate_tree_ids, wrong_depth
+
+    @classmethod
+    def check(cls, **kwargs):
+        errors = super().check(**kwargs)
+        manager_cls = cls._default_manager.__class__
+        # Raise a warning if the default manager for the model doesn't subclass NS_NodeManager
+        # This will allow us to move class-level methods into the manager in future (see issue #44)
+        if not issubclass(manager_cls, NS_NodeManager):
+            errors.append(
+                checks.Warning(
+                    f"{manager_cls.__module__}.{manager_cls.__name__} does not subclass "
+                    "treebeard.ns_tree.NS_NodeManager. This will cause an error in Treebeard 6.",
+                    obj=manager_cls,
+                    id="treebeard.E001",
+                )
+            )
+        return errors
 
     class Meta:
         """Abstract model."""


### PR DESCRIPTION
This is documented, but not currently enforced, and blocks us from implementing #44 (moving class methods currently on the model class to the manager, for consistency with how Django itself handles row-level methods).

Some downstream projects, notably Wagtail, do not currently subclass Treebeard's manager, making it impossible to move these methods in a backwards-compatible way. This it seems prudent to add a warning first.