### PR TITLE
Add support for many-to-many relationships to Node.load_bulk()

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+Next release (in development)
+-----------------------------
+
+- Added support for loading data for many-to-many relationships with `load_bulk()`.
+
+
 Release 5.2.2 (Jun 5, 2026)
 ---------------------------
 

--- a/tests/migrations/0001_initial.py
+++ b/tests/migrations/0001_initial.py
@@ -291,6 +291,7 @@ class Migration(migrations.Migration):
                 ("depth", models.PositiveIntegerField(db_index=True)),
                 ("desc", models.CharField(max_length=255)),
                 ("related", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to="tests.relatedmodel")),
+                ("related_m2m", models.ManyToManyField(to="tests.relatedmodel")),
             ],
             options={
                 "abstract": False,
@@ -312,6 +313,7 @@ class Migration(migrations.Migration):
                 ("numchild", models.PositiveIntegerField(default=0)),
                 ("desc", models.CharField(max_length=255)),
                 ("related", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to="tests.relatedmodel")),
+                ("related_m2m", models.ManyToManyField(to="tests.relatedmodel")),
             ],
             options={
                 "abstract": False,
@@ -361,6 +363,7 @@ class Migration(migrations.Migration):
                     ),
                 ),
                 ("related", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to="tests.relatedmodel")),
+                ("related_m2m", models.ManyToManyField(to="tests.relatedmodel")),
             ],
             options={
                 "abstract": False,
@@ -453,6 +456,32 @@ if os.environ.get("DATABASE_ENGINE") == "psql":
                     ),
                     ("node", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to="tests.lt_testnode")),
                 ],
