### PR TITLE
fix: clear prefetch_related before iterator() in tree delete methods (fixes #405)

### DIFF
--- a/treebeard/ltree/__init__.py
+++ b/treebeard/ltree/__init__.py
@@ -106,7 +106,7 @@ class LT_NodeQuerySet(models.query.QuerySet):
         """
         # Construct the minimal list of nodes that need deleting along with their descendants
         paths_to_remove = set()
-        for node in self.order_by("path").only("path").iterator():
+        for node in self.order_by("path").only("path").prefetch_related(None).iterator():
             found = False
             for depth in range(1, len(node.path)):
                 path = node.path[0:depth]

--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -39,7 +39,7 @@ class MP_NodeQuerySet(models.query.QuerySet):
         # to be deleted and remove nodes from the list if an ancestor is
         # already getting removed, since that would be redundant
         removed = {}
-        for node in self.order_by("depth", "path").only("path", "depth", "numchild").iterator():
+        for node in self.order_by("depth", "path").only("path", "depth", "numchild").prefetch_related(None).iterator():
             found = False
             for depth in range(1, int(len(node.path) / node.steplen)):
                 path = node._get_basepath(node.path, depth)

--- a/treebeard/ns_tree.py
+++ b/treebeard/ns_tree.py
@@ -39,7 +39,7 @@ class NS_NodeQuerySet(models.query.QuerySet):
         last_node = None
         toremove = []
         ranges = []
-        for node in self.order_by("tree_id", "lft").values("tree_id", "lft", "rgt").iterator():
+        for node in self.order_by("tree_id", "lft").values("tree_id", "lft", "rgt").prefetch_related(None).iterator():
             if (
                 last_node
                 and last_node["tree_id"] == node["tree_id"]


### PR DESCRIPTION
When a user adds `prefetch_related` to a tree admin `get_queryset` (e.g. to avoid N+1 queries in the admin list view), the queryset `delete()` crashed because `.iterator()` refuses to iterate when prefetch lookups are pending:

```
ValueError: chunk_size must be provided when using
QuerySet.iterator() after prefetch_related()
```

The three tree queryset classes (`MP_NodeQuerySet`, `NS_NodeQuerySet`, `LT_NodeQuerySet`) all call `.iterator()` in their custom `delete()` to enumerate nodes for removal. These delete paths only access `path`/`depth`/`numchild` (via `.only()`) or `tree_id`/`lft`/`rgt` (via `.values()`) — prefetched related objects are never used during deletion.

Calling `.prefetch_related(None)` before `.iterator()` clears any user-added prefetch lookups, which is safe because the delete path does not use related-object access.

Fixes #405.