### PR TITLE
Revert change to `MP_Node.get_ancestors()` that caused a performance regression

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+Release 5.2.2 (Jun 5, 2026)
+---------------------------
+
+Treebeard 5.2.2 is a bugfix release.
+
+- Fixed performance regression in `MP_Node.get_ancestors()` (https://github.com/django-treebeard/django-treebeard/issues/403).
+
+
 Release 5.2.1 (Jun 2, 2026)
 ---------------------------
 

--- a/treebeard/__init__.py
+++ b/treebeard/__init__.py
@@ -18,4 +18,4 @@ Release logic:
 14. git push
 """
 
-__version__ = "5.2.1"
+__version__ = "5.2.2"

--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -956,11 +956,9 @@ class MP_Node(Node):
         if self.is_root():
             return self.tree_model().objects.none()
 
-        return (
-            self.tree_model()
-            .objects.alias(ref_path=Value(self._get_parent_path_from_path(self.path)))
-            .filter(ref_path__startswith=F("path"))
-        )
+        # This is necessary to ensure the index is used as opposed to a table scan
+        paths = [self.path[0:pos] for pos in range(0, len(self.path), self.steplen)[1:]]
+        return self.tree_model().objects.filter(path__in=paths).order_by("depth")
 
     def get_parent(self, update=False):
         """


### PR DESCRIPTION
Fixes #403