+            ),
+            migrations.CreateModel(
+                name="LT_TestNodeRelated",
+                fields=[
+                    (
+                        "id",
+                        models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID"),
+                    ),
+                    ("path", treebeard.ltree.fields.PathField()),
+                    ("desc", models.CharField(max_length=255)),
+                    (
+                        "related",
+                        models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to="tests.relatedmodel"),
+                    ),
+                    ("related_m2m", models.ManyToManyField(to="tests.relatedmodel")),
+                ],
+                options={
+                    "abstract": False,
+                    "constraints": [
+                        models.UniqueConstraint(
+                            deferrable=django.db.models.constraints.Deferrable["DEFERRED"],
+                            fields=("path",),
+                            name="tests_lt_testnoderelated_deferred_unique_path",
+                        )
+                    ],
+                },
             ),
             migrations.CreateModel(
                 name="LT_TestNode_Proxy",

--- a/tests/models.py
+++ b/tests/models.py
@@ -26,6 +26,18 @@ class DescMixin(models.Model):
 class RelatedModel(DescMixin): ...
 
 
+class RelatedNodeMixin(models.Model):
+    """
+    Mixin for nodes with relationships (foreign key, m2m)
+    """
+
+    related = models.ForeignKey(RelatedModel, on_delete=models.CASCADE)
+    related_m2m = models.ManyToManyField(RelatedModel)
+
+    class Meta:
+        abstract = True
+
+
 class MP_TestNode(MP_Node, DescMixin):
     steplen = 3
 
@@ -34,9 +46,8 @@ class MP_TestNodeSomeDep(models.Model):
     node = models.ForeignKey(MP_TestNode, on_delete=models.CASCADE)
 
 
-class MP_TestNodeRelated(MP_Node, DescMixin):
+class MP_TestNodeRelated(MP_Node, DescMixin, RelatedNodeMixin):
     steplen = 3
-    related = models.ForeignKey(RelatedModel, on_delete=models.CASCADE)
 
 
 class MP_TestNodeInherited(MP_TestNode):
@@ -55,8 +66,7 @@ class NS_TestNodeSomeDep(models.Model):
     node = models.ForeignKey(NS_TestNode, on_delete=models.CASCADE)
 
 
-class NS_TestNodeRelated(NS_Node, DescMixin):
-    related = models.ForeignKey(RelatedModel, on_delete=models.CASCADE)
+class NS_TestNodeRelated(NS_Node, DescMixin, RelatedNodeMixin): ...
 
 
 class NS_TestNodeInherited(NS_TestNode):
@@ -78,7 +88,7 @@ class AL_TestNodeSomeDep(models.Model):
     node = models.ForeignKey(AL_TestNode, on_delete=models.CASCADE)
 
 
-class AL_TestNodeRelated(AL_Node, DescMixin):
+class AL_TestNodeRelated(AL_Node, DescMixin, RelatedNodeMixin):
     parent = models.ForeignKey(
         "self",
         related_name="children_set",
@@ -87,7 +97,6 @@ class AL_TestNodeRelated(AL_Node, DescMixin):
         on_delete=models.CASCADE,
     )
     sib_order = models.PositiveIntegerField()
-    related = models.ForeignKey(RelatedModel, on_delete=models.CASCADE)
 
 
 class AL_TestNodeInherited(AL_TestNode):
@@ -232,6 +241,8 @@ if os.environ.get("DATABASE_ENGINE", "") == "psql":
         class Meta:
             constraints = []  # Override parent class constraints
 
+    class LT_TestNodeRelated(LT_Node, DescMixin, RelatedNodeMixin): ...
+
     class LT_TestNodeSomeDep(models.Model):
         node = models.ForeignKey(LT_TestNode, on_delete=models.CASCADE)
 
@@ -240,6 +251,7 @@ if os.environ.get("DATABASE_ENGINE", "") == "psql":
     DEP_MODELS.append((LT_TestNode, LT_TestNodeSomeDep))
     INHERITED_MODELS.append((LT_TestNode, LT_TestNodeInherited))
     SORTED_MODELS.append(LT_TestNodeSorted)
+    RELATED_MODELS.append(LT_TestNodeRelated)
     INHERITED_MODELS_WITH_SORT.append((LT_TestNodeSorted, LT_TestNodeInheritedSorted))
     LT_BASE_MODELS.append(LT_TestNode)
     BENCHMARK_MODELS.append(LT_TestNode)

--- a/tests/test_treebeard.py
+++ b/tests/test_treebeard.py
@@ -118,6 +118,11 @@ def mp_model(request):
     return request.param
 
 
+@pytest.fixture(scope="function", params=[models.MP_TestNodeRelated])
+def mp_relatedmodel(request):
+    return request.param
+
+
 @pytest.fixture(scope="function", params=models.MP_SHORTPATH_MODELS)
 def mpshort_model(request):
     return request.param
@@ -463,32 +468,30 @@ class TestClassMethods(TestNonEmptyTree):
         got = [(o.desc, o.get_depth(), o.get_children_count()) for o in model.get_tree()]
         assert got == UNCHANGED
 
-    def test_load_and_dump_bulk_with_fk(self, related_model):
-        # https://bitbucket.org/tabo/django-treebeard/issue/48/
-        related_model.objects.all().delete()
-        related, _ = models.RelatedModel.objects.get_or_create(desc=f"Test {related_model.__name__}")
+    def test_load_and_dump_bulk_with_related_models(self, related_model):
+        related = models.RelatedModel.objects.create(desc=f"Test {related_model.__name__}")
 
         related_data = [
-            {"data": {"desc": "1", "related": related.pk}},
+            {"data": {"desc": "1", "related": related.pk, "related_m2m": [related.pk]}},
             {
-                "data": {"desc": "2", "related": related.pk},
+                "data": {"desc": "2", "related": related.pk, "related_m2m": []},
                 "children": [
-                    {"data": {"desc": "21", "related": related.pk}},
-                    {"data": {"desc": "22", "related": related.pk}},
+                    {"data": {"desc": "21", "related": related.pk, "related_m2m": [related.pk]}},
+                    {"data": {"desc": "22", "related": related.pk, "related_m2m": [related.pk]}},
                     {
-                        "data": {"desc": "23", "related": related.pk},
+                        "data": {"desc": "23", "related": related.pk, "related_m2m": []},
                         "children": [
-                            {"data": {"desc": "231", "related": related.pk}},
+                            {"data": {"desc": "231", "related": related.pk, "related_m2m": [related.pk]}},
                         ],
                     },
-                    {"data": {"desc": "24", "related": related.pk}},
+                    {"data": {"desc": "24", "related": related.pk, "related_m2m": []}},
                 ],
             },
-            {"data": {"desc": "3", "related": related.pk}},
+            {"data": {"desc": "3", "related": related.pk, "related_m2m": []}},
             {
-                "data": {"desc": "4", "related": related.pk},
+                "data": {"desc": "4", "related": related.pk, "related_m2m": []},
                 "children": [
-                    {"data": {"desc": "41", "related": related.pk}},
+                    {"data": {"desc": "41", "related": related.pk, "related_m2m": []}},
                 ],
             },
         ]
@@ -3566,6 +3569,37 @@ class TestMP_TreeLoadBulk(TestTreeBase):
         # do we really have an unchanged tree after the dump/delete/load?
         got = [(o.desc, o.get_depth(), o.get_children_count()) for o in mp_model.get_tree()]
         assert got == UNCHANGED
+
+    def test_load_bulk_keeping_ids_with_bulk_create_and_many_to_many(self, mp_relatedmodel):
+        related = models.RelatedModel.objects.create(desc=f"Test {related_model.__name__}")
+
+        related_data = [
+            {"data": {"desc": "1", "related": related.pk, "related_m2m": [related.pk]}},
+            {
+                "data": {"desc": "2", "related": related.pk, "related_m2m": []},
+                "children": [
+                    {"data": {"desc": "21", "related": related.pk, "related_m2m": [related.pk]}},
+                    {"data": {"desc": "22", "related": related.pk, "related_m2m": [related.pk]}},
+                    {
+                        "data": {"desc": "23", "related": related.pk, "related_m2m": []},
+                        "children": [
+                            {"data": {"desc": "231", "related": related.pk, "related_m2m": []}},
+                        ],
+                    },
+                    {"data": {"desc": "24", "related": related.pk, "related_m2m": []}},
+                ],
+            },
+            {"data": {"desc": "3", "related": related.pk, "related_m2m": []}},
+            {
+                "data": {"desc": "4", "related": related.pk, "related_m2m": []},
+                "children": [
+                    {"data": {"desc": "41", "related": related.pk, "related_m2m": []}},
+                ],
+            },
+        ]
+        mp_relatedmodel.load_bulk(related_data, bulk_create=True)
+        got = mp_relatedmodel.dump_bulk(keep_ids=False)
+        assert got == related_data
 
 
 @pytest.mark.django_db

--- a/treebeard/models.py
+++ b/treebeard/models.py
@@ -9,7 +9,7 @@ from django.db import models, transaction
 from django.db.models import Q
 
 from treebeard.exceptions import InvalidPosition, MissingNodeOrderBy
-from treebeard.utils import prepare_dumpdata_for_loading
+from treebeard.utils import prepare_dumpdata_for_loading, save_m2m
 
 
 class Node(models.Model):
@@ -80,14 +80,19 @@ class Node(models.Model):
         added = []
         bulk_data = prepare_dumpdata_for_loading(cls, data=bulk_data, keep_ids=keep_ids)
         # stack of nodes to analyze
-        stack = [(parent, node) for node in bulk_data[::-1]]
+        stack = [(parent, deserialized_obj) for deserialized_obj in bulk_data[::-1]]
 
         while stack:
-            parent, node_struct = stack.pop()
-            node_obj = parent.add_child(**node_struct["data"]) if parent else cls.add_root(**node_struct["data"])
+            parent, deserialized_obj = stack.pop()
+            node_obj = deserialized_obj.object = (
+                parent.add_child(instance=deserialized_obj.object)
+                if parent
+                else cls.add_root(instance=deserialized_obj.object)
+            )
+            save_m2m(node_obj, deserialized_obj)
             added.append(node_obj.pk)
             # extending the stack with the current node as the parent of the new nodes
-            stack.extend([(node_obj, node) for node in node_struct["children"][::-1]])
+            stack.extend([(node_obj, child) for child in deserialized_obj.children[::-1]])
         return added
 
     @classmethod

--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -14,7 +14,7 @@ from django.utils.translation import gettext_noop as _
 from treebeard.exceptions import InvalidMoveToDescendant, NodeAlreadySaved, PathOverflow
 from treebeard.models import Node
 from treebeard.numconv import NumConv
-from treebeard.utils import prepare_dumpdata_for_loading
+from treebeard.utils import prepare_dumpdata_for_loading, save_m2m
 
 path_updated = Signal()
 nodes_deleted = Signal()
@@ -1103,27 +1103,34 @@ class MP_Node(Node):
             child_depth = parent_node.depth + 1
 
             for i, child in enumerate(children):
-                child_obj = cls(
-                    depth=child_depth,
-                    numchild=len(child["children"]),
-                    path=cls._get_path(parent_node.path, child_depth, i + 1),
-                    **child["data"],
-                )
+                child.object.depth = child_depth
+                child.object.numchild = len(child.children)
+                child.object.path = cls._get_path(parent_node.path, child_depth, i + 1)
 
-                children_to_create.append(child_obj)
+                children_to_create.append(child)
 
                 # Recursively process grandchildren
-                _build_children(child_obj, child["children"])
+                _build_children(child.object, child.children)
 
         # Create first level of the bulk data using standard operations, since there may be existing siblings
-        for node_struct in bulk_data:
-            node_struct["data"]["numchild"] = len(node_struct["children"])  # Set numchild manually
-            node_obj = parent.add_child(**node_struct["data"]) if parent else cls.add_root(**node_struct["data"])
+        for deserialized_obj in bulk_data:
+            deserialized_obj.object.numchild = len(deserialized_obj.children)  # Set numchild manually
+            node_obj = (
+                parent.add_child(instance=deserialized_obj.object)
+                if parent
+                else cls.add_root(instance=deserialized_obj.object)
+            )
+            save_m2m(node_obj, deserialized_obj)
             added.append(node_obj.pk)
-            _build_children(node_obj, node_struct["children"])
+            _build_children(node_obj, deserialized_obj.children)
 
         # Bulk create descendants
-        created = cls.objects.bulk_create(children_to_create, batch_size=batch_size)
+        created = cls.objects.bulk_create([obj.object for obj in children_to_create], batch_size=batch_size)
+
+        # Save m2m relationships
+        for obj, source in zip(created, children_to_create):
+            save_m2m(obj, source)
+
         added.extend([obj.pk for obj in created])
 
         return added

--- a/treebeard/utils.py
+++ b/treebeard/utils.py
@@ -1,7 +1,7 @@
-from copy import deepcopy
-from functools import cache
 from typing import Any, TypedDict
 
+from django.core import serializers
+from django.core.serializers.base import DeserializedObject
 from django.db import models
 
 
@@ -10,37 +10,29 @@ class DumpData(TypedDict):
     children: list["DumpData"]  # TODO: This should really be NotRequired. Add when Python 3.10 support is dropped
 
 
-class PreparedDumpData(DumpData):
-    children: list["DumpData"]
-    pk: Any  # TODO: This should really be NotRequired. Add when Python 3.10 support is dropped
-
-
-@cache
-def get_foreign_key_fields(cls: type[models.Model]) -> set[str]:
-    return {field.name for field in cls._meta.fields if (field.one_to_one or field.many_to_one)}
-
-
 def prepare_dumpdata_for_loading(
     cls: type[models.Model], *, data: list[DumpData], keep_ids: bool
-) -> list[PreparedDumpData]:
+) -> list[DeserializedObject]:
     """
-    Given data previously dumped using dump_data, prepares the data for use with load_data.
-
-    - Modifies foreign key field names to append an `_id` suffix
-    - Adds a pk field if `keep_ids` is True.
+    Given data previously dumped using dump_data, prepares a DeserializedObject for use with load_data.
     """
-    foreign_key_fields = get_foreign_key_fields(cls)
     pk_field = cls._meta.pk.attname
+    model_identifier = str(cls._meta)
     output = []
     for item in data:
-        prepared = deepcopy(item)
-        for field in foreign_key_fields:
-            # Append _id to field name, so that we don't need to load the foreign objects into memory
-            prepared["data"][f"{field}_id"] = prepared["data"].pop(field, None)
-        if keep_ids:
-            prepared["data"]["pk"] = item[pk_field]
-
-        prepared["children"] = prepare_dumpdata_for_loading(cls, data=item.get("children", []), keep_ids=keep_ids)
-        output.append(prepared)
+        obj = {"fields": item["data"], "model": model_identifier, "pk": item[pk_field] if keep_ids else None}
+        deserialized_obj = next(serializers.deserialize("python", [obj]))
+        deserialized_obj.children = prepare_dumpdata_for_loading(cls, data=item.get("children", []), keep_ids=keep_ids)
+        output.append(deserialized_obj)
 
     return output
+
+
+def save_m2m(node: models.Model, deserialized_obj: DeserializedObject):
+    """
+    Saves m2m relationships stored on a DeserializedObject.
+    """
+    if deserialized_obj.m2m_data:
+        for accessor_name, object_list in deserialized_obj.m2m_data.items():
+            getattr(node, accessor_name).set(object_list)
+        deserialized_obj.m2m_data = None  # Avoid accidental reuse of m2m_data if save() is called on the object


### PR DESCRIPTION
`load_bulk()` currently doesn't handle any many-to-many relationships, even though `dump_bulk()` will dump them. This adds support for M2M relationships. Also refactors a little to rely more on the Django serializer/deserializer logic.