### PR TITLE
Move table-level methods into managers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,63 @@
+
+Release 6.0.0 (in development)
+------------------------------
+
+Treebeard 6.0.0 is a major release. It features a change to Treebeard's API.
+
+The following methods that previously existing on the `Node` model class have now moved to the 
+model manager instead:
+
+- `load_bulk`
+- `dump_bulk`
+- `find_problems`
+- `fix_tree`
+- `get_tree`
+- `get_descendants_group_count`
+- `get_annotated_list_qs`
+- `get_annotated_list`
+- `get_root_nodes`
+- `get_first_root_node`
+- `get_last_root_node`
+- `get_children`
+- `get_children_count`
+- `get_siblings`
+- `get_descendants`
+- `get_descendant_count`
+- `get_first_child`
+- `get_last_child`
+- `get_first_sibling`
+- `get_last_sibling`
+- `get_prev_sibling`
+- `get_next_sibling`
+- `get_root`
+- `get_parent`
+- `get_ancestors`
+
+So, for example, code like this:
+
+```python
+    node.get_children()
+```
+
+Would need to be rewritten as:
+
+```python
+    MyModel.objects.get_children(node)
+```
+
+Putting these methods on the model manager instead of the model class is more consistent with
+Django's design patterns, and provides much more flexibility with their use. It also keeps the 
+model class slim, avoiding conflicts with code layered on top.
+
+Backward compatibility exists for all these methods, which will be removed in Treebeard 7.
+
+It is now mandatory for the default model manager for a Treebeard model to subclass
+Treebeard's manager. An error will be raised if this is not the case.
+
 Release 5.3.0 (Jun 24, 2026)
 ----------------------------
 
-Treebeard 5.3.0 is a minor release release.
+Treebeard 5.3.0 is a minor release.
 
 - Added support for loading data for many-to-many relationships with `load_bulk()`. These were previously
   exported when using `dump_bulk()`, but were not handled when loading the same data.

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -7,70 +7,18 @@ API
 .. autoclass:: Node
   :show-inheritance:
 
-  This is the base class that defines the API of all tree models in this
-  library:
-
-     - :class:`treebeard.mp_tree.MP_Node` (materialized path)
-     - :class:`treebeard.ns_tree.NS_Node` (nested sets)
-     - :class:`treebeard.al_tree.AL_Node` (adjacency list)
+  This is the base class that all tree models in this library inherit from.
 
   .. warning::
 
       Please be aware of the :doc:`caveats` when using this library.
 
-  .. automethod:: Node.add_root
-
-     Example:
-
-     .. code-block:: python
-
-        MyNode.add_root(numval=1, strval='abcd')
-
-     Or, to pass in an existing instance:
-
-     .. code-block:: python
-
-        new_node = MyNode(numval=1, strval='abcd')
-        MyNode.add_root(instance=new_node)
-
-  .. automethod:: add_child
-
-     Example:
-
-     .. code-block:: python
-
-        node.add_child(numval=1, strval='abcd')
-
-     Or, to pass in an existing instance:
-
-     .. code-block:: python
-
-        new_node = MyNode(numval=1, strval='abcd')
-        node.add_child(instance=new_node)
-
-  .. automethod:: add_sibling
-
-     Examples:
-
-     .. code-block:: python
-
-        node.add_sibling('sorted-sibling', numval=1, strval='abc')
-
-     Or, to pass in an existing instance:
-
-     .. code-block:: python
-
-        new_node = MyNode(numval=1, strval='abc')
-        node.add_sibling('sorted-sibling', instance=new_node)
-
   .. automethod:: delete
 
         .. note::
 
-           Call our queryset's delete to handle children removal. Subclasses
-           will handle extra maintenance.
-
-  .. automethod:: get_tree
+         Call our queryset's delete to handle children removal. Subclasses
+         will handle extra maintenance.
 
   .. automethod:: get_depth
 
@@ -79,118 +27,6 @@ API
      .. code-block:: python
 
         node.get_depth()
-
-  .. automethod:: get_ancestors
-
-     Example:
-
-     .. code-block:: python
-
-        node.get_ancestors()
-
-  .. automethod:: get_children
-
-     Example:
-
-     .. code-block:: python
-
-        node.get_children()
-
-  .. automethod:: get_children_count
-
-     Example:
-
-     .. code-block:: python
-
-        node.get_children_count()
-
-  .. automethod:: get_descendants
-
-     Example:
-
-     .. code-block:: python
-
-        node.get_descendants()
-
-  .. automethod:: get_descendant_count
-
-     Example:
-
-     .. code-block:: python
-
-        node.get_descendant_count()
-
-  .. automethod:: get_first_child
-
-     Example:
-
-     .. code-block:: python
-
-        node.get_first_child()
-
-  .. automethod:: get_last_child
-
-     Example:
-
-     .. code-block:: python
-
-        node.get_last_child()
-
-  .. automethod:: get_first_sibling
-
-     Example:
-
-     .. code-block:: python
-
-        node.get_first_sibling()
-
-  .. automethod:: get_last_sibling
-
-     Example:
-
-     .. code-block:: python
-
-        node.get_last_sibling()
-
-  .. automethod:: get_prev_sibling
-
-     Example:
-
-     .. code-block:: python
-
-        node.get_prev_sibling()
-
-  .. automethod:: get_next_sibling
-
-     Example:
-
-     .. code-block:: python
-
-        node.get_next_sibling()
-
-  .. automethod:: get_parent
-
-     Example:
-
-     .. code-block:: python
-
-        node.get_parent()
-
-  .. automethod:: get_root
-
-     Example:
-
-     .. code-block:: python
-
-        node.get_root()
-
-  .. automethod:: get_siblings
-
-     Example:
-
-     .. code-block:: python
-
-        node.get_siblings()
 
   .. automethod:: is_child_of
 
@@ -232,6 +68,57 @@ API
 
         node.is_leaf()
 
+
+.. autoclass:: NodeManager
+
+  This is the base manager class for models subclassing ``Node``.
+  It contains the bulk of Treebeard's API for interacting with node objects.
+
+  .. automethod:: add_root
+
+     Example:
+
+     .. code-block:: python
+
+        MyNode.objects.add_root({"numval": 1, "strval"="abcd"})
+
+     Or, to pass in an existing instance:
+
+     .. code-block:: python
+
+        new_node = MyNode(numval=1, strval='abcd')
+        MyNode.objects.add_root(instance=new_node)
+
+  .. automethod:: add_child
+
+     Example:
+
+     .. code-block:: python
+
+        MyNode.objects.add_child(node, {"numval": 1, "strval": "abcd"})
+
+     Or, to pass in an existing instance:
+
+     .. code-block:: python
+
+        new_node = MyNode(numval=1, strval='abcd')
+        MyNode.objects.add_child(node, instance=new_node)
+
+  .. automethod:: add_sibling
+
+     Examples:
+
+     .. code-block:: python
+
+        MyNode.objects.add_sibling(node, "sorted-sibling", {"numval": 1, "strval": "abc"})
+
+     Or, to pass in an existing instance:
+
+     .. code-block:: python
+
+        new_node = MyNode(numval=1, strval='abc')
+        MyNode.objects.add_sibling(node, "sorted-sibling", instance=new_node)
+
   .. automethod:: move
 
      .. note:: The node can be moved under another root node.
@@ -240,10 +127,10 @@ API
 
      .. code-block:: python
 
-        node.move(node2, 'sorted-child')
-        node.move(node2, 'prev-sibling')
+        MyNode.objects.move(node, target=node2, pos='sorted-child')
+        MyNode.objects.move(node, target=node2, pos='prev-sibling')
 
-  .. automethod:: save
+  .. automethod:: get_tree
 
   .. automethod:: get_first_root_node
 
@@ -251,7 +138,7 @@ API
 
      .. code-block:: python
 
-        MyNodeModel.get_first_root_node()
+        MyNodeModel.objects.get_first_root_node()
 
   .. automethod:: get_last_root_node
 
@@ -259,7 +146,7 @@ API
 
      .. code-block:: python
 
-        MyNodeModel.get_last_root_node()
+        MyNodeModel.objects.get_last_root_node()
 
   .. automethod:: get_root_nodes
 
@@ -267,7 +154,120 @@ API
 
      .. code-block:: python
 
-        MyNodeModel.get_root_nodes()
+        MyNodeModel.objects.get_root_nodes()
+
+  .. automethod:: get_ancestors
+
+     Example:
+
+     .. code-block:: python
+
+        MyNode.objects.get_ancestors(node)
+
+  .. automethod:: get_children
+
+     Example:
+
+     .. code-block:: python
+
+        MyNode.objects.get_children(node)
+
+  .. automethod:: get_children_count
+
+     Example:
+
+     .. code-block:: python
+
+        MyNode.objects.get_children_count(node)
+
+  .. automethod:: get_descendants
+
+     Example:
+
+     .. code-block:: python
+
+        MyNode.objects.get_descendants(node)
+
+  .. automethod:: get_descendant_count
+
+     Example:
+
+     .. code-block:: python
+
+        MyNode.objects.get_descendant_count(node)
+
+  .. automethod:: get_first_child
+
+     Example:
+
+     .. code-block:: python
+
+        MyNode.objects.get_first_child(node)
+
+  .. automethod:: get_last_child
+
+     Example:
+
+     .. code-block:: python
+
+        MyNode.objects.get_last_child(node)
+
+  .. automethod:: get_first_sibling
+
+     Example:
+
+     .. code-block:: python
+
+        MyNode.objects.get_first_sibling(node)
+
+  .. automethod:: get_last_sibling
+
+     Example:
+
+     .. code-block:: python
+
+        MyNode.objects.get_last_sibling(node)
+
+  .. automethod:: get_prev_sibling
+
+     Example:
+
+     .. code-block:: python
+
+        MyNode.objects.get_prev_sibling(node)
+
+  .. automethod:: get_next_sibling
+
+     Example:
+
+     .. code-block:: python
+
+        MyNode.objects.get_next_sibling(node)
+
+  .. automethod:: get_parent
+
+     Example:
+
+     .. code-block:: python
+
+        MyNode.objects.get_parent(node)
+
+  .. automethod:: get_root
+
+     Example:
+
+     .. code-block:: python
+
+        MyNode.objects.get_root(node)
+
+  .. automethod:: get_siblings
+
+     Example:
+
+     .. code-block:: python
+
+        MyNode.object.get_siblings(node)
+
 
   .. automethod:: load_bulk
 
@@ -301,7 +301,7 @@ API
                     ]},
             ]
             # parent = None
-            MyNodeModel.load_bulk(data, None)
+            MyNodeModel.objects.load_bulk(data, None)
 
      Will create:
 
@@ -323,12 +323,8 @@ API
 
      .. code-block:: python
 
-        tree = MyNodeModel.dump_bulk()
-        branch = MyNodeModel.dump_bulk(node_obj)
-
-  .. automethod:: find_problems
-
-  .. automethod:: fix_tree
+        tree = MyNodeModel.objects.dump_bulk()
+        branch = MyNodeModel.objects.dump_bulk(node_obj)
 
   .. automethod:: get_descendants_group_count
 
@@ -345,12 +341,11 @@ API
 
   .. automethod:: get_annotated_list
 
-
      Example:
 
      .. code-block:: python
 
-        annotated_list = MyModel.get_annotated_list()
+        annotated_list = MyModel.objects.get_annotated_list()
 
      With data:
 
@@ -399,8 +394,6 @@ API
         This method was contributed originally by
         `Alexey Kinyov <rudi@05bit.com>`_, using an idea borrowed from
         `django-mptt`_.
-
-     .. versionadded:: 1.55
 
 
   .. automethod:: get_annotated_list_qs

--- a/docs/source/ltree.rst
+++ b/docs/source/ltree.rst
@@ -90,14 +90,6 @@ To use the ``ltree`` module, you need to create the extension in your database:
 
      See: :meth:`treebeard.models.Node.add_root`
 
-  .. automethod:: add_child
-
-     See: :meth:`treebeard.models.Node.add_child`
-
-  .. automethod:: add_sibling
-
-     See: :meth:`treebeard.models.Node.add_sibling`
-
   .. automethod:: move
 
      See: :meth:`treebeard.models.Node.move`
@@ -108,6 +100,14 @@ To use the ``ltree`` module, you need to create the extension in your database:
 
 .. autoclass:: LT_NodeManager
   :show-inheritance:
+
+  .. automethod:: add_child
+
+     See: :meth:`treebeard.models.NodeManager.add_child`
+
+  .. automethod:: add_sibling
+
+     See: :meth:`treebeard.models.NodeManager.add_sibling`
 
 .. autoclass:: LT_NodeQuerySet
   :show-inheritance:

--- a/docs/source/mp_tree.rst
+++ b/docs/source/mp_tree.rst
@@ -198,7 +198,6 @@ extra steps, materialized path is more efficient than other approaches.
 
         ``django-treebeard`` uses `numconv`_ for path encoding.
 
-
   .. attribute:: depth
 
      ``PositiveIntegerField``, depth of a node in the tree. A root node
@@ -208,60 +207,55 @@ extra steps, materialized path is more efficient than other approaches.
 
      ``PositiveIntegerField``, the number of children of the node.
 
-  .. automethod:: add_root
-
-     See: :meth:`treebeard.models.Node.add_root`
-
-  .. automethod:: add_child
-
-     See: :meth:`treebeard.models.Node.add_child`
-
-  .. automethod:: add_sibling
-
-     See: :meth:`treebeard.models.Node.add_sibling`
-
   .. automethod:: move
 
      See: :meth:`treebeard.models.Node.move`
+  
+
+.. autoclass:: MP_NodeManager
+  :show-inheritance:
 
   .. automethod:: get_tree
 
-     See: :meth:`treebeard.models.Node.get_tree`
+     See: :meth:`treebeard.models.NodeManager.get_tree`
 
      .. note::
 
         This method returns a queryset.
 
+  .. automethod:: add_root
+
+     See: :meth:`treebeard.models.NodeManager.add_root`
+
+  .. automethod:: add_child
+
+     See: :meth:`treebeard.models.NodeManager.add_child`
+
+  .. automethod:: add_sibling
+
+     See: :meth:`treebeard.models.NodeManager.add_sibling`
+
   .. automethod:: find_problems
 
-     .. note::
-
-        A node won't appear in more than one list, even when it exhibits
-        more than one problem. This method stops checking a node when it
-        finds a problem and continues to the next node.
-
-     .. note::
-
-        Problems 1, 2 and 3 can't be solved automatically.
-
-     Example:
+   Example:
 
      .. code-block:: python
 
-        MyNodeModel.find_problems()
+        MyNodeModel.objects.find_problems()
 
+   .. note::
+
+      A node won't appear in more than one list, even when it exhibits
+      more than one problem. This method stops checking a node when it
+      finds a problem and continues to the next node.
+
+   .. note::
+
+      Problems 1, 2 and 3 can't be solved automatically.
+  
   .. automethod:: fix_tree
 
-     Example:
-
-     .. code-block:: python
-
-        MyNodeModel.fix_tree()
-
   .. automethod:: load_bulk
-
-.. autoclass:: MP_NodeManager
-  :show-inheritance:
 
 .. autoclass:: MP_NodeQuerySet
   :show-inheritance:

--- a/docs/source/ns_tree.rst
+++ b/docs/source/ns_tree.rst
@@ -67,15 +67,22 @@ write/delete operations.
 
      ``PositiveIntegerField``
 
+
   .. automethod:: get_tree
 
         See: :meth:`treebeard.models.Node.get_tree`
 
-        .. note::
 
-            This method returns a queryset.
+.. autoclass:: NS_NodeManager
+  :show-inheritance:
 
   .. automethod:: find_problems
+
+   Example:
+
+     .. code-block:: python
+
+        MyNodeModel.objects.find_problems()
 
      .. note::
 
@@ -86,16 +93,6 @@ write/delete operations.
      .. note::
 
         These problems can't be solved automatically.
-
-     Example:
-
-     .. code-block:: python
-
-        MyNodeModel.find_problems()
-
-
-.. autoclass:: NS_NodeManager
-  :show-inheritance:
 
 .. autoclass:: NS_NodeQuerySet
   :show-inheritance:

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -30,17 +30,17 @@ Let's create some nodes:
 
     >>> from treebeard_tutorial.models import Category
     >>> get = lambda node_id: Category.objects.get(pk=node_id)
-    >>> root = Category.add_root(name='Computer Hardware')
-    >>> node = get(root.pk).add_child(name='Memory')
-    >>> get(node.pk).add_sibling(name='Hard Drives')
+    >>> root = Category.objects.add_root({"name": "Computer Hardware"})
+    >>> node = get(root.pk).add_child({"name": "Memory"})
+    >>> get(node.pk).add_sibling({"name": "Hard Drives"})
     <Category: Category: Hard Drives>
-    >>> get(node.pk).add_sibling(name='SSD')
+    >>> get(node.pk).add_sibling({"name": "SSD"})
     <Category: Category: SSD>
-    >>> get(node.pk).add_child(name='Desktop Memory')
+    >>> get(node.pk).add_child({"name": "Desktop Memory"})
     <Category: Category: Desktop Memory>
-    >>> get(node.pk).add_child(name='Laptop Memory')
+    >>> get(node.pk).add_child({"name": "Laptop Memory"})
     <Category: Category: Laptop Memory>
-    >>> get(node.pk).add_child(name='Server Memory')
+    >>> get(node.pk).add_child({"name": "Server Memory"})
     <Category: Category: Server Memory>
 
 .. note::
@@ -68,7 +68,7 @@ You can see the tree structure with code:
 
 .. code-block:: python
 
-    >>> Category.dump_bulk()
+    >>> Category.objects.dump_bulk()
     [{'id': 1, 'data': {'name': u'Computer Hardware'},
       'children': [
          {'id': 3, 'data': {'name': u'Hard Drives'}},
@@ -78,7 +78,7 @@ You can see the tree structure with code:
              {'id': 6, 'data': {'name': u'Laptop Memory'}},
              {'id': 7, 'data': {'name': u'Server Memory'}}]},
          {'id': 4, 'data': {'name': u'SSD'}}]}]
-    >>> Category.get_annotated_list()
+    >>> Category.objects.get_annotated_list()
     [(<Category: Category: Computer Hardware>,
       {'close': [], 'level': 0, 'open': True}),
      (<Category: Category: Hard Drives>,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,8 @@ from django.apps import apps
 from django.db import connection
 from django.db.models.signals import pre_migrate
 
+from tests.admin import register_all as admin_register_all
+
 
 def pytest_report_header(config):
     return "Django: " + django.get_version()
@@ -18,6 +20,7 @@ def pytest_report_header(config):
 
 def pytest_configure(config):
     django.setup()
+    admin_register_all()
 
 
 def _pre_migration(*args, **kwargs):

--- a/tests/test_benchmarks.py
+++ b/tests/test_benchmarks.py
@@ -23,13 +23,13 @@ def create_nodes(cls):
     """
     roots = []
     for i in range(5):
-        roots.append(cls.add_root(desc=f"root-{i}"))
+        roots.append(cls.add_root({"desc": f"root-{i}"}))
 
     for root in roots:
         depth = 1
         node = root
         while depth < 20:
-            node = node.add_child(desc=f"{root.desc}-child-{depth}")
+            node = node.add_child({"desc": f"{root.desc}-child-{depth}"})
             depth += 1
 
 
@@ -39,11 +39,11 @@ def create_sorted_nodes(cls):
     """
     roots = []
     for i in range(5):
-        roots.append(cls.add_root(desc=f"root-{i}", val1=randint(0, 100), val2=randint(0, 100)))
+        roots.append(cls.add_root({"desc": f"root-{i}", "val1": randint(0, 100), "val2": randint(0, 100)}))
 
     for root in roots:
         for n in range(20):
-            root.add_child(desc=f"{root.desc}-child-{n}", val1=randint(0, 100), val2=randint(0, 100))
+            root.add_child({"desc": f"{root.desc}-child-{n}", "val1": randint(0, 100), "val2": randint(0, 100)})
 
 
 def get_descendants(cls):
@@ -61,17 +61,17 @@ def move(cls):
     """
     root = cls.objects.get(desc="root-1")
     child = cls.objects.get(desc="root-2-child-18")
-    root.move(child, "first-sibling")
+    cls.objects.move(root, child, "first-sibling")
 
     child = cls.objects.get(desc="root-3-child-18")
     root = cls.objects.get(desc="root-2")
-    child.move(root, "first-sibling")
+    cls.objects.move(child, root, "first-sibling")
 
 
 def move_sorted(cls):
     root = cls.objects.get(desc="root-1")
     child = cls.objects.get(desc="root-2-child-18")
-    root.move(child, "sorted-sibling")
+    cls.objects.move(root, child, "sorted-sibling")
 
 
 def delete(cls):

--- a/tests/test_deprecated_api.py
+++ b/tests/test_deprecated_api.py
@@ -1,33 +1,20 @@
-"""Unit/Functional tests"""
+"""
+Duplicate of test_treebeard.py that uses the old, deprecated API for methods that moved
+from the Node class to the model manager.
+
+To be removed when backward compatibility is removed in Treebeard 7.
+"""
 
 import os
 import threading
 from contextlib import contextmanager
-from unittest import mock
-from unittest.mock import patch
 
 import pytest
-from django.apps import apps
-from django.contrib.admin.options import TO_FIELD_VAR
-from django.contrib.admin.sites import AdminSite
-from django.contrib.admin.views.main import ChangeList
-from django.contrib.auth.models import AnonymousUser, User
-from django.contrib.messages.storage.fallback import FallbackStorage
-from django.core import checks
-from django.core.checks.model_checks import check_all_models
-from django.core.exceptions import PermissionDenied
-from django.db.models import Manager
 from django.db.models.signals import post_save
 from django.dispatch import receiver
-from django.forms import ValidationError
-from django.template import Context, Template
-from django.test.client import RequestFactory
 from django.utils.timezone import now
 
 from tests import models
-from tests.admin import register_all as admin_register_all
-from treebeard import numconv
-from treebeard.admin import admin_factory
 from treebeard.al_tree import AL_Node
 from treebeard.exceptions import (
     InvalidMoveToDescendant,
@@ -36,17 +23,26 @@ from treebeard.exceptions import (
     NodeAlreadySaved,
     PathOverflow,
 )
-from treebeard.forms import movenodeform_factory
 from treebeard.ltree import LT_Node
 from treebeard.ltree import nodes_deleted as lt_nodes_deleted
 from treebeard.ltree import subtree_moved as lt_subtree_moved
 from treebeard.ltree import subtree_moved_right as lt_subtree_moved_right
-from treebeard.mp_tree import MP_Node, path_updated
+from treebeard.mp_tree import (
+    MP_AddChildHandler,
+    MP_AddRootHandler,
+    MP_AddSiblingHandler,
+    MP_MoveHandler,
+    MP_Node,
+    path_updated,
+)
 from treebeard.mp_tree import nodes_deleted as mp_nodes_deleted
 from treebeard.ns_tree import NS_Node, gap_altered, tree_ids_incremented
 from treebeard.ns_tree import nodes_deleted as ns_nodes_deleted
 from treebeard.ns_tree import subtree_moved as ns_subtree_moved
-from treebeard.templatetags.admin_tree import tree_context
+
+# Suppress deprecation warnings
+pytestmark = pytest.mark.filterwarnings("ignore::DeprecationWarning")
+
 
 BASE_DATA = [
     {"data": {"desc": "1"}},
@@ -88,7 +84,7 @@ UNCHANGED = [
 
 @pytest.fixture(scope="function", params=models.BASE_MODELS + models.PROXY_MODELS)
 def model(request):
-    request.param.objects.load_bulk(BASE_DATA)
+    request.param.load_bulk(BASE_DATA)
     return request.param
 
 
@@ -99,7 +95,7 @@ def model_without_data(request):
 
 @pytest.fixture(scope="function", params=models.BASE_MODELS)
 def model_without_proxy(request):
-    request.param.objects.load_bulk(BASE_DATA)
+    request.param.load_bulk(BASE_DATA)
     return request.param
 
 
@@ -115,7 +111,7 @@ def related_model(request):
 
 @pytest.fixture(scope="function", params=models.MP_MODELS)
 def mp_model(request):
-    request.param.objects.load_bulk(BASE_DATA)
+    request.param.load_bulk(BASE_DATA)
     return request.param
 
 
@@ -262,51 +258,51 @@ class TestTreeBase:
                 good_edges = list(range(1, len(got_edges) + 1))
                 assert sorted(got_edges) == good_edges
 
-        return [(o.desc, o.get_depth(), model.objects.get_children_count(o)) for o in model.objects.get_tree()]
+        return [(o.desc, o.get_depth(), o.get_children_count()) for o in model.get_tree()]
 
     def _assert_get_annotated_list(self, model, expected, parent=None):
-        results = model.objects.get_annotated_list(parent)
+        results = model.get_annotated_list(parent)
         got = [(obj[0].desc, obj[1]["open"], obj[1]["close"], obj[1]["level"]) for obj in results]
         assert expected == got
         assert all(isinstance(obj[0], model) for obj in results)
 
     def _assert_no_tree_problems(self, model):
         if issubclass(model, (MP_Node, NS_Node)):
-            assert not any(model.objects.find_problems())
+            assert not any(model.find_problems())
 
 
 @pytest.mark.django_db
 class TestEmptyTree(TestTreeBase):
     def test_load_bulk_empty(self, model_without_data):
-        ids = model_without_data.objects.load_bulk(BASE_DATA)
+        ids = model_without_data.load_bulk(BASE_DATA)
         got_descs = [obj.desc for obj in model_without_data.objects.filter(pk__in=ids)]
         expected_descs = [x[0] for x in UNCHANGED]
         assert sorted(got_descs) == sorted(expected_descs)
         assert self.got(model_without_data) == UNCHANGED
 
     def test_dump_bulk_empty(self, model_without_data):
-        assert model_without_data.objects.dump_bulk() == []
+        assert model_without_data.dump_bulk() == []
 
     def test_add_root_empty(self, model_without_data):
-        model_without_data.objects.add_root({"desc": "1"})
+        model_without_data.add_root(desc="1")
         expected = [("1", 1, 0)]
         assert self.got(model_without_data) == expected
 
     def test_get_root_nodes_empty(self, model_without_data):
-        got = model_without_data.objects.get_root_nodes()
+        got = model_without_data.get_root_nodes()
         expected = []
         assert [node.desc for node in got] == expected
 
     def test_get_first_root_node_empty(self, model_without_data):
-        got = model_without_data.objects.get_first_root_node()
+        got = model_without_data.get_first_root_node()
         assert got is None
 
     def test_get_last_root_node_empty(self, model_without_data):
-        got = model_without_data.objects.get_last_root_node()
+        got = model_without_data.get_last_root_node()
         assert got is None
 
     def test_get_tree(self, model_without_data):
-        got = list(model_without_data.objects.get_tree())
+        got = list(model_without_data.get_tree())
         assert got == []
 
     def test_get_annotated_list(self, model_without_data):
@@ -314,10 +310,10 @@ class TestEmptyTree(TestTreeBase):
         self._assert_get_annotated_list(model_without_data, expected)
 
     def test_add_multiple_root_nodes_adds_sibling_leaves(self, model_without_data):
-        model_without_data.objects.add_root({"desc": "1"})
-        model_without_data.objects.add_root({"desc": "2"})
-        model_without_data.objects.add_root({"desc": "3"})
-        model_without_data.objects.add_root({"desc": "4"})
+        model_without_data.add_root(desc="1")
+        model_without_data.add_root(desc="2")
+        model_without_data.add_root(desc="3")
+        model_without_data.add_root(desc="4")
         # these are all sibling root nodes (depth=1), and leaf nodes (children=0)
         expected = [("1", 1, 0), ("2", 1, 0), ("3", 1, 0), ("4", 1, 0)]
         assert self.got(model_without_data) == expected
@@ -332,7 +328,7 @@ class TestClassMethods(TestNonEmptyTree):
     def test_load_bulk_existing(self, model):
         # inserting on an existing node
         node = model.objects.get(desc="231")
-        ids = model.objects.load_bulk(BASE_DATA, node)
+        ids = model.load_bulk(BASE_DATA, node)
         expected = [
             ("1", 1, 0),
             ("2", 1, 4),
@@ -363,26 +359,26 @@ class TestClassMethods(TestNonEmptyTree):
     def test_get_tree_all(self, model, django_assert_max_num_queries):
         max_queries = 4 if issubclass(model, AL_Node) else 1
         with django_assert_max_num_queries(max_queries):
-            nodes = model.objects.get_tree()
-        got = [(o.desc, o.get_depth(), model.objects.get_children_count(o)) for o in nodes]
+            nodes = model.get_tree()
+        got = [(o.desc, o.get_depth(), o.get_children_count()) for o in nodes]
         assert got == UNCHANGED
         assert all(isinstance(o, model) for o in nodes)
 
     def test_dump_bulk_all(self, model):
-        assert model.objects.dump_bulk(keep_ids=False) == BASE_DATA
+        assert model.dump_bulk(keep_ids=False) == BASE_DATA
 
     def test_get_tree_node(self, model, django_assert_max_num_queries):
         node = model.objects.get(desc="231")
-        model.objects.load_bulk(BASE_DATA, node)
+        model.load_bulk(BASE_DATA, node)
 
         # the tree was modified by load_bulk, so we reload our node object
         node = model.objects.get(pk=node.pk)
 
         max_queries = 7 if issubclass(model, AL_Node) else 1
         with django_assert_max_num_queries(max_queries):
-            nodes = model.objects.get_tree(node)
+            nodes = model.get_tree(node)
 
-        got = [(o.desc, o.get_depth(), model.objects.get_children_count(o)) for o in nodes]
+        got = [(o.desc, o.get_depth(), o.get_children_count()) for o in nodes]
         expected = [
             ("231", 3, 4),
             ("1", 4, 0),
@@ -402,11 +398,11 @@ class TestClassMethods(TestNonEmptyTree):
     def test_get_tree_leaf(self, model, django_assert_max_num_queries):
         node = model.objects.get(desc="1")
 
-        assert 0 == model.objects.get_children_count(node)
+        assert 0 == node.get_children_count()
 
         with django_assert_max_num_queries(1):
-            nodes = model.objects.get_tree(node)
-        got = [(o.desc, o.get_depth(), model.objects.get_children_count(o)) for o in nodes]
+            nodes = model.get_tree(node)
+        got = [(o.desc, o.get_depth(), o.get_children_count()) for o in nodes]
         expected = [("1", 1, 0)]
         assert got == expected
         assert all(isinstance(o, model) for o in nodes)
@@ -450,23 +446,23 @@ class TestClassMethods(TestNonEmptyTree):
 
     def test_dump_bulk_node(self, model):
         node = model.objects.get(desc="231")
-        model.objects.load_bulk(BASE_DATA, node)
+        model.load_bulk(BASE_DATA, node)
 
         # the tree was modified by load_bulk, so we reload our node object
         node = model.objects.get(pk=node.pk)
 
-        got = model.objects.dump_bulk(node, False)
+        got = model.dump_bulk(node, False)
         expected = [{"data": {"desc": "231"}, "children": BASE_DATA}]
         assert got == expected
 
     def test_load_and_dump_bulk_keeping_ids(self, model):
-        exp = model.objects.dump_bulk(keep_ids=True)
+        exp = model.dump_bulk(keep_ids=True)
         model.objects.all().delete()
-        model.objects.load_bulk(exp, None, True)
-        got = model.objects.dump_bulk(keep_ids=True)
+        model.load_bulk(exp, None, True)
+        got = model.dump_bulk(keep_ids=True)
         assert got == exp
         # do we really have an unchanged tree after the dump/delete/load?
-        got = [(o.desc, o.get_depth(), model.objects.get_children_count(o)) for o in model.objects.get_tree()]
+        got = [(o.desc, o.get_depth(), o.get_children_count()) for o in model.get_tree()]
         assert got == UNCHANGED
 
     def test_load_and_dump_bulk_with_related_models(self, related_model):
@@ -496,48 +492,48 @@ class TestClassMethods(TestNonEmptyTree):
                 ],
             },
         ]
-        related_model.objects.load_bulk(related_data)
-        got = related_model.objects.dump_bulk(keep_ids=False)
+        related_model.load_bulk(related_data)
+        got = related_model.dump_bulk(keep_ids=False)
         assert got == related_data
 
     def test_get_root_nodes(self, model, django_assert_max_num_queries):
         with django_assert_max_num_queries(1):
-            got = model.objects.get_root_nodes()
+            got = model.get_root_nodes()
         expected = ["1", "2", "3", "4"]
         assert [node.desc for node in got] == expected
         assert all(isinstance(node, model) for node in got)
 
     def test_get_first_root_node(self, model, django_assert_max_num_queries):
         with django_assert_max_num_queries(1):
-            got = model.objects.get_first_root_node()
+            got = model.get_first_root_node()
         assert got.desc == "1"
         assert isinstance(got, model)
 
     def test_get_last_root_node(self, model, django_assert_max_num_queries):
         with django_assert_max_num_queries(1):
-            got = model.objects.get_last_root_node()
+            got = model.get_last_root_node()
         assert got.desc == "4"
         assert isinstance(got, model)
 
     def test_add_root(self, model):
-        obj = model.objects.add_root({"desc": "5"})
+        obj = model.add_root(desc="5")
         assert obj.get_depth() == 1
-        got = model.objects.get_last_root_node()
+        got = model.get_last_root_node()
         assert got.desc == "5"
         assert isinstance(got, model)
 
     def test_add_root_with_passed_instance(self, model):
         obj = model(desc="5")
-        result = model.objects.add_root(instance=obj)
+        result = model.add_root(instance=obj)
         assert result == obj
-        got = model.objects.get_last_root_node()
+        got = model.get_last_root_node()
         assert got.desc == "5"
         assert isinstance(got, model)
 
     def test_add_root_with_already_saved_instance(self, model):
         obj = model.objects.get(desc="4")
         with pytest.raises(NodeAlreadySaved):
-            model.objects.add_root(instance=obj)
+            model.add_root(instance=obj)
 
 
 @pytest.mark.django_db
@@ -585,7 +581,7 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
             descendant = model.objects.get(desc=desc)
             max_queries = 2 if issubclass(model, AL_Node) else 1
             with django_assert_max_num_queries(max_queries):
-                node = model.objects.get_root(descendant)
+                node = descendant.get_root()
             assert node.desc == expected
             assert isinstance(node, model)
 
@@ -604,7 +600,7 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
         for desc, expected in data.items():
             node = model.objects.get(desc=desc)
             with django_assert_max_num_queries(1):
-                parent = model.objects.get_parent(node)
+                parent = node.get_parent()
             if expected:
                 assert parent.desc == expected
                 assert isinstance(parent, model)
@@ -618,7 +614,7 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
             node = objs[desc]
             # asking get_parent to not use the parent cache (since we
             # corrupted it in the previous loop)
-            parent = model.objects.get_parent(node, True)
+            parent = node.get_parent(True)
             if expected:
                 assert parent.desc == expected
                 assert isinstance(parent, model)
@@ -634,7 +630,7 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
         for desc, expected in data:
             node = model.objects.get(desc=desc)
             with django_assert_max_num_queries(1):
-                children = model.objects.get_children(node)
+                children = node.get_children()
             assert [node.desc for node in children] == expected
             assert all(isinstance(node, model) for node in children)
 
@@ -648,7 +644,7 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
             node = model.objects.get(desc=desc)
             max_queries = 0 if issubclass(model, MP_Node) else 1
             with django_assert_max_num_queries(max_queries):
-                got = model.objects.get_children_count(node)
+                got = node.get_children_count()
             assert got == expected
 
     def test_get_siblings(self, model, django_assert_max_num_queries):
@@ -660,7 +656,7 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
         for desc, expected in data:
             node = model.objects.get(desc=desc)
             with django_assert_max_num_queries(1):
-                siblings = model.objects.get_siblings(node)
+                siblings = node.get_siblings()
             assert [node.desc for node in siblings] == expected
             assert all(isinstance(node, model) for node in siblings)
 
@@ -678,7 +674,7 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
             node = model.objects.get(desc=desc)
             max_queries = 2 if issubclass(model, NS_Node) else 1
             with django_assert_max_num_queries(max_queries):
-                sibling = model.objects.get_first_sibling(node)
+                sibling = node.get_first_sibling()
             assert sibling.desc == expected
             assert isinstance(sibling, model)
 
@@ -696,7 +692,7 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
             node = model.objects.get(desc=desc)
             max_queries = 4 if issubclass(model, NS_Node) else 1
             with django_assert_max_num_queries(max_queries):
-                sibling = model.objects.get_prev_sibling(node)
+                sibling = node.get_prev_sibling()
             if expected is None:
                 assert sibling is None
             else:
@@ -717,7 +713,7 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
             node = model.objects.get(desc=desc)
             max_queries = 4 if issubclass(model, NS_Node) else 1  # TODO can NS be made more efficient?
             with django_assert_max_num_queries(max_queries):
-                sibling = model.objects.get_next_sibling(node)
+                sibling = node.get_next_sibling()
             if expected is None:
                 assert sibling is None
             else:
@@ -738,7 +734,7 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
             node = model.objects.get(desc=desc)
             max_queries = 4 if issubclass(model, NS_Node) else 1  # TODO can NS be made more efficient?
             with django_assert_max_num_queries(max_queries):
-                sibling = model.objects.get_last_sibling(node)
+                sibling = node.get_last_sibling()
             assert sibling.desc == expected
             assert isinstance(sibling, model)
 
@@ -752,7 +748,7 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
         for desc, expected in data:
             parent = model.objects.get(desc=desc)
             with django_assert_max_num_queries(1):
-                node = model.objects.get_first_child(parent)
+                node = parent.get_first_child()
             if expected is None:
                 assert node is None
             else:
@@ -769,7 +765,7 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
         for desc, expected in data:
             parent = model.objects.get(desc=desc)
             with django_assert_max_num_queries(1):
-                node = model.objects.get_last_child(parent)
+                node = parent.get_last_child()
             if expected is None:
                 assert node is None
             else:
@@ -786,7 +782,7 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
             descendant = model.objects.get(desc=desc)
             max_queries = 2 if issubclass(model, AL_Node) else 1
             with django_assert_max_num_queries(max_queries):
-                nodes = model.objects.get_ancestors(descendant)
+                nodes = descendant.get_ancestors()
             assert [node.desc for node in nodes] == expected
             assert all(isinstance(node, model) for node in nodes)
 
@@ -802,7 +798,7 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
             parent = model.objects.get(desc=desc)
             max_queries = 3 if issubclass(model, AL_Node) else 1
             with django_assert_max_num_queries(max_queries):
-                nodes = model.objects.get_descendants(parent)
+                nodes = parent.get_descendants()
             assert [node.desc for node in nodes] == expected
             assert all(isinstance(node, model) for node in nodes)
 
@@ -818,7 +814,7 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
             parent = model.objects.get(desc=desc)
             max_queries = 3 if issubclass(model, AL_Node) else 1
             with django_assert_max_num_queries(max_queries):
-                nodes = model.objects.get_descendants(parent, include_self=True)
+                nodes = parent.get_descendants(include_self=True)
             assert [node.desc for node in nodes] == expected
             assert all(isinstance(node, model) for node in nodes)
 
@@ -834,7 +830,7 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
             parent = model.objects.get(desc=desc)
             max_queries = 3 if issubclass(model, AL_Node) else 1
             with django_assert_max_num_queries(max_queries):
-                got = model.objects.get_descendant_count(parent)
+                got = parent.get_descendant_count()
             assert got == expected
 
     def test_is_sibling_of(self, model, django_assert_max_num_queries):
@@ -891,8 +887,7 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
 class TestAddChild(TestNonEmptyTree):
     def test_add_child_to_leaf(self, model):
         with capture_signals() as signals:
-            model.objects.add_child(model.objects.get(desc="231"), {"desc": "2311"})
-
+            model.objects.get(desc="231").add_child(desc="2311")
         expected = [
             ("1", 1, 0),
             ("2", 1, 4),
@@ -918,7 +913,7 @@ class TestAddChild(TestNonEmptyTree):
 
     def test_add_child_to_node(self, model):
         with capture_signals() as signals:
-            model.objects.add_child(model.objects.get(desc="2"), {"desc": "25"})
+            model.objects.get(desc="2").add_child(desc="25")
         expected = [
             ("1", 1, 0),
             ("2", 1, 5),
@@ -945,7 +940,7 @@ class TestAddChild(TestNonEmptyTree):
     def test_add_child_with_passed_instance(self, model):
         child = model(desc="2311")
         with capture_signals() as signals:
-            result = model.objects.add_child(model.objects.get(desc="231"), instance=child)
+            result = model.objects.get(desc="231").add_child(instance=child)
         assert result == child
         expected = [
             ("1", 1, 0),
@@ -972,16 +967,13 @@ class TestAddChild(TestNonEmptyTree):
 
     def test_add_child_called_consecutively(self, model_without_data):
         # Regression test for https://github.com/django-treebeard/django-treebeard/issues/307
-        parent = model_without_data.objects.add_root({"desc": "1"})
+        parent = model_without_data.add_root(desc="1")
         child1 = model_without_data(desc="11")
         child2 = model_without_data(desc="12")
-        assert model_without_data.objects.get_children_count(parent) == 0
-        model_without_data.objects.add_child(parent, instance=child1)
-        model_without_data.objects.add_child(parent, instance=child2)
-        assert list(model_without_data.objects.get_children(parent).values_list("desc", flat=True)) == [
-            child1.desc,
-            child2.desc,
-        ]
+        assert parent.get_children_count() == 0
+        parent.add_child(instance=child1)
+        parent.add_child(instance=child2)
+        assert list(parent.get_children().values_list("desc", flat=True)) == [child1.desc, child2.desc]
 
     @pytest.mark.django_db(transaction=True)
     @pytest.mark.skipif(
@@ -992,7 +984,7 @@ class TestAddChild(TestNonEmptyTree):
         # 5 threads x 5 add_child each on same parent; no IntegrityError.
         num_threads = 5
         per_thread = 5
-        parent = model_without_data.objects.add_root({"desc": "parent"})
+        parent = model_without_data.add_root(desc="parent")
         parent_pk = parent.pk
         errors = []
 
@@ -1000,7 +992,7 @@ class TestAddChild(TestNonEmptyTree):
             try:
                 p = model_without_data.objects.get(pk=parent_pk)
                 for i in range(per_thread):
-                    model_without_data.objects.add_child(p, {"desc": f"t{thread_id}-{i}"})
+                    p.add_child(desc=f"t{thread_id}-{i}")
             except Exception as e:
                 errors.append(e)
 
@@ -1012,12 +1004,12 @@ class TestAddChild(TestNonEmptyTree):
         if errors:
             raise errors[0]
         parent.refresh_from_db()
-        assert model_without_data.objects.get_children_count(parent) == num_threads * per_thread
+        assert parent.get_children_count() == num_threads * per_thread
 
     def test_add_child_with_already_saved_instance(self, model):
         child = model.objects.get(desc="21")
         with pytest.raises(NodeAlreadySaved):
-            model.objects.add_child(model.objects.get(desc="2"), instance=child)
+            model.objects.get(desc="2").add_child(instance=child)
 
     def test_add_child_with_pk_set(self, model):
         """
@@ -1025,7 +1017,7 @@ class TestAddChild(TestNonEmptyTree):
         already set when the instance is inserted.
         """
         child = model(pk=999999, desc="natural key")
-        result = model.objects.add_child(model.objects.get(desc="2"), instance=child)
+        result = model.objects.get(desc="2").add_child(instance=child)
         assert result == child
 
     def test_add_child_post_save(self, model):
@@ -1033,14 +1025,14 @@ class TestAddChild(TestNonEmptyTree):
 
             @receiver(post_save, dispatch_uid="test_add_child_post_save")
             def on_post_save(instance, **kwargs):
-                parent = model.objects.get_parent(instance)
-                assert model.objects.get_descendant_count(parent) == 1
+                parent = instance.get_parent()
+                assert parent.get_descendant_count() == 1
 
             # It's important that we're testing a leaf node
             parent = model.objects.get(desc="231")
             assert parent.is_leaf()
 
-            model.objects.add_child(parent, {"desc": "2311"})
+            parent.add_child(desc="2311")
         finally:
             post_save.disconnect(dispatch_uid="test_add_child_post_save")
 
@@ -1049,19 +1041,19 @@ class TestAddChild(TestNonEmptyTree):
 class TestAddSibling(TestNonEmptyTree):
     def test_add_sibling_invalid_pos(self, model):
         with pytest.raises(InvalidPosition):
-            model.objects.add_sibling(model.objects.get(desc="231"), "invalid_pos", {})
+            model.objects.get(desc="231").add_sibling("invalid_pos")
 
     def test_add_sibling_missing_nodeorderby(self, model):
         node_wchildren = model.objects.get(desc="2")
         with pytest.raises(MissingNodeOrderBy):
-            model.objects.add_sibling(node_wchildren, "sorted-sibling", {"desc": "aaa"})
+            node_wchildren.add_sibling("sorted-sibling", desc="aaa")
 
     def test_add_sibling_last_root(self, model):
         node_wchildren = model.objects.get(desc="2")
         with capture_signals() as signals:
-            obj = model.objects.add_sibling(node_wchildren, "last-sibling", {"desc": "5"})
+            obj = node_wchildren.add_sibling("last-sibling", desc="5")
         assert obj.get_depth() == 1
-        assert model.objects.get_last_sibling(node_wchildren).desc == "5"
+        assert node_wchildren.get_last_sibling().desc == "5"
         if issubclass(model, MP_Node):
             assert signals == []
         elif issubclass(model, NS_Node):
@@ -1072,9 +1064,9 @@ class TestAddSibling(TestNonEmptyTree):
     def test_add_sibling_last(self, model):
         node = model.objects.get(desc="231")
         with capture_signals() as signals:
-            obj = model.objects.add_sibling(node, "last-sibling", {"desc": "232"})
+            obj = node.add_sibling("last-sibling", desc="232")
         assert obj.get_depth() == 3
-        assert model.objects.get_last_sibling(node).desc == "232"
+        assert node.get_last_sibling().desc == "232"
         if issubclass(model, MP_Node):
             assert signals == []
         elif issubclass(model, NS_Node):
@@ -1087,7 +1079,7 @@ class TestAddSibling(TestNonEmptyTree):
     def test_add_sibling_first_root(self, model):
         node_wchildren = model.objects.get(desc="2")
         with capture_signals() as signals:
-            obj = model.objects.add_sibling(node_wchildren, "first-sibling", {"desc": "new"})
+            obj = node_wchildren.add_sibling("first-sibling", desc="new")
         assert obj.get_depth() == 1
         expected = [
             ("new", 1, 0),
@@ -1131,7 +1123,7 @@ class TestAddSibling(TestNonEmptyTree):
     def test_add_sibling_first(self, model):
         node_wchildren = model.objects.get(desc="23")
         with capture_signals() as signals:
-            obj = model.objects.add_sibling(node_wchildren, "first-sibling", {"desc": "new"})
+            obj = node_wchildren.add_sibling("first-sibling", desc="new")
         assert obj.get_depth() == 2
         expected = [
             ("1", 1, 0),
@@ -1175,7 +1167,7 @@ class TestAddSibling(TestNonEmptyTree):
     def test_add_sibling_left_root(self, model):
         node_wchildren = model.objects.get(desc="2")
         with capture_signals() as signals:
-            obj = model.objects.add_sibling(node_wchildren, "left", {"desc": "new"})
+            obj = node_wchildren.add_sibling("left", desc="new")
         assert obj.get_depth() == 1
         expected = [
             ("1", 1, 0),
@@ -1217,7 +1209,7 @@ class TestAddSibling(TestNonEmptyTree):
     def test_add_sibling_left(self, model):
         node_wchildren = model.objects.get(desc="23")
         with capture_signals() as signals:
-            obj = model.objects.add_sibling(node_wchildren, "left", {"desc": "new"})
+            obj = node_wchildren.add_sibling("left", desc="new")
         assert obj.get_depth() == 2
         expected = [
             ("1", 1, 0),
@@ -1257,7 +1249,7 @@ class TestAddSibling(TestNonEmptyTree):
     def test_add_sibling_left_noleft_root(self, model):
         node = model.objects.get(desc="1")
         with capture_signals() as signals:
-            obj = model.objects.add_sibling(node, "left", {"desc": "new"})
+            obj = node.add_sibling("left", desc="new")
         assert obj.get_depth() == 1
         expected = [
             ("new", 1, 0),
@@ -1301,7 +1293,7 @@ class TestAddSibling(TestNonEmptyTree):
     def test_add_sibling_left_noleft(self, model):
         node = model.objects.get(desc="231")
         with capture_signals() as signals:
-            obj = model.objects.add_sibling(node, "left", {"desc": "new"})
+            obj = node.add_sibling("left", desc="new")
         assert obj.get_depth() == 3
         expected = [
             ("1", 1, 0),
@@ -1339,7 +1331,7 @@ class TestAddSibling(TestNonEmptyTree):
     def test_add_sibling_right_root(self, model):
         node_wchildren = model.objects.get(desc="2")
         with capture_signals() as signals:
-            obj = model.objects.add_sibling(node_wchildren, "right", {"desc": "new"})
+            obj = node_wchildren.add_sibling("right", desc="new")
         assert obj.get_depth() == 1
         expected = [
             ("1", 1, 0),
@@ -1379,7 +1371,7 @@ class TestAddSibling(TestNonEmptyTree):
     def test_add_sibling_right(self, model):
         node_wchildren = model.objects.get(desc="23")
         with capture_signals() as signals:
-            obj = model.objects.add_sibling(node_wchildren, "right", {"desc": "new"})
+            obj = node_wchildren.add_sibling("right", desc="new")
         assert obj.get_depth() == 2
         expected = [
             ("1", 1, 0),
@@ -1418,7 +1410,7 @@ class TestAddSibling(TestNonEmptyTree):
     def test_add_sibling_right_noright_root(self, model):
         node = model.objects.get(desc="4")
         with capture_signals() as signals:
-            obj = model.objects.add_sibling(node, "right", {"desc": "new"})
+            obj = node.add_sibling("right", desc="new")
         assert obj.get_depth() == 1
         expected = [
             ("1", 1, 0),
@@ -1444,7 +1436,7 @@ class TestAddSibling(TestNonEmptyTree):
     def test_add_sibling_right_noright(self, model):
         node = model.objects.get(desc="231")
         with capture_signals() as signals:
-            obj = model.objects.add_sibling(node, "right", {"desc": "new"})
+            obj = node.add_sibling("right", desc="new")
         assert obj.get_depth() == 3
         expected = [
             ("1", 1, 0),
@@ -1472,16 +1464,16 @@ class TestAddSibling(TestNonEmptyTree):
     def test_add_sibling_with_passed_instance(self, model):
         node_wchildren = model.objects.get(desc="2")
         obj = model(desc="5")
-        result = model.objects.add_sibling(node_wchildren, "last-sibling", instance=obj)
+        result = node_wchildren.add_sibling("last-sibling", instance=obj)
         assert result == obj
         assert obj.get_depth() == 1
-        assert model.objects.get_last_sibling(node_wchildren).desc == "5"
+        assert node_wchildren.get_last_sibling().desc == "5"
 
     def test_add_sibling_already_saved_instance(self, model):
         node_wchildren = model.objects.get(desc="2")
         existing_node = model.objects.get(desc="4")
         with pytest.raises(NodeAlreadySaved):
-            model.objects.add_sibling(node_wchildren, "last-sibling", instance=existing_node)
+            node_wchildren.add_sibling("last-sibling", instance=existing_node)
 
     def test_add_child_with_pk_set(self, model):
         """
@@ -1489,285 +1481,8 @@ class TestAddSibling(TestNonEmptyTree):
         already set when the instance is inserted.
         """
         child = model(pk=999999, desc="natural key")
-        result = model.objects.add_child(model.objects.get(desc="2"), instance=child)
+        result = model.objects.get(desc="2").add_child(instance=child)
         assert result == child
-
-
-@pytest.mark.django_db
-class TestDelete(TestTreeBase):
-    @staticmethod
-    @pytest.fixture(
-        scope="function",
-        params=models.DEP_MODELS,
-        ids=lambda fv: f"base={fv[0].__name__} dep={fv[1].__name__}",
-    )
-    def delete_dep_model_pair(request):
-        base_model, dep_model = request.param
-        base_model.objects.load_bulk(BASE_DATA)
-        for node in base_model.objects.all():
-            dep_model(node=node).save()
-        return base_model, dep_model
-
-    def test_delete_leaf(self, delete_dep_model_pair):
-        delete_model, dep_model = delete_dep_model_pair
-        node = delete_model.objects.get(desc="231")
-        with capture_signals() as signals:
-            result = node.delete()
-        expected = [
-            ("1", 1, 0),
-            ("2", 1, 4),
-            ("21", 2, 0),
-            ("22", 2, 0),
-            ("23", 2, 0),
-            ("24", 2, 0),
-            ("3", 1, 0),
-            ("4", 1, 1),
-            ("41", 2, 0),
-        ]
-        assert self.got(delete_model) == expected
-        assert result == (2, {delete_model._meta.label: 1, dep_model._meta.label: 1})
-        if issubclass(delete_model, MP_Node):
-            assert signals == [
-                ("nodes_deleted", delete_model, [node.pk], [], "default"),
-            ]
-        elif issubclass(delete_model, NS_Node):
-            assert signals == [
-                ("nodes_deleted", delete_model, [(2, 7, 8)], "default"),
-                ("gap_altered", delete_model, 2, 7, -2, "default"),
-            ]
-        elif issubclass(delete_model, LT_Node):
-            assert signals == [
-                ("nodes_deleted", delete_model, ["B.C.A"], "default"),
-            ]
-
-    def test_delete_node(self, delete_dep_model_pair):
-        delete_model, dep_model = delete_dep_model_pair
-        with capture_signals() as signals:
-            result = delete_model.objects.get(desc="23").delete()
-        expected = [
-            ("1", 1, 0),
-            ("2", 1, 3),
-            ("21", 2, 0),
-            ("22", 2, 0),
-            ("24", 2, 0),
-            ("3", 1, 0),
-            ("4", 1, 1),
-            ("41", 2, 0),
-        ]
-        assert self.got(delete_model) == expected
-        assert result == (4, {delete_model._meta.label: 2, dep_model._meta.label: 2})
-        if issubclass(delete_model, MP_Node):
-            if delete_model.steplen == 1:
-                expected_signals = [
-                    ("nodes_deleted", delete_model, [], ["23"], "default"),
-                ]
-            elif delete_model.steplen == 3:
-                expected_signals = [
-                    ("nodes_deleted", delete_model, [], ["002003"], "default"),
-                ]
-            else:
-                assert False, f"Unexpected steplen: {delete_model.steplen}"
-            assert signals == expected_signals
-        elif issubclass(delete_model, NS_Node):
-            assert signals == [
-                ("nodes_deleted", delete_model, [(2, 6, 9)], "default"),
-                ("gap_altered", delete_model, 2, 6, -4, "default"),
-            ]
-        elif issubclass(delete_model, LT_Node):
-            assert signals == [
-                ("nodes_deleted", delete_model, ["B.C"], "default"),
-            ]
-
-    def test_delete_root(self, delete_dep_model_pair):
-        delete_model, dep_model = delete_dep_model_pair
-        with capture_signals() as signals:
-            result = delete_model.objects.get(desc="2").delete()
-        expected = [("1", 1, 0), ("3", 1, 0), ("4", 1, 1), ("41", 2, 0)]
-        assert self.got(delete_model) == expected
-        assert result == (12, {delete_model._meta.label: 6, dep_model._meta.label: 6})
-        if issubclass(delete_model, MP_Node):
-            if delete_model.steplen == 1:
-                expected_signals = [
-                    ("nodes_deleted", delete_model, [], ["2"], "default"),
-                ]
-            elif delete_model.steplen == 3:
-                expected_signals = [
-                    ("nodes_deleted", delete_model, [], ["002"], "default"),
-                ]
-            else:
-                assert False, f"Unexpected steplen: {delete_model.steplen}"
-            assert signals == expected_signals
-        elif issubclass(delete_model, NS_Node):
-            assert signals == [
-                ("nodes_deleted", delete_model, [(2, 1, 12)], "default"),
-            ]
-        elif issubclass(delete_model, LT_Node):
-            assert signals == [
-                ("nodes_deleted", delete_model, ["B"], "default"),
-            ]
-
-    def test_delete_filter_root_nodes(self, delete_dep_model_pair):
-        delete_model, dep_model = delete_dep_model_pair
-        node3 = delete_model.objects.get(desc="3")
-        with capture_signals() as signals:
-            result = delete_model.objects.filter(desc__in=("2", "3")).delete()
-        expected = [("1", 1, 0), ("4", 1, 1), ("41", 2, 0)]
-        assert self.got(delete_model) == expected
-        assert result == (14, {delete_model._meta.label: 7, dep_model._meta.label: 7})
-        if issubclass(delete_model, MP_Node):
-            if delete_model.steplen == 1:
-                expected_signals = [
-                    ("nodes_deleted", delete_model, [node3.pk], ["2"], "default"),
-                ]
-            elif delete_model.steplen == 3:
-                expected_signals = [
-                    ("nodes_deleted", delete_model, [node3.pk], ["002"], "default"),
-                ]
-            else:
-                assert False, f"Unexpected steplen: {delete_model.steplen}"
-            assert signals == expected_signals
-        elif issubclass(delete_model, NS_Node):
-            assert signals == [
-                ("nodes_deleted", delete_model, [(2, 1, 12), (3, 1, 2)], "default"),
-            ]
-        elif issubclass(delete_model, LT_Node):
-            assert signals == [
-                ("nodes_deleted", delete_model, ["B", "C"], "default"),
-            ]
-
-    def test_delete_filter_children(self, delete_dep_model_pair):
-        delete_model, dep_model = delete_dep_model_pair
-        with capture_signals() as signals:
-            result = delete_model.objects.filter(desc__in=("2", "23", "231")).delete()
-        expected = [("1", 1, 0), ("3", 1, 0), ("4", 1, 1), ("41", 2, 0)]
-        assert self.got(delete_model) == expected
-        assert result == (12, {delete_model._meta.label: 6, dep_model._meta.label: 6})
-        if issubclass(delete_model, MP_Node):
-            if delete_model.steplen == 1:
-                expected_signals = [
-                    ("nodes_deleted", delete_model, [], ["2"], "default"),
-                ]
-            elif delete_model.steplen == 3:
-                expected_signals = [
-                    ("nodes_deleted", delete_model, [], ["002"], "default"),
-                ]
-            else:
-                assert False, f"Unexpected steplen: {delete_model.steplen}"
-            assert signals == expected_signals
-        elif issubclass(delete_model, NS_Node):
-            assert signals == [
-                ("nodes_deleted", delete_model, [(2, 1, 12)], "default"),
-            ]
-        elif issubclass(delete_model, LT_Node):
-            assert signals == [
-                ("nodes_deleted", delete_model, ["B"], "default"),
-            ]
-
-    def test_delete_nonexistant_nodes(self, delete_dep_model_pair):
-        delete_model, dep_model = delete_dep_model_pair
-        with capture_signals() as signals:
-            result = delete_model.objects.filter(desc__in=("ZZZ", "XXX")).delete()
-        assert self.got(delete_model) == UNCHANGED
-        assert result == (0, {})
-        if issubclass(delete_model, MP_Node):
-            assert signals == []
-        elif issubclass(delete_model, NS_Node):
-            assert signals == []
-
-    def test_delete_same_node_twice(self, delete_dep_model_pair):
-        delete_model, dep_model = delete_dep_model_pair
-        with capture_signals() as signals:
-            result = delete_model.objects.filter(desc__in=("2", "2")).delete()
-        expected = [("1", 1, 0), ("3", 1, 0), ("4", 1, 1), ("41", 2, 0)]
-        assert self.got(delete_model) == expected
-        assert result == (12, {delete_model._meta.label: 6, dep_model._meta.label: 6})
-        if issubclass(delete_model, MP_Node):
-            if delete_model.steplen == 1:
-                expected_signals = [
-                    ("nodes_deleted", delete_model, [], ["2"], "default"),
-                ]
-            elif delete_model.steplen == 3:
-                expected_signals = [
-                    ("nodes_deleted", delete_model, [], ["002"], "default"),
-                ]
-            else:
-                assert False, f"Unexpected steplen: {delete_model.steplen}"
-            assert signals == expected_signals
-        elif issubclass(delete_model, NS_Node):
-            assert signals == [
-                ("nodes_deleted", delete_model, [(2, 1, 12)], "default"),
-            ]
-        elif issubclass(delete_model, LT_Node):
-            assert signals == [
-                ("nodes_deleted", delete_model, ["B"], "default"),
-            ]
-
-    def test_delete_all_root_nodes(self, delete_dep_model_pair):
-        delete_model, dep_model = delete_dep_model_pair
-        node1 = delete_model.objects.get(desc="1")
-        node3 = delete_model.objects.get(desc="3")
-        with capture_signals() as signals:
-            result = delete_model.objects.get_root_nodes().delete()
-        assert result == (20, {delete_model._meta.label: 10, dep_model._meta.label: 10})
-        assert delete_model.objects.count() == 0
-        if issubclass(delete_model, MP_Node):
-            if delete_model.steplen == 1:
-                expected_signals = [
-                    ("nodes_deleted", delete_model, [node1.pk, node3.pk], ["2", "4"], "default"),
-                ]
-            elif delete_model.steplen == 3:
-                expected_signals = [
-                    ("nodes_deleted", delete_model, [node1.pk, node3.pk], ["002", "004"], "default"),
-                ]
-            else:
-                assert False, f"Unexpected steplen: {delete_model.steplen}"
-            assert signals == expected_signals
-        elif issubclass(delete_model, NS_Node):
-            assert signals == [
-                ("nodes_deleted", delete_model, [(1, 1, 2), (2, 1, 12), (3, 1, 2), (4, 1, 4)], "default"),
-            ]
-        elif issubclass(delete_model, LT_Node):
-            assert signals == [
-                ("nodes_deleted", delete_model, ["A", "B", "C", "D"], "default"),
-            ]
-
-    def test_delete_all_nodes(self, delete_dep_model_pair):
-        delete_model, dep_model = delete_dep_model_pair
-        node1 = delete_model.objects.get(desc="1")
-        node3 = delete_model.objects.get(desc="3")
-        with capture_signals() as signals:
-            result = delete_model.objects.all().delete()
-        assert result == (20, {delete_model._meta.label: 10, dep_model._meta.label: 10})
-        assert delete_model.objects.count() == 0
-        if issubclass(delete_model, MP_Node):
-            if delete_model.steplen == 1:
-                expected_signals = [
-                    ("nodes_deleted", delete_model, [node1.pk, node3.pk], ["2", "4"], "default"),
-                ]
-            elif delete_model.steplen == 3:
-                expected_signals = [
-                    ("nodes_deleted", delete_model, [node1.pk, node3.pk], ["002", "004"], "default"),
-                ]
-            else:
-                assert False, f"Unexpected steplen: {delete_model.steplen}"
-            assert signals == expected_signals
-        elif issubclass(delete_model, NS_Node):
-            assert signals == [
-                ("nodes_deleted", delete_model, [(1, 1, 2), (2, 1, 12), (3, 1, 2), (4, 1, 4)], "default"),
-            ]
-        elif issubclass(delete_model, LT_Node):
-            assert signals == [
-                ("nodes_deleted", delete_model, ["A", "B", "C", "D"], "default"),
-            ]
-
-    def test_delete_with_prefetch_related(self, related_model):
-        # Regression test for https://github.com/django-treebeard/django-treebeard/issues/405
-        # If `delete()` is run on a queryset with `prefetch_related()` set, then Treebeard's use
-        # of `iterator()` will throw an exception unless the prefetch is cleared.
-        related = models.RelatedModel.objects.create(desc=f"Test {related_model.__name__}")
-        related_model.objects.add_root({"desc": "A", "related": related})
-        num_deleted, _ = related_model.objects.prefetch_related("related_m2m").all().delete()
-        assert num_deleted == 1
 
 
 @pytest.mark.django_db
@@ -1775,40 +1490,40 @@ class TestMoveErrors(TestNonEmptyTree):
     def test_move_invalid_pos(self, model):
         node = model.objects.get(desc="231")
         with pytest.raises(InvalidPosition):
-            model.objects.move(node, node, "invalid_pos")
+            node.move(node, "invalid_pos")
 
     def test_move_to_descendant(self, model):
         node = model.objects.get(desc="2")
         target = model.objects.get(desc="231")
         with pytest.raises(InvalidMoveToDescendant):
-            model.objects.move(node, target, "first-sibling")
+            node.move(target, "first-sibling")
 
     @pytest.mark.parametrize("pos", ("first-child", "last-child"))
     def test_cannot_move_node_to_its_own_child(self, pos, model):
         # Test for non-leaf node
         node = model.objects.get(desc="22")
         with pytest.raises(InvalidMoveToDescendant, match="move node to itself"):
-            model.objects.move(node, node, pos)
+            node.move(node, pos)
 
         # Test for leaf node
         node = model.objects.get(desc="231")
         with pytest.raises(InvalidMoveToDescendant, match="move node to itself"):
-            model.objects.move(node, node, pos)
+            node.move(node, pos)
 
     def test_move_missing_nodeorderby(self, model):
         node = model.objects.get(desc="231")
         with pytest.raises(MissingNodeOrderBy):
-            model.objects.move(node, node, "sorted-child")
+            node.move(node, "sorted-child")
         with pytest.raises(MissingNodeOrderBy):
-            model.objects.move(node, node, "sorted-sibling")
+            node.move(node, "sorted-sibling")
 
 
 @pytest.mark.django_db
 class TestMoveSortedErrors(TestTreeBase):
     def test_nonsorted_move_in_sorted(self, sorted_model):
-        node = sorted_model.objects.add_root({"val1": 3, "val2": 3, "desc": "zxy"})
+        node = sorted_model.add_root(val1=3, val2=3, desc="zxy")
         with pytest.raises(InvalidPosition):
-            sorted_model.objects.move(node, node, "left")
+            node.move(node, "left")
 
 
 @pytest.mark.django_db
@@ -1816,7 +1531,7 @@ class TestMoveLeafRoot(TestNonEmptyTree):
     def test_move_leaf_last_sibling_root(self, model):
         target = model.objects.get(desc="2")
         with capture_signals() as signals:
-            model.objects.move(model.objects.get(desc="231"), target, "last-sibling")
+            model.objects.get(desc="231").move(target, "last-sibling")
         expected = [
             ("1", 1, 0),
             ("2", 1, 4),
@@ -1855,7 +1570,7 @@ class TestMoveLeafRoot(TestNonEmptyTree):
     def test_move_leaf_first_sibling_root(self, model):
         target = model.objects.get(desc="2")
         with capture_signals() as signals:
-            model.objects.move(model.objects.get(desc="231"), target, "first-sibling")
+            model.objects.get(desc="231").move(target, "first-sibling")
         expected = [
             ("231", 1, 0),
             ("1", 1, 0),
@@ -1903,7 +1618,7 @@ class TestMoveLeafRoot(TestNonEmptyTree):
     def test_move_leaf_left_sibling_root(self, model):
         target = model.objects.get(desc="2")
         with capture_signals() as signals:
-            model.objects.move(model.objects.get(desc="231"), target, "left")
+            model.objects.get(desc="231").move(target, "left")
         expected = [
             ("1", 1, 0),
             ("231", 1, 0),
@@ -1949,7 +1664,7 @@ class TestMoveLeafRoot(TestNonEmptyTree):
     def test_move_leaf_right_sibling_root(self, model):
         target = model.objects.get(desc="2")
         with capture_signals() as signals:
-            model.objects.move(model.objects.get(desc="231"), target, "right")
+            model.objects.get(desc="231").move(target, "right")
         expected = [
             ("1", 1, 0),
             ("2", 1, 4),
@@ -1993,7 +1708,7 @@ class TestMoveLeafRoot(TestNonEmptyTree):
     def test_move_leaf_last_child_root(self, model):
         target = model.objects.get(desc="2")
         with capture_signals() as signals:
-            model.objects.move(model.objects.get(desc="231"), target, "last-child")
+            model.objects.get(desc="231").move(target, "last-child")
         expected = [
             ("1", 1, 0),
             ("2", 1, 5),
@@ -2033,7 +1748,7 @@ class TestMoveLeafRoot(TestNonEmptyTree):
     def test_move_leaf_first_child_root(self, model):
         target = model.objects.get(desc="2")
         with capture_signals() as signals:
-            model.objects.move(model.objects.get(desc="231"), target, "first-child")
+            model.objects.get(desc="231").move(target, "first-child")
         expected = [
             ("1", 1, 0),
             ("2", 1, 5),
@@ -2084,7 +1799,7 @@ class TestMoveLeaf(TestNonEmptyTree):
     def test_move_leaf_last_sibling(self, model):
         target = model.objects.get(desc="22")
         with capture_signals() as signals:
-            model.objects.move(model.objects.get(desc="231"), target, "last-sibling")
+            model.objects.get(desc="231").move(target, "last-sibling")
         expected = [
             ("1", 1, 0),
             ("2", 1, 5),
@@ -2124,7 +1839,7 @@ class TestMoveLeaf(TestNonEmptyTree):
     def test_move_leaf_first_sibling(self, model):
         target = model.objects.get(desc="22")
         with capture_signals() as signals:
-            model.objects.move(model.objects.get(desc="231"), target, "first-sibling")
+            model.objects.get(desc="231").move(target, "first-sibling")
         expected = [
             ("1", 1, 0),
             ("2", 1, 5),
@@ -2172,7 +1887,7 @@ class TestMoveLeaf(TestNonEmptyTree):
     def test_move_leaf_left_sibling(self, model):
         target = model.objects.get(desc="22")
         with capture_signals() as signals:
-            model.objects.move(model.objects.get(desc="231"), target, "left")
+            model.objects.get(desc="231").move(target, "left")
         expected = [
             ("1", 1, 0),
             ("2", 1, 5),
@@ -2218,7 +1933,7 @@ class TestMoveLeaf(TestNonEmptyTree):
     def test_move_leaf_right_sibling(self, model):
         target = model.objects.get(desc="22")
         with capture_signals() as signals:
-            model.objects.move(model.objects.get(desc="231"), target, "right")
+            model.objects.get(desc="231").move(target, "right")
         expected = [
             ("1", 1, 0),
             ("2", 1, 5),
@@ -2262,7 +1977,7 @@ class TestMoveLeaf(TestNonEmptyTree):
     def test_move_leaf_left_sibling_itself(self, model):
         target = model.objects.get(desc="231")
         with capture_signals() as signals:
-            model.objects.move(model.objects.get(desc="231"), target, "left")
+            model.objects.get(desc="231").move(target, "left")
         assert self.got(model) == UNCHANGED
         if issubclass(model, MP_Node):
             assert signals == []
@@ -2276,7 +1991,7 @@ class TestMoveLeaf(TestNonEmptyTree):
     def test_move_leaf_last_child(self, model):
         target = model.objects.get(desc="22")
         with capture_signals() as signals:
-            model.objects.move(model.objects.get(desc="231"), target, "last-child")
+            model.objects.get(desc="231").move(target, "last-child")
         expected = [
             ("1", 1, 0),
             ("2", 1, 4),
@@ -2316,7 +2031,7 @@ class TestMoveLeaf(TestNonEmptyTree):
     def test_move_leaf_first_child(self, model):
         target = model.objects.get(desc="22")
         with capture_signals() as signals:
-            model.objects.move(model.objects.get(desc="231"), target, "first-child")
+            model.objects.get(desc="231").move(target, "first-child")
         expected = [
             ("1", 1, 0),
             ("2", 1, 4),
@@ -2359,7 +2074,7 @@ class TestMoveBranchRoot(TestNonEmptyTree):
     def test_move_branch_first_sibling_root(self, model):
         target = model.objects.get(desc="2")
         with capture_signals() as signals:
-            model.objects.move(model.objects.get(desc="4"), target, "first-sibling")
+            model.objects.get(desc="4").move(target, "first-sibling")
         expected = [
             ("4", 1, 1),
             ("41", 2, 0),
@@ -2406,7 +2121,7 @@ class TestMoveBranchRoot(TestNonEmptyTree):
     def test_move_branch_last_sibling_root(self, model):
         target = model.objects.get(desc="2")
         with capture_signals() as signals:
-            model.objects.move(model.objects.get(desc="4"), target, "last-sibling")
+            model.objects.get(desc="4").move(target, "last-sibling")
         expected = [
             ("1", 1, 0),
             ("2", 1, 4),
@@ -2434,7 +2149,7 @@ class TestMoveBranchRoot(TestNonEmptyTree):
     def test_move_branch_left_sibling_root(self, model):
         target = model.objects.get(desc="2")
         with capture_signals() as signals:
-            model.objects.move(model.objects.get(desc="4"), target, "left")
+            model.objects.get(desc="4").move(target, "left")
         expected = [
             ("1", 1, 0),
             ("4", 1, 1),
@@ -2480,7 +2195,7 @@ class TestMoveBranchRoot(TestNonEmptyTree):
     def test_move_branch_right_sibling_root(self, model):
         target = model.objects.get(desc="2")
         with capture_signals() as signals:
-            model.objects.move(model.objects.get(desc="4"), target, "right")
+            model.objects.get(desc="4").move(target, "right")
         expected = [
             ("1", 1, 0),
             ("2", 1, 4),
@@ -2521,9 +2236,9 @@ class TestMoveBranchRoot(TestNonEmptyTree):
             ]
 
     def test_move_branch_left_noleft_sibling_root(self, model):
-        target = model.objects.get_first_sibling(model.objects.get(desc="2"))
+        target = model.objects.get(desc="2").get_first_sibling()
         with capture_signals() as signals:
-            model.objects.move(model.objects.get(desc="4"), target, "left")
+            model.objects.get(desc="4").move(target, "left")
         expected = [
             ("4", 1, 1),
             ("41", 2, 0),
@@ -2568,9 +2283,9 @@ class TestMoveBranchRoot(TestNonEmptyTree):
             ]
 
     def test_move_branch_right_noright_sibling_root(self, model):
-        target = model.objects.get_last_sibling(model.objects.get(desc="2"))
+        target = model.objects.get(desc="2").get_last_sibling()
         with capture_signals() as signals:
-            model.objects.move(model.objects.get(desc="4"), target, "right")
+            model.objects.get(desc="4").move(target, "right")
         expected = [
             ("1", 1, 0),
             ("2", 1, 4),
@@ -2596,7 +2311,7 @@ class TestMoveBranchRoot(TestNonEmptyTree):
     def test_move_branch_first_child_root(self, model):
         target = model.objects.get(desc="2")
         with capture_signals() as signals:
-            model.objects.move(model.objects.get(desc="4"), target, "first-child")
+            model.objects.get(desc="4").move(target, "first-child")
         expected = [
             ("1", 1, 0),
             ("2", 1, 5),
@@ -2643,7 +2358,7 @@ class TestMoveBranchRoot(TestNonEmptyTree):
     def test_move_branch_last_child_root(self, model):
         target = model.objects.get(desc="2")
         with capture_signals() as signals:
-            model.objects.move(model.objects.get(desc="4"), target, "last-child")
+            model.objects.get(desc="4").move(target, "last-child")
         expected = [
             ("1", 1, 0),
             ("2", 1, 5),
@@ -2685,7 +2400,7 @@ class TestMoveBranch(TestNonEmptyTree):
     def test_move_branch_first_sibling(self, model):
         target = model.objects.get(desc="23")
         with capture_signals() as signals:
-            model.objects.move(model.objects.get(desc="4"), target, "first-sibling")
+            model.objects.get(desc="4").move(target, "first-sibling")
         expected = [
             ("1", 1, 0),
             ("2", 1, 5),
@@ -2732,7 +2447,7 @@ class TestMoveBranch(TestNonEmptyTree):
     def test_move_branch_last_sibling(self, model):
         target = model.objects.get(desc="23")
         with capture_signals() as signals:
-            model.objects.move(model.objects.get(desc="4"), target, "last-sibling")
+            model.objects.get(desc="4").move(target, "last-sibling")
         expected = [
             ("1", 1, 0),
             ("2", 1, 5),
@@ -2771,7 +2486,7 @@ class TestMoveBranch(TestNonEmptyTree):
     def test_move_branch_left_sibling(self, model):
         target = model.objects.get(desc="23")
         with capture_signals() as signals:
-            model.objects.move(model.objects.get(desc="4"), target, "left")
+            model.objects.get(desc="4").move(target, "left")
         expected = [
             ("1", 1, 0),
             ("2", 1, 5),
@@ -2814,7 +2529,7 @@ class TestMoveBranch(TestNonEmptyTree):
     def test_move_branch_right_sibling(self, model):
         target = model.objects.get(desc="23")
         with capture_signals() as signals:
-            model.objects.move(model.objects.get(desc="4"), target, "right")
+            model.objects.get(desc="4").move(target, "right")
         expected = [
             ("1", 1, 0),
             ("2", 1, 5),
@@ -2853,9 +2568,9 @@ class TestMoveBranch(TestNonEmptyTree):
             ]
 
     def test_move_branch_left_noleft_sibling(self, model):
-        target = model.objects.get_first_sibling(model.objects.get(desc="23"))
+        target = model.objects.get(desc="23").get_first_sibling()
         with capture_signals() as signals:
-            model.objects.move(model.objects.get(desc="4"), target, "left")
+            model.objects.get(desc="4").move(target, "left")
         expected = [
             ("1", 1, 0),
             ("2", 1, 5),
@@ -2900,9 +2615,9 @@ class TestMoveBranch(TestNonEmptyTree):
             ]
 
     def test_move_branch_right_noright_sibling(self, model):
-        target = model.objects.get_last_sibling(model.objects.get(desc="23"))
+        target = model.objects.get(desc="23").get_last_sibling()
         with capture_signals() as signals:
-            model.objects.move(model.objects.get(desc="4"), target, "right")
+            model.objects.get(desc="4").move(target, "right")
         expected = [
             ("1", 1, 0),
             ("2", 1, 5),
@@ -2941,7 +2656,7 @@ class TestMoveBranch(TestNonEmptyTree):
     def test_move_branch_left_itself_sibling(self, model):
         target = model.objects.get(desc="4")
         with capture_signals() as signals:
-            model.objects.move(model.objects.get(desc="4"), target, "left")
+            model.objects.get(desc="4").move(target, "left")
         assert self.got(model) == UNCHANGED
         if issubclass(model, MP_Node):
             assert signals == []
@@ -2956,7 +2671,7 @@ class TestMoveBranch(TestNonEmptyTree):
         target = model.objects.get(desc="23")
         node = model.objects.get(desc="4")
         with capture_signals() as signals:
-            model.objects.move(node, target, "first-child")
+            node.move(target, "first-child")
         expected = [
             ("1", 1, 0),
             ("2", 1, 4),
@@ -2996,13 +2711,13 @@ class TestMoveBranch(TestNonEmptyTree):
 
         # Check that for MP, NS and LT nodes, the depth was updated on the in-memory instances
         assert node.get_depth() == 3
-        assert model.objects.get_children_count(target) == 2
+        assert target.get_children_count() == 2
         assert self.got(model) == expected
 
     def test_move_branch_last_child(self, model):
         target = model.objects.get(desc="23")
         with capture_signals() as signals:
-            model.objects.move(model.objects.get(desc="4"), target, "last-child")
+            model.objects.get(desc="4").move(target, "last-child")
         expected = [
             ("1", 1, 0),
             ("2", 1, 4),
@@ -3042,20 +2757,17 @@ class TestMoveBranch(TestNonEmptyTree):
 @pytest.mark.django_db
 class TestTreeSorted(TestTreeBase):
     def got(self, sorted_model):
-        return [
-            (o.val1, o.val2, o.desc, o.get_depth(), sorted_model.objects.get_children_count(o))
-            for o in sorted_model.objects.get_tree()
-        ]
+        return [(o.val1, o.val2, o.desc, o.get_depth(), o.get_children_count()) for o in sorted_model.get_tree()]
 
     def test_add_root_sorted(self, sorted_model):
-        sorted_model.objects.add_root({"val1": 3, "val2": 3, "desc": "zxy"})
-        sorted_model.objects.add_root({"val1": 1, "val2": 4, "desc": "bcd"})
-        sorted_model.objects.add_root({"val1": 2, "val2": 5, "desc": "zxy"})
-        sorted_model.objects.add_root({"val1": 3, "val2": 3, "desc": "abc"})
-        sorted_model.objects.add_root({"val1": 4, "val2": 1, "desc": "fgh"})
-        sorted_model.objects.add_root({"val1": 3, "val2": 3, "desc": "abc"})
-        sorted_model.objects.add_root({"val1": 2, "val2": 2, "desc": "qwe"})
-        sorted_model.objects.add_root({"val1": 3, "val2": 2, "desc": "vcx"})
+        sorted_model.add_root(val1=3, val2=3, desc="zxy")
+        sorted_model.add_root(val1=1, val2=4, desc="bcd")
+        sorted_model.add_root(val1=2, val2=5, desc="zxy")
+        sorted_model.add_root(val1=3, val2=3, desc="abc")
+        sorted_model.add_root(val1=4, val2=1, desc="fgh")
+        sorted_model.add_root(val1=3, val2=3, desc="abc")
+        sorted_model.add_root(val1=2, val2=2, desc="qwe")
+        sorted_model.add_root(val1=3, val2=2, desc="vcx")
         expected = [
             (1, 4, "bcd", 1, 0),
             (2, 2, "qwe", 1, 0),
@@ -3069,8 +2781,8 @@ class TestTreeSorted(TestTreeBase):
         assert self.got(sorted_model) == expected
 
     def test_add_root_sorted_with_instances(self, sorted_model):
-        sorted_model.objects.add_root(instance=sorted_model(val1=3, val2=3, desc="zxy"))
-        sorted_model.objects.add_root(instance=sorted_model(val1=1, val2=4, desc="bcd"))
+        sorted_model.add_root(instance=sorted_model(val1=3, val2=3, desc="zxy"))
+        sorted_model.add_root(instance=sorted_model(val1=1, val2=4, desc="bcd"))
         expected = [
             (1, 4, "bcd", 1, 0),
             (3, 3, "zxy", 1, 0),
@@ -3078,15 +2790,15 @@ class TestTreeSorted(TestTreeBase):
         assert self.got(sorted_model) == expected
 
     def test_add_child_root_sorted(self, sorted_model):
-        root = sorted_model.objects.add_root({"val1": 0, "val2": 0, "desc": "aaa"})
-        sorted_model.objects.add_child(root, {"val1": 3, "val2": 3, "desc": "zxy"})
-        sorted_model.objects.add_child(root, {"val1": 1, "val2": 4, "desc": "bcd"})
-        sorted_model.objects.add_child(root, {"val1": 2, "val2": 5, "desc": "zxy"})
-        sorted_model.objects.add_child(root, {"val1": 3, "val2": 3, "desc": "abc"})
-        sorted_model.objects.add_child(root, {"val1": 4, "val2": 1, "desc": "fgh"})
-        sorted_model.objects.add_child(root, {"val1": 3, "val2": 3, "desc": "abc"})
-        sorted_model.objects.add_child(root, {"val1": 2, "val2": 2, "desc": "qwe"})
-        sorted_model.objects.add_child(root, {"val1": 3, "val2": 2, "desc": "vcx"})
+        root = sorted_model.add_root(val1=0, val2=0, desc="aaa")
+        root.add_child(val1=3, val2=3, desc="zxy")
+        root.add_child(val1=1, val2=4, desc="bcd")
+        root.add_child(val1=2, val2=5, desc="zxy")
+        root.add_child(val1=3, val2=3, desc="abc")
+        root.add_child(val1=4, val2=1, desc="fgh")
+        root.add_child(val1=3, val2=3, desc="abc")
+        root.add_child(val1=2, val2=2, desc="qwe")
+        root.add_child(val1=3, val2=2, desc="vcx")
         expected = [
             (0, 0, "aaa", 1, 8),
             (1, 4, "bcd", 2, 0),
@@ -3104,13 +2816,13 @@ class TestTreeSorted(TestTreeBase):
         def get_node(node_id):
             return sorted_model.objects.get(pk=node_id)
 
-        root_id = sorted_model.objects.add_root({"val1": 0, "val2": 0, "desc": "a"}).pk
-        node_id = sorted_model.objects.add_child(get_node(root_id), {"val1": 0, "val2": 0, "desc": "ac"}).pk
-        sorted_model.objects.add_child(get_node(root_id), {"val1": 0, "val2": 0, "desc": "aa"})
-        sorted_model.objects.add_child(get_node(root_id), {"val1": 0, "val2": 0, "desc": "av"})
-        sorted_model.objects.add_child(get_node(node_id), {"val1": 0, "val2": 0, "desc": "aca"})
-        sorted_model.objects.add_child(get_node(node_id), {"val1": 0, "val2": 0, "desc": "acc"})
-        sorted_model.objects.add_child(get_node(node_id), {"val1": 0, "val2": 0, "desc": "acb"})
+        root_id = sorted_model.add_root(val1=0, val2=0, desc="a").pk
+        node_id = get_node(root_id).add_child(val1=0, val2=0, desc="ac").pk
+        get_node(root_id).add_child(val1=0, val2=0, desc="aa")
+        get_node(root_id).add_child(val1=0, val2=0, desc="av")
+        get_node(node_id).add_child(val1=0, val2=0, desc="aca")
+        get_node(node_id).add_child(val1=0, val2=0, desc="acc")
+        get_node(node_id).add_child(val1=0, val2=0, desc="acb")
 
         expected = [
             (0, 0, "a", 1, 3),
@@ -3124,21 +2836,21 @@ class TestTreeSorted(TestTreeBase):
         assert self.got(sorted_model) == expected
 
     def test_move_sorted(self, sorted_model):
-        sorted_model.objects.add_root({"val1": 3, "val2": 3, "desc": "zxy"})
-        sorted_model.objects.add_root({"val1": 1, "val2": 4, "desc": "bcd"})
-        sorted_model.objects.add_root({"val1": 2, "val2": 5, "desc": "zxy"})
-        sorted_model.objects.add_root({"val1": 3, "val2": 3, "desc": "abc"})
-        sorted_model.objects.add_root({"val1": 4, "val2": 1, "desc": "fgh"})
-        sorted_model.objects.add_root({"val1": 3, "val2": 3, "desc": "abc"})
-        sorted_model.objects.add_root({"val1": 2, "val2": 2, "desc": "qwe"})
-        sorted_model.objects.add_root({"val1": 3, "val2": 2, "desc": "vcx"})
-        root_nodes = sorted_model.objects.get_root_nodes()
+        sorted_model.add_root(val1=3, val2=3, desc="zxy")
+        sorted_model.add_root(val1=1, val2=4, desc="bcd")
+        sorted_model.add_root(val1=2, val2=5, desc="zxy")
+        sorted_model.add_root(val1=3, val2=3, desc="abc")
+        sorted_model.add_root(val1=4, val2=1, desc="fgh")
+        sorted_model.add_root(val1=3, val2=3, desc="abc")
+        sorted_model.add_root(val1=2, val2=2, desc="qwe")
+        sorted_model.add_root(val1=3, val2=2, desc="vcx")
+        root_nodes = sorted_model.get_root_nodes()
         target = root_nodes[0]
         for node in root_nodes[1:]:
             # because raw queries don't update django objects
             node = sorted_model.objects.get(pk=node.pk)
             target = sorted_model.objects.get(pk=target.pk)
-            sorted_model.objects.move(node, target, "sorted-child")
+            node.move(target, "sorted-child")
         expected = [
             (1, 4, "bcd", 1, 7),
             (2, 2, "qwe", 2, 0),
@@ -3153,15 +2865,15 @@ class TestTreeSorted(TestTreeBase):
 
     def test_move_sortedsibling(self, sorted_model):
         # https://bitbucket.org/tabo/django-treebeard/issue/27
-        sorted_model.objects.add_root({"val1": 3, "val2": 3, "desc": "zxy"})
-        sorted_model.objects.add_root({"val1": 1, "val2": 4, "desc": "bcd"})
-        sorted_model.objects.add_root({"val1": 2, "val2": 5, "desc": "zxy"})
-        sorted_model.objects.add_root({"val1": 3, "val2": 3, "desc": "abc"})
-        sorted_model.objects.add_root({"val1": 4, "val2": 1, "desc": "fgh"})
-        sorted_model.objects.add_root({"val1": 3, "val2": 3, "desc": "abc"})
-        sorted_model.objects.add_root({"val1": 2, "val2": 2, "desc": "qwe"})
-        sorted_model.objects.add_root({"val1": 3, "val2": 2, "desc": "vcx"})
-        root_nodes = sorted_model.objects.get_root_nodes()
+        sorted_model.add_root(val1=3, val2=3, desc="zxy")
+        sorted_model.add_root(val1=1, val2=4, desc="bcd")
+        sorted_model.add_root(val1=2, val2=5, desc="zxy")
+        sorted_model.add_root(val1=3, val2=3, desc="abc")
+        sorted_model.add_root(val1=4, val2=1, desc="fgh")
+        sorted_model.add_root(val1=3, val2=3, desc="abc")
+        sorted_model.add_root(val1=2, val2=2, desc="qwe")
+        sorted_model.add_root(val1=3, val2=2, desc="vcx")
+        root_nodes = sorted_model.get_root_nodes()
         target = root_nodes[0]
         for node in root_nodes[1:]:
             # because raw queries don't update django objects
@@ -3169,7 +2881,7 @@ class TestTreeSorted(TestTreeBase):
             target = sorted_model.objects.get(pk=target.pk)
             node.val1 -= 2
             node.save()
-            sorted_model.objects.move(node, target, "sorted-sibling")
+            node.move(target, "sorted-sibling")
         expected = [
             (0, 2, "qwe", 1, 0),
             (0, 5, "zxy", 1, 0),
@@ -3193,18 +2905,18 @@ class TestInheritedModels(TestTreeBase):
     )
     def inherited_model(request):
         base_model, inherited_model = request.param
-        base_model.objects.add_root({"desc": "1"})
-        base_model.objects.add_root({"desc": "2"})
+        base_model.add_root(desc="1")
+        base_model.add_root(desc="2")
 
         node21 = inherited_model(desc="21")
-        base_model.objects.add_child(base_model.objects.get(desc="2"), instance=node21)
+        base_model.objects.get(desc="2").add_child(instance=node21)
 
-        base_model.objects.add_child(base_model.objects.get(desc="21"), {"desc": "211"})
-        base_model.objects.add_child(base_model.objects.get(desc="21"), {"desc": "212"})
-        base_model.objects.add_child(base_model.objects.get(desc="2"), {"desc": "22"})
+        base_model.objects.get(desc="21").add_child(desc="211")
+        base_model.objects.get(desc="21").add_child(desc="212")
+        base_model.objects.get(desc="2").add_child(desc="22")
 
         node3 = inherited_model(desc="3")
-        base_model.objects.add_root(instance=node3)
+        base_model.add_root(instance=node3)
         return inherited_model
 
     @staticmethod
@@ -3217,10 +2929,7 @@ class TestInheritedModels(TestTreeBase):
         return request.param
 
     def test_get_tree_all(self, inherited_model):
-        got = [
-            (o.desc, o.get_depth(), inherited_model.objects.get_children_count(o))
-            for o in inherited_model.objects.get_tree()
-        ]
+        got = [(o.desc, o.get_depth(), o.get_children_count()) for o in inherited_model.get_tree()]
         expected = [
             ("1", 1, 0),
             ("2", 1, 2),
@@ -3235,10 +2944,7 @@ class TestInheritedModels(TestTreeBase):
     def test_get_tree_node(self, inherited_model):
         node = inherited_model.objects.get(desc="21")
 
-        got = [
-            (o.desc, o.get_depth(), inherited_model.objects.get_children_count(o))
-            for o in inherited_model.objects.get_tree(node)
-        ]
+        got = [(o.desc, o.get_depth(), o.get_children_count()) for o in inherited_model.get_tree(node)]
         expected = [
             ("21", 2, 2),
             ("211", 3, 0),
@@ -3247,16 +2953,16 @@ class TestInheritedModels(TestTreeBase):
         assert got == expected
 
     def test_get_root_nodes(self, inherited_model):
-        got = inherited_model.objects.get_root_nodes()
+        got = inherited_model.get_root_nodes()
         expected = ["1", "2", "3"]
         assert [node.desc for node in got] == expected
 
     def test_get_first_root_node(self, inherited_model):
-        got = inherited_model.objects.get_first_root_node()
+        got = inherited_model.get_first_root_node()
         assert got.desc == "1"
 
     def test_get_last_root_node(self, inherited_model):
-        got = inherited_model.objects.get_last_root_node()
+        got = inherited_model.get_last_root_node()
         assert got.desc == "3"
 
     def test_is_root(self, inherited_model):
@@ -3274,86 +2980,86 @@ class TestInheritedModels(TestTreeBase):
     def test_get_root(self, inherited_model):
         node21 = inherited_model.objects.get(desc="21")
         node3 = inherited_model.objects.get(desc="3")
-        assert inherited_model.objects.get_root(node21).desc == "2"
-        assert inherited_model.objects.get_root(node3).desc == "3"
+        assert node21.get_root().desc == "2"
+        assert node3.get_root().desc == "3"
 
     def test_get_parent(self, inherited_model):
         node21 = inherited_model.objects.get(desc="21")
         node3 = inherited_model.objects.get(desc="3")
-        assert inherited_model.objects.get_parent(node21).desc == "2"
-        assert inherited_model.objects.get_parent(node3) is None
+        assert node21.get_parent().desc == "2"
+        assert node3.get_parent() is None
 
     def test_get_children(self, inherited_model):
         node21 = inherited_model.objects.get(desc="21")
         node3 = inherited_model.objects.get(desc="3")
-        assert [node.desc for node in inherited_model.objects.get_children(node21)] == ["211", "212"]
-        assert [node.desc for node in inherited_model.objects.get_children(node3)] == []
+        assert [node.desc for node in node21.get_children()] == ["211", "212"]
+        assert [node.desc for node in node3.get_children()] == []
 
     def test_get_children_count(self, inherited_model):
         node21 = inherited_model.objects.get(desc="21")
         node3 = inherited_model.objects.get(desc="3")
-        assert inherited_model.objects.get_children_count(node21) == 2
-        assert inherited_model.objects.get_children_count(node3) == 0
+        assert node21.get_children_count() == 2
+        assert node3.get_children_count() == 0
 
     def test_get_siblings(self, inherited_model):
         node21 = inherited_model.objects.get(desc="21")
         node3 = inherited_model.objects.get(desc="3")
-        assert [node.desc for node in inherited_model.objects.get_siblings(node21)] == ["21", "22"]
-        assert [node.desc for node in inherited_model.objects.get_siblings(node3)] == ["1", "2", "3"]
+        assert [node.desc for node in node21.get_siblings()] == ["21", "22"]
+        assert [node.desc for node in node3.get_siblings()] == ["1", "2", "3"]
 
     def test_get_first_sibling(self, inherited_model):
         node21 = inherited_model.objects.get(desc="21")
         node3 = inherited_model.objects.get(desc="3")
-        assert inherited_model.objects.get_first_sibling(node21).desc == "21"
-        assert inherited_model.objects.get_first_sibling(node3).desc == "1"
+        assert node21.get_first_sibling().desc == "21"
+        assert node3.get_first_sibling().desc == "1"
 
     def test_get_prev_sibling(self, inherited_model):
         node21 = inherited_model.objects.get(desc="21")
         node3 = inherited_model.objects.get(desc="3")
-        assert inherited_model.objects.get_prev_sibling(node21) is None
-        assert inherited_model.objects.get_prev_sibling(node3).desc == "2"
+        assert node21.get_prev_sibling() is None
+        assert node3.get_prev_sibling().desc == "2"
 
     def test_get_next_sibling(self, inherited_model):
         node21 = inherited_model.objects.get(desc="21")
         node3 = inherited_model.objects.get(desc="3")
-        assert inherited_model.objects.get_next_sibling(node21).desc == "22"
-        assert inherited_model.objects.get_next_sibling(node3) is None
+        assert node21.get_next_sibling().desc == "22"
+        assert node3.get_next_sibling() is None
 
     def test_get_last_sibling(self, inherited_model):
         node21 = inherited_model.objects.get(desc="21")
         node3 = inherited_model.objects.get(desc="3")
-        assert inherited_model.objects.get_last_sibling(node21).desc == "22"
-        assert inherited_model.objects.get_last_sibling(node3).desc == "3"
+        assert node21.get_last_sibling().desc == "22"
+        assert node3.get_last_sibling().desc == "3"
 
     def test_get_first_child(self, inherited_model):
         node21 = inherited_model.objects.get(desc="21")
         node3 = inherited_model.objects.get(desc="3")
-        assert inherited_model.objects.get_first_child(node21).desc == "211"
-        assert inherited_model.objects.get_first_child(node3) is None
+        assert node21.get_first_child().desc == "211"
+        assert node3.get_first_child() is None
 
     def test_get_last_child(self, inherited_model):
         node21 = inherited_model.objects.get(desc="21")
         node3 = inherited_model.objects.get(desc="3")
-        assert inherited_model.objects.get_last_child(node21).desc == "212"
-        assert inherited_model.objects.get_last_child(node3) is None
+        assert node21.get_last_child().desc == "212"
+        assert node3.get_last_child() is None
 
     def test_get_ancestors(self, inherited_model):
         node21 = inherited_model.objects.get(desc="21")
         node3 = inherited_model.objects.get(desc="3")
-        assert [node.desc for node in inherited_model.objects.get_ancestors(node21)] == ["2"]
-        assert [node.desc for node in inherited_model.objects.get_ancestors(node3)] == []
+        assert [node.desc for node in node21.get_ancestors()] == ["2"]
+        assert [node.desc for node in node3.get_ancestors()] == []
 
     def test_get_descendants(self, inherited_model):
         node21 = inherited_model.objects.get(desc="21")
         node3 = inherited_model.objects.get(desc="3")
-        assert [node.desc for node in inherited_model.objects.get_descendants(node21)] == ["211", "212"]
-        assert [node.desc for node in inherited_model.objects.get_descendants(node3)] == []
+        assert [node.desc for node in node21.get_descendants()] == ["211", "212"]
+        assert [node.desc for node in node3.get_descendants()] == []
 
     def test_get_descendant_count(self, inherited_model):
         node21 = inherited_model.objects.get(desc="21")
         node3 = inherited_model.objects.get(desc="3")
-        assert inherited_model.objects.get_descendant_count(node21) == 2
-        assert inherited_model.objects.get_descendant_count(node3) == 0
+        assert node21.get_descendant_count() == 2
+        assert node3.get_descendant_count() == 0
 
     def test_cascading_deletion(self, inherited_model):
         # Deleting a node by calling delete() on the inherited_model class
@@ -3366,26 +3072,26 @@ class TestInheritedModels(TestTreeBase):
         node2 = base_model.objects.get(desc="2")
         for desc in ["21", "211", "212"]:
             assert not base_model.objects.filter(desc=desc).exists()
-        assert [node.desc for node in inherited_model.objects.get_descendants(node2)] == ["22"]
+        assert [node.desc for node in node2.get_descendants()] == ["22"]
 
     def test_move_with_children(self, inherited_model):
         base_model = inherited_model.__bases__[0]
 
         node1 = base_model.objects.get(desc="1")
         node21 = inherited_model.objects.get(desc="21")
-        inherited_model.objects.move(node21, node1, "first-child")
+        node21.move(node1, "first-child")
 
-        assert [node.desc for node in inherited_model.objects.get_children(node1)] == ["21"]
-        assert [node.desc for node in inherited_model.objects.get_children(node21)] == ["211", "212"]
+        assert [node.desc for node in node1.get_children()] == ["21"]
+        assert [node.desc for node in node21.get_children()] == ["211", "212"]
         self._assert_no_tree_problems(base_model)
 
     def test_get_descendants_group_count(self, inherited_model):
         base_model = inherited_model.__bases__[0]
-        for node in base_model.objects.get_descendants_group_count():
-            assert node.descendants_count == inherited_model.objects.get_descendant_count(node)
+        for node in base_model.get_descendants_group_count():
+            assert node.descendants_count == node.get_descendant_count()
 
-        for node in inherited_model.objects.get_descendants_group_count():
-            assert node.descendants_count == inherited_model.objects.get_descendant_count(node)
+        for node in inherited_model.get_descendants_group_count():
+            assert node.descendants_count == node.get_descendant_count()
 
     def test_add_root_with_node_order_by(self, inherited_model_with_sort):
         """
@@ -3395,8 +3101,8 @@ class TestInheritedModels(TestTreeBase):
         to the parent class.
         """
         _, inherited_model = inherited_model_with_sort
-        inherited_model.objects.add_root({"val1": 2, "val2": 3, "desc": "A"})
-        inherited_model.objects.add_root({"val1": 2, "val2": 3, "desc": "B"})
+        inherited_model.add_root(val1=2, val2=3, desc="A")
+        inherited_model.add_root(val1=2, val2=3, desc="B")
         assert list(inherited_model.objects.values_list("desc", flat=True)) == ["B", "A"]
         self._assert_no_tree_problems(inherited_model)
 
@@ -3410,83 +3116,30 @@ class TestInheritedModels(TestTreeBase):
         # We need a leaf node of inherited_model to test against, as non-leaves will delegate to add_sibling instead
         node21 = inherited_model.objects.get(desc="21")
         node213 = inherited_model(desc="213")
-        inherited_model.objects.add_child(node21, instance=node213)
-        inherited_model.objects.add_child(node213, {"desc": "2131"})
+        node21.add_child(instance=node213)
 
-        assert [node.desc for node in inherited_model.objects.get_children(node213)] == ["2131"]
+        node213.add_child(desc="2131")
+
+        assert [node.desc for node in node213.get_children()] == ["2131"]
         self._assert_no_tree_problems(base_model)
 
     def test_add_sibling_to_root(self, inherited_model):
         base_model = inherited_model.__bases__[0]
 
         node3 = inherited_model.objects.get(desc="3")
-        inherited_model.objects.add_sibling(node3, "first-sibling", {"desc": "0"})
+        node3.add_sibling("first-sibling", desc="0")
 
-        assert [node.desc for node in base_model.objects.get_root_nodes()] == ["0", "1", "2", "3"]
+        assert [node.desc for node in base_model.get_root_nodes()] == ["0", "1", "2", "3"]
         self._assert_no_tree_problems(base_model)
 
     def test_add_sibling_to_nonroot(self, inherited_model):
         base_model = inherited_model.__bases__[0]
 
         node21 = inherited_model.objects.get(desc="21")
-        inherited_model.objects.add_sibling(node21, "first-sibling", {"desc": "20"})
+        node21.add_sibling("first-sibling", desc="20")
 
-        assert [node.desc for node in base_model.objects.get_children(base_model.objects.get(desc="2"))] == [
-            "20",
-            "21",
-            "22",
-        ]
+        assert [node.desc for node in base_model.objects.get(desc="2").get_children()] == ["20", "21", "22"]
         self._assert_no_tree_problems(base_model)
-
-
-@pytest.mark.django_db
-class TestMP_TreeAlphabet(TestTreeBase):
-    @pytest.mark.skipif(
-        not os.getenv("TREEBEARD_TEST_ALPHABET", False),
-        reason="TREEBEARD_TEST_ALPHABET env variable not set.",
-    )
-    def test_alphabet(self, mpalphabet_model):
-        """This isn't actually a test, it's an informational routine."""
-        basealpha = numconv.BASE85
-        got_err = False
-        last_good = None
-
-        for alphabetlen in range(3, len(basealpha) + 1):
-            alphabet = basealpha[0:alphabetlen]
-            assert len(alphabet) >= 3
-            expected = [alphabet[0] + char for char in alphabet[1:]]
-            expected.extend([alphabet[1] + char for char in alphabet])
-            expected.append(alphabet[2] + alphabet[0])
-
-            # remove all nodes
-            mpalphabet_model.objects.all().delete()
-
-            # change the model's alphabet
-            mpalphabet_model.alphabet = alphabet
-            mpalphabet_model.numconv_obj_ = None
-
-            # insert root nodes
-            for pos in range(len(alphabet) * 2):
-                try:
-                    added = mpalphabet_model.objects.add_root(numval=pos)
-                except Exception:
-                    got_err = True
-                    break
-
-                # Check for case-insensitive LIKE that would break querying even if the object was inserted correctly
-                if mpalphabet_model.objects.filter(path__startswith=added.path).count() != 1:
-                    got_err = True
-                    break
-            if got_err:
-                break
-
-            got = list(mpalphabet_model.objects.values_list("path", flat=True))
-            if got != expected:
-                break
-
-            last_good = alphabet
-
-        assert False, f"Best BASE85 based alphabet for your setup: {last_good} (base {len(last_good)})"
 
 
 @pytest.mark.django_db
@@ -3495,25 +3148,21 @@ class TestHelpers(TestTreeBase):
     @pytest.fixture(scope="function", params=models.BASE_MODELS + models.PROXY_MODELS)
     def helpers_model(request):
         model = request.param
-        model.objects.load_bulk(BASE_DATA)
-        for node in model.objects.get_root_nodes():
-            model.objects.load_bulk(BASE_DATA, node)
-        model.objects.add_root({"desc": "5"})
+        model.load_bulk(BASE_DATA)
+        for node in model.get_root_nodes():
+            model.load_bulk(BASE_DATA, node)
+        model.add_root(desc="5")
         return model
 
     def test_descendants_group_count_root(self, helpers_model):
-        expected = [
-            (o.desc, helpers_model.objects.get_descendant_count(o)) for o in helpers_model.objects.get_root_nodes()
-        ]
-        got = [(o.desc, o.descendants_count) for o in helpers_model.objects.get_descendants_group_count()]
+        expected = [(o.desc, o.get_descendant_count()) for o in helpers_model.get_root_nodes()]
+        got = [(o.desc, o.descendants_count) for o in helpers_model.get_descendants_group_count()]
         assert got == expected
 
     def test_descendants_group_count_node(self, helpers_model):
-        parent = helpers_model.objects.get_root_nodes().get(desc="2")
-        expected = [
-            (o.desc, helpers_model.objects.get_descendant_count(o)) for o in helpers_model.objects.get_children(parent)
-        ]
-        got = [(o.desc, o.descendants_count) for o in helpers_model.objects.get_descendants_group_count(parent)]
+        parent = helpers_model.get_root_nodes().get(desc="2")
+        expected = [(o.desc, o.get_descendant_count()) for o in parent.get_children()]
+        got = [(o.desc, o.descendants_count) for o in helpers_model.get_descendants_group_count(parent)]
         assert got == expected
 
 
@@ -3526,34 +3175,33 @@ class TestMP_Tree(TestTreeBase):
     def test_sorted_sibling_move_noop_path_not_changed(self, mpsorted_model):
         # Regression test for https://github.com/django-treebeard/django-treebeard/issues/389
         # A noop on a sorted-sibling should not increment the path of siblings
-        node = mpsorted_model.objects.add_root({"desc": "A"})
+        node = mpsorted_model.add_root(desc="A")
         old_path = node.path
-        mpsorted_model.objects.move(node, node, "sorted-sibling")
+        node.move(node, "sorted-sibling")
         assert node.path == old_path
 
-        node2 = mpsorted_model.objects.add_root({"desc": "B"})
-        mpsorted_model.objects.move(node, node2, "sorted-sibling")
+        node2 = mpsorted_model.add_root(desc="B")
+        node.move(node2, "sorted-sibling")
         assert node.path == old_path
 
     def test_sorted_sibling_path(self, mpsorted_model):
         # Regression test for https://github.com/django-treebeard/django-treebeard/issues/389
-        node1 = mpsorted_model.objects.add_root({"desc": "B"})
-        node2 = mpsorted_model.objects.add_root({"desc": "C"})
+        node1 = mpsorted_model.add_root(desc="B")
+        node2 = mpsorted_model.add_root(desc="C")
 
         # Update node2 sorted field and then move it
         node2.desc = "A"
         node2.save()
-        mpsorted_model.objects.move(node2, node1, "sorted-sibling")
+        node2.move(node1, "sorted-sibling")
         assert node2.path == "1"
         assert node1.path == "2"
 
     def test_short_path(self, mpshortnotsorted_model):
         """Test a tree with a very small path field (max_length=4) and a steplen of 1"""
-        obj = mpshortnotsorted_model.objects.add_root({})
-        for i in range(0, 3):
-            obj = mpshortnotsorted_model.objects.add_child(obj, {})
+        obj = mpshortnotsorted_model.add_root()
+        obj = obj.add_child().add_child().add_child()
         with pytest.raises(PathOverflow):
-            mpshortnotsorted_model.objects.add_child(obj, {})
+            obj.add_child()
 
 
 @pytest.mark.skipif(os.getenv("DATABASE_ENGINE") in ["mysql", "mssql"], reason="Unsupported database backend")
@@ -3563,7 +3211,7 @@ class TestMP_TreeLoadBulk(TestTreeBase):
         # inserting on an existing node
         node = mp_model.objects.get(desc="231")
         with django_assert_max_num_queries(26):
-            ids = mp_model.objects.load_bulk(BASE_DATA, node, bulk_create=True)
+            ids = mp_model.load_bulk(BASE_DATA, node, bulk_create=True)
         expected = [
             ("1", 1, 0),
             ("2", 1, 4),
@@ -3592,13 +3240,13 @@ class TestMP_TreeLoadBulk(TestTreeBase):
         assert self.got(mp_model) == expected
 
     def test_load_bulk_keeping_ids_with_bulk_create(self, mp_model):
-        exp = mp_model.objects.dump_bulk(keep_ids=True)
+        exp = mp_model.dump_bulk(keep_ids=True)
         mp_model.objects.all().delete()
-        mp_model.objects.load_bulk(exp, parent=None, keep_ids=True, bulk_create=True)
-        got = mp_model.objects.dump_bulk(keep_ids=True)
+        mp_model.load_bulk(exp, parent=None, keep_ids=True, bulk_create=True)
+        got = mp_model.dump_bulk(keep_ids=True)
         assert got == exp
         # do we really have an unchanged tree after the dump/delete/load?
-        got = [(o.desc, o.get_depth(), mp_model.objects.get_children_count(o)) for o in mp_model.objects.get_tree()]
+        got = [(o.desc, o.get_depth(), o.get_children_count()) for o in mp_model.get_tree()]
         assert got == UNCHANGED
 
     def test_load_bulk_keeping_ids_with_bulk_create_and_many_to_many(self, mp_relatedmodel):
@@ -3628,8 +3276,8 @@ class TestMP_TreeLoadBulk(TestTreeBase):
                 ],
             },
         ]
-        mp_relatedmodel.objects.load_bulk(related_data, bulk_create=True)
-        got = mp_relatedmodel.objects.dump_bulk(keep_ids=False)
+        mp_relatedmodel.load_bulk(related_data, bulk_create=True)
+        got = mp_relatedmodel.dump_bulk(keep_ids=False)
         assert got == related_data
 
 
@@ -3644,1117 +3292,35 @@ class TestMP_TreeSortedAutoNow(TestTreeBase):
     """
 
     def test_sorted_by_autonow_ignores_and_warns(self, mpsortedautonow_model):
-        mpsortedautonow_model.objects.add_root({"desc": "node1"})
+        mpsortedautonow_model.add_root(desc="node1")
         with pytest.warns(RuntimeWarning, match="Received a null value for field 'created'"):
-            mpsortedautonow_model.objects.add_root({"desc": "node2"})
+            mpsortedautonow_model.add_root(desc="node2")
 
         # Object was still created, but `created` order isn't respected
         assert list(mpsortedautonow_model.objects.values_list("desc", flat=True)) == ["node2", "node1"]
 
     def test_sorted_by_autonow_value_added_manually(self, mpsortedautonow_model):
-        mpsortedautonow_model.objects.add_root({"desc": "node1", "created": now()})
-        mpsortedautonow_model.objects.add_root({"desc": "node2", "created": now()})
+        mpsortedautonow_model.add_root(desc="node1", created=now())
+        mpsortedautonow_model.add_root(desc="node2", created=now())
         assert list(mpsortedautonow_model.objects.values_list("desc", flat=True)) == ["node1", "node2"]
-
-
-@pytest.mark.django_db
-class TestMP_TreeStepOverflow(TestTreeBase):
-    def test_add_root(self, mpsmallstep_model):
-        method = mpsmallstep_model.objects.add_root
-        for i in range(1, 10):
-            method({})
-        with pytest.raises(PathOverflow):
-            method({})
-
-    def test_add_child(self, mpsmallstep_model):
-        root = mpsmallstep_model.objects.add_root({})
-        method = mpsmallstep_model.objects.add_child
-        for i in range(1, 10):
-            method(root, {})
-        with pytest.raises(PathOverflow):
-            method(root, {})
-
-    def test_add_sibling(self, mpsmallstep_model):
-        root = mpsmallstep_model.objects.add_root({})
-        for i in range(1, 10):
-            mpsmallstep_model.objects.add_child(root, {})
-        positions = ("first-sibling", "left", "right", "last-sibling")
-        for pos in positions:
-            with pytest.raises(PathOverflow):
-                mpsmallstep_model.objects.add_sibling(mpsmallstep_model.objects.get_last_child(root), pos, {})
-
-    def test_move(self, mpsmallstep_model):
-        root = mpsmallstep_model.objects.add_root({})
-        for i in range(1, 10):
-            mpsmallstep_model.objects.add_child(root, {})
-        newroot = mpsmallstep_model.objects.add_root({})
-        targets = [
-            (root, ["first-child", "last-child"]),
-            (
-                mpsmallstep_model.objects.get_first_child(root),
-                ["first-sibling", "left", "right", "last-sibling"],
-            ),
-        ]
-        for target, positions in targets:
-            for pos in positions:
-                with pytest.raises(PathOverflow):
-                    mpsmallstep_model.objects.move(newroot, target, pos)
-
-
-@pytest.mark.django_db
-class TestMP_TreeFindProblems(TestTreeBase):
-    def test_find_problems(self, mpalphabet_model):
-        mpalphabet_model.alphabet = "01234"
-        mpalphabet_model(path="01", depth=1, numchild=0, numval=0).save()
-        mpalphabet_model(path="1", depth=1, numchild=0, numval=0).save()
-        mpalphabet_model(path="111", depth=1, numchild=0, numval=0).save()
-        mpalphabet_model(path="abcd", depth=1, numchild=0, numval=0).save()
-        mpalphabet_model(path="qa#$%!", depth=1, numchild=0, numval=0).save()
-        mpalphabet_model(path="0201", depth=2, numchild=0, numval=0).save()
-        mpalphabet_model(path="020201", depth=3, numchild=0, numval=0).save()
-        mpalphabet_model(path="03", depth=1, numchild=2, numval=0).save()
-        mpalphabet_model(path="0301", depth=2, numchild=0, numval=0).save()
-        mpalphabet_model(path="030102", depth=3, numchild=10, numval=0).save()
-        mpalphabet_model(path="04", depth=10, numchild=1, numval=0).save()
-        mpalphabet_model(path="0401", depth=20, numchild=0, numval=0).save()
-
-        def got(ids):
-            return [o.path for o in mpalphabet_model.objects.filter(pk__in=ids)]
-
-        (
-            evil_chars,
-            bad_steplen,
-            orphans,
-            wrong_depth,
-            wrong_numchild,
-        ) = mpalphabet_model.objects.find_problems()
-        assert ["abcd", "qa#$%!"] == got(evil_chars)
-        assert ["1", "111"] == got(bad_steplen)
-        assert ["0201", "020201"] == got(orphans)
-        assert ["03", "0301", "030102"] == got(wrong_numchild)
-        assert ["04", "0401"] == got(wrong_depth)
-
-    def test_find_problems_with_root_clean(self, mpalphabet_model):
-        mpalphabet_model.alphabet = "01234"
-        mpalphabet_model(path="01", depth=1, numchild=1, numval=0).save()
-        mpalphabet_model(path="0101", depth=2, numchild=0, numval=0).save()
-        root = mpalphabet_model.objects.get(path="01")
-        result = mpalphabet_model.objects.find_problems(parent=root)
-        assert all(not group for group in result)
-
-    def test_find_problems_with_root_scoped_to_single_tree(self, mpalphabet_model):
-        """Problems in one tree should not appear when checking another tree."""
-        mpalphabet_model.alphabet = "01234"
-        # Tree 1: clean
-        mpalphabet_model(path="01", depth=1, numchild=1, numval=0).save()
-        mpalphabet_model(path="0101", depth=2, numchild=0, numval=0).save()
-        # Tree 2: root is valid but children have problems (wrong depth, wrong numchild)
-        mpalphabet_model(path="02", depth=1, numchild=5, numval=0).save()
-        mpalphabet_model(path="0201", depth=20, numchild=0, numval=0).save()
-
-        root1 = mpalphabet_model.objects.get(path="01")
-        root2 = mpalphabet_model.objects.get(path="02")
-
-        # Tree 1 should be clean
-        result1 = mpalphabet_model.objects.find_problems(parent=root1)
-        assert all(not group for group in result1)
-
-        # Tree 2 should have problems
-        result2 = mpalphabet_model.objects.find_problems(parent=root2)
-        evil_chars, bad_steplen, orphans, wrong_depth, wrong_numchild = result2
-        assert not evil_chars
-        assert not bad_steplen
-        assert not orphans
-        # child "0201" has wrong depth (20 instead of 2)
-        assert len(wrong_depth) == 1
-        # root "02" reports numchild=5 but only has 1 child
-        assert len(wrong_numchild) == 1
-
-    def test_find_problems_with_root_detects_all_problem_types(self, mpalphabet_model):
-        """Verify all five problem categories are detected within a single tree."""
-        mpalphabet_model.alphabet = "01234"
-        # Another clean tree to ensure isolation
-        mpalphabet_model(path="01", depth=1, numchild=0, numval=0).save()
-
-        # Tree with various problems rooted at "03"
-        mpalphabet_model(path="03", depth=1, numchild=2, numval=0).save()
-        mpalphabet_model(path="0301", depth=2, numchild=0, numval=0).save()
-        mpalphabet_model(path="030102", depth=3, numchild=10, numval=0).save()
-
-        def got(ids):
-            return [o.path for o in mpalphabet_model.objects.filter(pk__in=ids)]
-
-        root = mpalphabet_model.objects.get(path="03")
-        evil_chars, bad_steplen, orphans, wrong_depth, wrong_numchild = mpalphabet_model.objects.find_problems(
-            parent=root
-        )
-        # "03" reports numchild=2 but only has 1 direct child -> wrong_numchild
-        assert "03" in got(wrong_numchild)
-        # "030102" reports numchild=10 which is wrong
-        assert "030102" in got(wrong_numchild)
-
-
-@pytest.mark.django_db
-class TestNS_TreeFindProblems(TestTreeBase):
-    def test_find_problems_all_ok(self, ns_model):
-        ns_model(tree_id=1, lft=1, rgt=8, depth=1).save()
-        ns_model(tree_id=1, lft=2, rgt=5, depth=2).save()
-        ns_model(tree_id=1, lft=3, rgt=4, depth=3).save()
-        ns_model(tree_id=1, lft=6, rgt=7, depth=2).save()
-        ns_model(tree_id=2, lft=1, rgt=2, depth=1).save()
-
-        result = ns_model.objects.find_problems()
-        assert result == ([], [], [], [])
-
-    def test_find_problems_reversed_lft_rgt(self, ns_model):
-        bad_node = ns_model(tree_id=1, lft=2, rgt=1, depth=1)
-        bad_node.save()
-
-        result = ns_model.objects.find_problems()
-        assert result == ([bad_node.pk], [], [], [])
-
-    def test_find_problems_overlapping_nodes(self, ns_model):
-        ns_model(tree_id=1, lft=1, rgt=6, depth=1).save()
-        ns_model(tree_id=1, lft=2, rgt=4, depth=2).save()
-        bad_node = ns_model(tree_id=1, lft=3, rgt=5, depth=3)
-        bad_node.save()
-
-        result = ns_model.objects.find_problems()
-        assert result == ([], [bad_node.pk], [], [])
-
-    def test_find_problems_duplicate_root(self, ns_model):
-        ns_model(tree_id=1, lft=1, rgt=8, depth=1).save()
-        ns_model(tree_id=1, lft=2, rgt=5, depth=2).save()
-        ns_model(tree_id=1, lft=3, rgt=4, depth=3).save()
-        ns_model(tree_id=1, lft=6, rgt=7, depth=2).save()
-        bad_node = ns_model(tree_id=1, lft=9, rgt=12, depth=1)
-        bad_node.save()
-        ns_model(tree_id=1, lft=10, rgt=11, depth=2).save()
-
-        result = ns_model.objects.find_problems()
-        assert result == ([], [], [bad_node.pk], [])
-
-    def test_find_problems_wrong_depth(self, ns_model):
-        ns_model(tree_id=1, lft=1, rgt=8, depth=1).save()
-        bad_node_1 = ns_model(tree_id=1, lft=2, rgt=5, depth=1)
-        bad_node_1.save()
-        ns_model(tree_id=1, lft=3, rgt=4, depth=3).save()
-        ns_model(tree_id=1, lft=6, rgt=7, depth=2).save()
-        bad_node_2 = ns_model(tree_id=2, lft=1, rgt=2, depth=2)
-        bad_node_2.save()
-
-        result = ns_model.objects.find_problems()
-        assert result == ([], [], [], [bad_node_1.pk, bad_node_2.pk])
-
-    def test_find_problems_within_parent(self, ns_model):
-        ns_model(tree_id=1, lft=1, rgt=8, depth=99).save()  # ignored
-        parent_node = ns_model(tree_id=1, lft=2, rgt=5, depth=2)
-        parent_node.save()
-        bad_node = ns_model(tree_id=1, lft=3, rgt=4, depth=99)
-        bad_node.save()
-        ns_model(tree_id=1, lft=6, rgt=7, depth=2).save()
-        ns_model(tree_id=2, lft=1, rgt=2, depth=99).save()  # ignored
-
-        result = ns_model.objects.find_problems(parent=parent_node)
-        assert result == ([], [], [], [bad_node.pk])
-
-
-@pytest.mark.django_db
-class TestMP_TreeFix(TestTreeBase):
-    expected_no_holes = {
-        models.MP_TestNodeShortPath: [
-            ("1", "b", 1, 2),
-            ("11", "u", 2, 1),
-            ("111", "i", 3, 1),
-            ("1111", "e", 4, 0),
-            ("12", "o", 2, 0),
-            ("2", "d", 1, 0),
-            ("3", "g", 1, 0),
-            ("4", "a", 1, 4),
-            ("41", "a", 2, 0),
-            ("42", "a", 2, 0),
-            ("43", "u", 2, 1),
-            ("431", "i", 3, 1),
-            ("4311", "e", 4, 0),
-            ("44", "o", 2, 0),
-        ],
-        models.MP_TestSortedNodeShortPath: [
-            ("1", "a", 1, 4),
-            ("11", "a", 2, 0),
-            ("12", "a", 2, 0),
-            ("13", "o", 2, 0),
-            ("14", "u", 2, 1),
-            ("141", "i", 3, 1),
-            ("1411", "e", 4, 0),
-            ("2", "b", 1, 2),
-            ("21", "o", 2, 0),
-            ("22", "u", 2, 1),
-            ("221", "i", 3, 1),
-            ("2211", "e", 4, 0),
-            ("3", "d", 1, 0),
-            ("4", "g", 1, 0),
-        ],
-    }
-    expected_with_holes = {
-        models.MP_TestNodeShortPath: [
-            ("1", "b", 1, 2),
-            ("13", "u", 2, 1),
-            ("134", "i", 3, 1),
-            ("1343", "e", 4, 0),
-            ("14", "o", 2, 0),
-            ("2", "d", 1, 0),
-            ("3", "g", 1, 0),
-            ("4", "a", 1, 4),
-            ("41", "a", 2, 0),
-            ("42", "a", 2, 0),
-            ("43", "u", 2, 1),
-            ("434", "i", 3, 1),
-            ("4343", "e", 4, 0),
-            ("44", "o", 2, 0),
-        ],
-        models.MP_TestSortedNodeShortPath: [
-            ("1", "b", 1, 2),
-            ("13", "u", 2, 1),
-            ("134", "i", 3, 1),
-            ("1343", "e", 4, 0),
-            ("14", "o", 2, 0),
-            ("2", "d", 1, 0),
-            ("3", "g", 1, 0),
-            ("4", "a", 1, 4),
-            ("41", "a", 2, 0),
-            ("42", "a", 2, 0),
-            ("43", "u", 2, 1),
-            ("434", "i", 3, 1),
-            ("4343", "e", 4, 0),
-            ("44", "o", 2, 0),
-        ],
-    }
-
-    def got(self, model):
-        return [(o.path, o.desc, o.get_depth(), model.objects.get_children_count(o)) for o in model.objects.get_tree()]
-
-    def add_broken_test_data(self, model):
-        model(path="4", depth=2, numchild=2, desc="a").save()
-        model(path="13", depth=1000, numchild=0, desc="u").save()
-        model(path="14", depth=4, numchild=500, desc="o").save()
-        model(path="134", depth=321, numchild=543, desc="i").save()
-        model(path="1343", depth=321, numchild=543, desc="e").save()
-        model(path="42", depth=1, numchild=1, desc="a").save()
-        model(path="43", depth=1000, numchild=0, desc="u").save()
-        model(path="44", depth=4, numchild=500, desc="o").save()
-        model(path="434", depth=321, numchild=543, desc="i").save()
-        model(path="4343", depth=321, numchild=543, desc="e").save()
-        model(path="41", depth=1, numchild=1, desc="a").save()
-        model(path="3", depth=221, numchild=322, desc="g").save()
-        model(path="1", depth=10, numchild=3, desc="b").save()
-        model(path="2", depth=10, numchild=3, desc="d").save()
-
-    def test_fix_tree_no_fix_paths(self, mpshort_model):
-        self.add_broken_test_data(mpshort_model)
-        mpshort_model.objects.fix_tree(fix_paths=False)
-        got = self.got(mpshort_model)
-        expected = self.expected_with_holes[mpshort_model]
-        assert got == expected
-        assert all(not group for group in mpshort_model.objects.find_problems())
-
-    def test_fix_tree_fix_paths(self, mpshort_model):
-        self.add_broken_test_data(mpshort_model)
-        with capture_signals() as signals:
-            mpshort_model.objects.fix_tree(fix_paths=True)
-        got = self.got(mpshort_model)
-        expected = self.expected_no_holes[mpshort_model]
-        assert got == expected
-        assert all(not group for group in mpshort_model.objects.find_problems())
-        if issubclass(mpshort_model, MP_Node):
-            # Confirm that path_updated signals were fired for any path moves -
-            # enumerating the exact sequence of updates would be too brittle
-            assert any(signal[0] == "path_updated" for signal in signals)
-
-    def test_fix_tree_with_parent(self, mpshort_model):
-        """
-        Fix the tree only for parent with path 4 and everything inside it.
-        All other bad data should be left intact.
-        """
-
-        self.add_broken_test_data(mpshort_model)
-        mpshort_model.objects.fix_tree(parent=mpshort_model.objects.get(path="4"))
-        got = self.got(mpshort_model)
-        expected = self.expected_with_holes[mpshort_model]
-
-        assert got[7:] == expected[7:]  # Only compare items from path 4 onwards
-        problems = mpshort_model.objects.find_problems()
-        assert not any([problems[0], problems[1], problems[2], problems[4]])
-        assert set(problems[3]) == set(mpshort_model.objects.exclude(path__startswith="4").values_list("pk", flat=True))
-
-    def test_fix_tree_with_parent_fix_paths(self, mpshort_model):
-        """
-        Fix the tree only for parent with path 4 and everything inside it.
-        All other bad data should be left intact.
-        """
-
-        self.add_broken_test_data(mpshort_model)
-        parent = mpshort_model.objects.get(path="4")
-        # Fix the depth on the parent - we need a valid parent to operate on only part of a tree
-        parent.depth = 1
-        parent.save()
-        with capture_signals() as signals:
-            mpshort_model.objects.fix_tree(parent=parent, fix_paths=True)
-        got = self.got(mpshort_model)
-        expected_partial = {
-            models.MP_TestNodeShortPath: [
-                ("4", "a", 1, 4),
-                ("41", "a", 2, 0),
-                ("42", "a", 2, 0),
-                ("43", "u", 2, 1),
-                ("431", "i", 3, 1),
-                ("4311", "e", 4, 0),
-                ("44", "o", 2, 0),
-            ],
-            models.MP_TestSortedNodeShortPath: [
-                ("4", "a", 1, 4),
-                ("41", "a", 2, 0),
-                ("42", "a", 2, 0),
-                ("43", "o", 2, 0),
-                ("44", "u", 2, 1),
-                ("441", "i", 3, 1),
-                ("4411", "e", 4, 0),
-            ],
-        }
-
-        assert got[7:] == expected_partial[mpshort_model]  # Only compare items from path 4 onwards
-        problems = mpshort_model.objects.find_problems()
-        assert not any([problems[0], problems[1], problems[2], problems[4]])
-        assert set(problems[3]) == set(mpshort_model.objects.exclude(path__startswith="4").values_list("pk", flat=True))
-        if issubclass(mpshort_model, MP_Node):
-            # Confirm that path_updated signals were fired for any path moves -
-            # enumerating the exact sequence of updates would be too brittle
-            assert any(signal[0] == "path_updated" for signal in signals)
-
-
-@pytest.mark.django_db
-class TestMoveNodeForm:
-    def _get_nodes_list(self, nodes):
-        return [(str(pk), f"{'&nbsp;' * 4 * (depth - 1)}{_str}") for pk, _str, depth in nodes]
-
-    def _assert_nodes_in_choices(self, form, nodes):
-        choices = list(form.fields["treebeard_ref_node"].choices)
-        assert choices.pop(0)[0] == ""  # Empty choice
-        assert nodes == [(str(choice[0]), choice[1]) for choice in choices]
-
-    def _move_node_helper(self, node, safe_parent_nodes):
-        form_class = movenodeform_factory(type(node))
-        form = form_class(instance=node)
-        assert ["desc", "treebeard_position", "treebeard_ref_node"] == list(form.base_fields.keys())
-        got = [choice[0] for choice in form.fields["treebeard_position"].choices]
-        assert ["first-child", "left", "right"] == got
-        nodes = self._get_nodes_list(safe_parent_nodes)
-        self._assert_nodes_in_choices(form, nodes)
-
-    def _get_node_ids_strs_and_depths(self, nodes):
-        return [(node.pk, str(node), node.get_depth()) for node in nodes]
-
-    def test_form_root_node(self, model):
-        nodes = list(model.objects.get_tree())
-        node = nodes.pop(0)
-        safe_parent_nodes = self._get_node_ids_strs_and_depths(nodes)
-        self._move_node_helper(node, safe_parent_nodes)
-
-    def test_form_admin(self, model):
-        request = None
-        nodes = list(model.objects.get_tree())
-        safe_parent_nodes = self._get_node_ids_strs_and_depths(nodes)
-        for node in model.objects.all():
-            site = AdminSite()
-            form_class = movenodeform_factory(model)
-            admin_class = admin_factory(form_class)
-            ma = admin_class(model, site)
-            got = list(ma.get_form(request).base_fields.keys())
-            desc_pos_refnodeid = ["desc", "treebeard_position", "treebeard_ref_node"]
-            assert desc_pos_refnodeid == got
-            got = ma.get_fieldsets(request)
-            expected = [(None, {"fields": desc_pos_refnodeid})]
-            assert got == expected
-            got = ma.get_fieldsets(request, node)
-            assert got == expected
-            form = ma.get_form(request)()
-            nodes = self._get_nodes_list(safe_parent_nodes)
-            self._assert_nodes_in_choices(form, nodes)
-
-    def test_skips_move_if_no_change(self, model_without_data):
-        parent = model_without_data.objects.add_root({"desc": "A"})
-        child = model_without_data.objects.add_child(parent, {"desc": "B"})
-        form_class = movenodeform_factory(model_without_data)
-        form = form_class(
-            instance=child, data={"desc": "B", "treebeard_position": "first-child", "treebeard_ref_node": parent.pk}
-        )
-        assert form.is_valid()
-        with mock.patch.object(model_without_data.objects, "move") as mock_move:
-            form.save()
-            mock_move.assert_not_called()
-
-        # Now change the reference node - should trigger a move
-        form = form_class(
-            instance=child, data={"desc": "B", "treebeard_position": "first-child", "treebeard_ref_node": None}
-        )
-        assert form.is_valid()
-        with mock.patch.object(model_without_data.objects, "move") as mock_move:
-            form.save()
-            mock_move.assert_called_once()
-
-    def test_skips_move_if_no_change_node_order_by(self, sorted_model):
-        parent = sorted_model.objects.add_root({"desc": "A", "val1": 1, "val2": 1})
-        child = sorted_model.objects.add_child(parent, {"desc": "B", "val1": 3, "val2": 4})
-        form_class = movenodeform_factory(sorted_model)
-        form = form_class(
-            instance=child,
-            data={
-                "desc": "B",
-                "val1": 3,
-                "val2": 4,
-                "treebeard_position": "sorted-child",
-                "treebeard_ref_node": parent.pk,
-            },
-        )
-        assert form.is_valid()
-        with mock.patch.object(sorted_model.objects, "move") as mock_move:
-            form.save()
-            mock_move.assert_not_called()
-
-        # Now change the reference node - should trigger a move
-        form = form_class(
-            instance=child,
-            data={
-                "desc": "B",
-                "val1": 10,
-                "val2": 4,
-                "treebeard_position": "sorted-child",
-                "treebeard_ref_node": parent.pk,
-            },
-        )
-        assert form.is_valid()
-        with mock.patch.object(sorted_model.objects, "move") as mock_move:
-            form.save()
-            mock_move.assert_called_once()
-
-
-@pytest.mark.django_db
-class TestSortedForm(TestTreeSorted):
-    def test_sorted_form(self, sorted_model):
-        sorted_model.objects.add_root({"val1": 3, "val2": 3, "desc": "zxy"})
-        sorted_model.objects.add_root({"val1": 1, "val2": 4, "desc": "bcd"})
-        sorted_model.objects.add_root({"val1": 2, "val2": 5, "desc": "zxy"})
-        sorted_model.objects.add_root({"val1": 3, "val2": 3, "desc": "abc"})
-        sorted_model.objects.add_root({"val1": 4, "val2": 1, "desc": "fgh"})
-        sorted_model.objects.add_root({"val1": 3, "val2": 3, "desc": "abc"})
-        sorted_model.objects.add_root({"val1": 2, "val2": 2, "desc": "qwe"})
-        sorted_model.objects.add_root({"val1": 3, "val2": 2, "desc": "vcx"})
-
-        form_class = movenodeform_factory(sorted_model)
-        form = form_class()
-        assert list(form.fields.keys()) == [
-            "desc",
-            "val1",
-            "val2",
-            "treebeard_position",
-            "treebeard_ref_node",
-        ]
-
-        form = form_class(instance=sorted_model.objects.get(desc="bcd"))
-        assert list(form.fields.keys()) == [
-            "desc",
-            "val1",
-            "val2",
-            "treebeard_position",
-            "treebeard_ref_node",
-        ]
-        assert "id_treebeard_position" in str(form)
-        assert "id_treebeard_ref_node" in str(form)
-
-
-@pytest.mark.django_db
-class TestForm(TestNonEmptyTree):
-    def test_form(self, model):
-        form_class = movenodeform_factory(model)
-        form = form_class()
-        assert list(form.fields.keys()) == ["desc", "treebeard_position", "treebeard_ref_node"]
-
-        form = form_class(instance=model.objects.get(desc="1"))
-        assert list(form.fields.keys()) == ["desc", "treebeard_position", "treebeard_ref_node"]
-        assert "id_treebeard_position" in str(form)
-        assert "id_treebeard_ref_node" in str(form)
-
-    def test_move_node_form(self, model):
-        form_class = movenodeform_factory(model)
-
-        bad_node = model.objects.add_child(
-            model.objects.get(desc="1"), {"desc": 'Benign<script>alert("Compromised");</script>'}
-        )
-
-        form = form_class(instance=bad_node)
-        rendered_html = form.as_p()
-        assert "Benign" in rendered_html
-        assert "<script>" not in rendered_html
-        assert "&lt;script&gt;" in rendered_html
-
-    def test_get_initial(self, model):
-        form_class = movenodeform_factory(model)
-
-        instance_parent = model.objects.get(desc="1")
-        form = form_class(instance=instance_parent)
-        assert form._get_initial(instance_parent) == {
-            "treebeard_position": "first-child",
-            "treebeard_ref_node": None,
-        }
-
-        instance_child = model.objects.get(desc="21")
-        form = form_class(instance=instance_child)
-        assert form._get_initial(instance_child) == {
-            "treebeard_position": "first-child",
-            "treebeard_ref_node": model.objects.get(desc="2"),
-        }
-
-        instance_grandchild = model.objects.get(desc="22")
-        form = form_class(instance=instance_grandchild)
-        assert form._get_initial(instance_grandchild) == {
-            "treebeard_position": "right",
-            "treebeard_ref_node": model.objects.get(desc="21"),
-        }
-
-        instance_grandchild = model.objects.get(desc="231")
-        form = form_class(instance=instance_grandchild)
-        assert form._get_initial(instance_grandchild) == {
-            "treebeard_position": "first-child",
-            "treebeard_ref_node": model.objects.get(desc="23"),
-        }
-
-    def test_save_edit(self, model):
-        instance_parent = model.objects.get(desc="1")
-        original_count = model.objects.count()
-        form_class = movenodeform_factory(model)
-        form = form_class(
-            instance=instance_parent,
-            data={
-                "treebeard_position": "first-child",
-                "treebeard_ref_node": model.objects.get(desc="2").pk,
-                "desc": instance_parent.desc,
-            },
-        )
-        assert form.is_valid()
-        saved_instance = form.save()
-        assert original_count == model.objects.all().count()
-        assert model.objects.get_children_count(saved_instance) == 0
-        assert saved_instance.get_depth() == 2
-        assert not saved_instance.is_root()
-        assert saved_instance.is_leaf()
-
-        # Return to original state
-        form_class = movenodeform_factory(model)
-        form = form_class(
-            instance=saved_instance,
-            data={
-                "treebeard_position": "first-child",
-                "treebeard_ref_node": "",
-                "desc": saved_instance.desc,
-            },
-        )
-        assert form.is_valid()
-        restored_instance = form.save()
-        assert original_count == model.objects.all().count()
-        assert model.objects.get_children_count(restored_instance) == 0
-        assert restored_instance.get_depth() == 1
-        assert restored_instance.is_root()
-        assert restored_instance.is_leaf()
-
-    def test_save_new(self, model):
-        original_count = model.objects.all().count()
-        assert original_count == 10
-        treebeard_position = "first-child"
-        form_class = movenodeform_factory(model)
-        form = form_class(data={"treebeard_position": treebeard_position, "desc": "New Form Test"})
-        assert form.is_valid()
-        assert form.save() is not None
-        assert original_count < model.objects.all().count()
-
-    def test_save_new_with_pk_set(self, model):
-        """
-        If the model is using a natural primary key then it will be
-        already set when the instance is inserted.
-        """
-        original_count = model.objects.all().count()
-        assert original_count == 10
-        treebeard_position = "first-child"
-        form_class = movenodeform_factory(model)
-        form = form_class(data={"treebeard_position": treebeard_position, "id": 999999, "desc": "New Form Test"})
-        assert form.is_valid()
-        # Fake a natural key by updating the instance directly, because
-        # the model form will have removed the id from cleaned data because
-        # it thinks it is an AutoField.
-        form.instance.id = 999999
-        assert form.save() is not None
-        assert original_count < model.objects.all().count()
-
-    def test_save_instance(self, model):
-        form_class = movenodeform_factory(model)
-        form = form_class(data={"treebeard_position": "first-child", "desc": "Test Instance"})
-        assert form.is_valid()
-        form.instance.desc = "Modified Instance"
-        instance = form.save()
-        assert instance.desc == "Modified Instance"
-
-
-@pytest.mark.django_db
-class TestAdminTreeContext(TestNonEmptyTree):
-    def test_tree_context(self, model_without_proxy):
-        model = model_without_proxy
-        request = RequestFactory().get("/admin/tree/")
-        request.user = AnonymousUser()
-        site = AdminSite()
-        form_class = movenodeform_factory(model)
-        admin_class = admin_factory(form_class)
-        m = admin_class(model, site)
-        list_display = m.get_list_display(request)
-        list_display_links = m.get_list_display_links(request, list_display)
-        cl = ChangeList(
-            request,
-            model,
-            list_display,
-            list_display_links,
-            m.list_filter,
-            m.date_hierarchy,
-            m.search_fields,
-            m.list_select_related,
-            m.list_per_page,
-            m.list_max_show_all,
-            m.list_editable,
-            m,
-            [],
-            "",
-        )
-        cl.formset = None
-        tree_ctx = tree_context(cl)
-
-        for idx, obj in enumerate(cl.result_list):
-            assert tree_ctx[idx] == {
-                "node-id": str(obj.pk),
-                "parent-id": 0 if obj.is_root() else model.objects.get_parent(obj).pk,
-                "level": obj.get_depth(),
-                "has-children": 0 if obj.is_leaf() else 1,
-            }
-
-
-@pytest.mark.django_db
-class TestAdminTreeList(TestNonEmptyTree):
-    template = Template("{% load admin_tree_list %}{% result_tree cl request %}")
-
-    def test_result_tree_list(self, model_without_proxy):
-        """
-        Verifies that inclusion tag result_list generates a table when with
-        default ModelAdmin settings.
-        """
-        model = model_without_proxy
-        request = RequestFactory().get("/admin/tree/")
-        request.user = AnonymousUser()
-        site = AdminSite()
-        form_class = movenodeform_factory(model)
-        admin_class = admin_factory(form_class)
-        m = admin_class(model, site)
-        list_display = m.get_list_display(request)
-        list_display_links = m.get_list_display_links(request, list_display)
-        cl = ChangeList(
-            request,
-            model,
-            list_display,
-            list_display_links,
-            m.list_filter,
-            m.date_hierarchy,
-            m.search_fields,
-            m.list_select_related,
-            m.list_per_page,
-            m.list_max_show_all,
-            m.list_editable,
-            m,
-            [],
-            "",
-        )
-        cl.formset = None
-        context = Context({"cl": cl, "request": request})
-        table_output = self.template.render(context)
-        output_template = '<li><a href="%s/" >%s</a>'
-        for object in model.objects.all():
-            expected_output = output_template % (object.pk, str(object))
-            assert expected_output in table_output
-
-    def test_result_tree_list_with_action(self, model_without_proxy):
-        model = model_without_proxy
-        request = RequestFactory().get("/admin/tree/")
-        request.user = AnonymousUser()
-        site = AdminSite()
-        form_class = movenodeform_factory(model)
-        admin_class = admin_factory(form_class)
-        m = admin_class(model, site)
-        list_display = m.get_list_display(request)
-        list_display_links = m.get_list_display_links(request, list_display)
-        cl = ChangeList(
-            request,
-            model,
-            list_display,
-            list_display_links,
-            m.list_filter,
-            m.date_hierarchy,
-            m.search_fields,
-            m.list_select_related,
-            m.list_per_page,
-            m.list_max_show_all,
-            m.list_editable,
-            m,
-            [],
-            "",
-        )
-        cl.formset = None
-        context = Context({"cl": cl, "request": request, "action_form": True})
-        table_output = self.template.render(context)
-        output_template = (
-            '<input type="checkbox" class="action-select" value="%s" name="_selected_action" /> <a href="%s/" >%s</a>'
-        )
-
-        for object in model.objects.all():
-            expected_output = output_template % (object.pk, object.pk, str(object))
-            assert expected_output in table_output
-
-    def test_result_tree_list_with_get(self, model_without_proxy):
-        model = model_without_proxy
-        pk_field = model._meta.pk.attname
-        # Test t GET parameter with value id
-        request = RequestFactory().get(f"/admin/tree/?{TO_FIELD_VAR}={pk_field}")
-        request.user = AnonymousUser()
-        site = AdminSite()
-        admin_register_all(site)
-        form_class = movenodeform_factory(model)
-        admin_class = admin_factory(form_class)
-        m = admin_class(model, site)
-        list_display = m.get_list_display(request)
-        list_display_links = m.get_list_display_links(request, list_display)
-        cl = ChangeList(
-            request,
-            model,
-            list_display,
-            list_display_links,
-            m.list_filter,
-            m.date_hierarchy,
-            m.search_fields,
-            m.list_select_related,
-            m.list_per_page,
-            m.list_max_show_all,
-            m.list_editable,
-            m,
-            [],
-            "",
-        )
-        cl.formset = None
-        context = Context({"cl": cl, "request": request})
-        table_output = self.template.render(context)
-        output_template = "opener.dismissRelatedLookupPopup(window, '%s');"
-        for object in model.objects.all():
-            expected_output = output_template % object.pk
-            assert expected_output in table_output
-
-    def test_result_tree_list_escapes_labels(self, model):
-        """
-        Verifies that inclusion tag result_list generates a table when with
-        default ModelAdmin settings.
-        """
-        object = model.objects.add_root({"desc": "<>"})
-        request = RequestFactory().get("/admin/tree/")
-        request.user = AnonymousUser()
-        site = AdminSite()
-        form_class = movenodeform_factory(model)
-        admin_class = admin_factory(form_class)
-        m = admin_class(model, site)
-        list_display = m.get_list_display(request)
-        list_display_links = m.get_list_display_links(request, list_display)
-        cl = ChangeList(
-            request,
-            model,
-            list_display,
-            list_display_links,
-            m.list_filter,
-            m.date_hierarchy,
-            m.search_fields,
-            m.list_select_related,
-            m.list_per_page,
-            m.list_max_show_all,
-            m.list_editable,
-            m,
-            [],
-            "",
-        )
-        cl.formset = None
-        context = Context({"cl": cl, "request": request})
-        table_output = self.template.render(context)
-        expected_output = f'<li><a href="{object.pk}/" >&lt;&gt;</a>'
-        assert expected_output in table_output
-
-
-@pytest.mark.django_db
-class TestTreeAdmin(TestNonEmptyTree):
-    site = AdminSite()
-
-    def _create_user(self, username, **kwargs):
-        return User.objects.create(username=username, **kwargs)
-
-    def _mocked_request(self, data, user=None):
-        request = RequestFactory().post("/", data=data)
-        request.session = {}
-        request.user = user or AnonymousUser()
-        request._messages = FallbackStorage(request)
-        return request
-
-    def _get_admin_obj(self, model_class):
-        form_class = movenodeform_factory(model_class)
-        admin_class = admin_factory(form_class)
-        return admin_class(model_class, self.site)
-
-    def test_default_fields(self, model):
-        site = AdminSite()
-        form_class = movenodeform_factory(model)
-        admin_class = admin_factory(form_class)
-        ma = admin_class(model, site)
-        assert list(ma.get_form(None).base_fields.keys()) == [
-            "desc",
-            "treebeard_position",
-            "treebeard_ref_node",
-        ]
-
-    def test_changeform_view_rolls_back_on_form_error(self, model_without_proxy):
-        admin_obj = self._get_admin_obj(model_without_proxy)
-        target = model_without_proxy.objects.get(desc="231")
-        user = self._create_user("tmp", is_superuser=True)
-
-        request = self._mocked_request(
-            data={"desc": "new node", "treebeard_position": "first-child", "treebeard_ref_node": target.pk},
-            user=user,
-        )
-        # Access the inner function, skipping CSRF checks
-        response = admin_obj.changeform_view.__wrapped__(admin_obj, request)
-        assert response.status_code == 302
-        target.refresh_from_db()
-        children = model_without_proxy.objects.get_children(target)
-        assert len(children) == 1  # Normal case: form submitted successfully and child added
-        assert children[0].desc == "new node"
-
-        request = self._mocked_request(
-            data={"desc": "second new node", "treebeard_position": "first-child", "treebeard_ref_node": target.pk},
-            user=user,
-        )
-
-        def fake_error(*args):
-            admin_obj.form.errors = {"__all__": [ValidationError("fake error")]}
-            return False
-
-        with mock.patch("django.contrib.admin.options.all_valid", side_effect=fake_error):
-            response = admin_obj.changeform_view.__wrapped__(admin_obj, request)
-        assert response.status_code == 200
-        target.refresh_from_db()
-        assert len(model_without_proxy.objects.get_children(target)) == 1  # Second new child should not have been added
-
-    def test_changelist_view(self):
-        request = RequestFactory().get("/")
-        request.user = self._create_user("changelist_tmp", is_superuser=True)
-        admin_obj = self._get_admin_obj(models.AL_TestNode)
-        admin_obj.changelist_view(request)
-        assert admin_obj.change_list_template == "admin/tree_list.html"
-
-        admin_obj = self._get_admin_obj(models.MP_TestNode)
-        admin_obj.changelist_view(request)
-        assert admin_obj.change_list_template != "admin/tree_list.html"
-
-    def test_changelist_view_renders_hidden_inputs_with_extra_context(self):
-        user = self._create_user("changelist_tmp", is_superuser=True)
-        request = RequestFactory().get("/")
-        request.user = user
-        admin_obj = self._get_admin_obj(models.MP_TestNode)
-        response = admin_obj.changelist_view(request)
-        response.render()
-        content = response.content.decode()
-        assert '<input type="hidden" id="has-change-permission" value="1"/>' in content
-        assert '<input type="hidden" id="has-filters" value="0"/>' in content
-        assert '<script id="tree-context" type="application/json">[]</script>' in content
-
-        request = RequestFactory().get("/?desc=foo")
-        request.user = user
-        admin_obj = self._get_admin_obj(models.MP_TestNode)
-        with patch.object(admin_obj, "has_change_permission", return_value=False):
-            response = admin_obj.changelist_view(request)
-            response.render()
-            content = response.content.decode()
-        assert '<input type="hidden" id="has-change-permission" value="0"/>' in content
-        assert '<input type="hidden" id="has-filters" value="1"/>' in content
-
-    def test_get_node(self, model):
-        admin_obj = self._get_admin_obj(model)
-        target = model.objects.get(desc="2")
-        assert admin_obj.get_node(target.pk) == target
-
-    def test_move_node_validate_keyerror(self, model):
-        admin_obj = self._get_admin_obj(model)
-        request = self._mocked_request(data={})
-        response = admin_obj.move_node(request)
-        assert response.status_code == 400
-        assert response.content.decode() == "Malformed POST params"
-        request = self._mocked_request(data={"node_id": 1})
-        response = admin_obj.move_node(request)
-        assert response.status_code == 400
-        assert response.content.decode() == "Malformed POST params"
-
-    def test_move_node_validate_valueerror(self, model):
-        admin_obj = self._get_admin_obj(model)
-        request = self._mocked_request(data={"node_id": 1, "sibling_id": 2, "as_child": "invalid"})
-        response = admin_obj.move_node(request)
-        assert response.status_code == 400
-        assert response.content.decode() == "Malformed POST params"
-
-    def test_move_validate_missing_nodeorderby(self, model):
-        node = model.objects.get(desc="231")
-        admin_obj = self._get_admin_obj(model)
-        request = self._mocked_request(data={})
-        response = admin_obj.try_to_move_node(True, node, "sorted-child", request, target=node)
-        assert response.status_code == 400
-
-        response = admin_obj.try_to_move_node(True, node, "sorted-sibling", request, target=node)
-        assert response.status_code == 400
-
-    def test_move_validate_invalid_pos(self, model):
-        node = model.objects.get(desc="231")
-        admin_obj = self._get_admin_obj(model)
-        request = self._mocked_request(data={})
-        response = admin_obj.try_to_move_node(True, node, "invalid_pos", request, target=node)
-        assert response.status_code == 400
-
-    def test_move_validate_to_descendant(self, model):
-        node = model.objects.get(desc="2")
-        target = model.objects.get(desc="231")
-        admin_obj = self._get_admin_obj(model)
-        request = self._mocked_request(data={})
-        response = admin_obj.try_to_move_node(True, node, "first-sibling", request, target)
-        assert response.status_code == 400
-
-    def test_move_requires_change_permission(self, model):
-        node = model.objects.get(desc="231")
-        target = model.objects.get(desc="2")
-
-        admin_obj = self._get_admin_obj(model)
-        request = self._mocked_request(
-            data={"node_id": node.pk, "sibling_id": target.pk, "as_child": 0},
-            user=self._create_user("test_move_perm"),
-        )
-
-        with patch.object(admin_obj, "has_change_permission", return_value=False):
-            with pytest.raises(PermissionDenied):
-                admin_obj.move_node(request)
-
-        with patch.object(admin_obj, "has_change_permission", return_value=True):
-            response = admin_obj.move_node(request)
-            assert response.status_code == 200
-
-    def test_move_left(self, model):
-        node = model.objects.get(desc="231")
-        target = model.objects.get(desc="2")
-
-        admin_obj = self._get_admin_obj(model)
-        request = self._mocked_request(
-            data={"node_id": node.pk, "sibling_id": target.pk, "as_child": 0},
-            user=self._create_user("tmp", is_superuser=True),
-        )
-        response = admin_obj.move_node(request)
-        assert response.status_code == 200
-        expected = [
-            ("1", 1, 0),
-            ("231", 1, 0),
-            ("2", 1, 4),
-            ("21", 2, 0),
-            ("22", 2, 0),
-            ("23", 2, 0),
-            ("24", 2, 0),
-            ("3", 1, 0),
-            ("4", 1, 1),
-            ("41", 2, 0),
-        ]
-        assert self.got(model) == expected
-
-    def test_move_last_child(self, model):
-        node = model.objects.get(desc="231")
-        target = model.objects.get(desc="2")
-
-        admin_obj = self._get_admin_obj(model)
-        request = self._mocked_request(
-            data={"node_id": node.pk, "sibling_id": target.pk, "as_child": 1},
-            user=self._create_user("tmp", is_superuser=True),
-        )
-        response = admin_obj.move_node(request)
-        assert response.status_code == 200
-        expected = [
-            ("1", 1, 0),
-            ("2", 1, 5),
-            ("21", 2, 0),
-            ("22", 2, 0),
-            ("23", 2, 0),
-            ("24", 2, 0),
-            ("231", 2, 0),
-            ("3", 1, 0),
-            ("4", 1, 1),
-            ("41", 2, 0),
-        ]
-        assert self.got(model) == expected
-
-
-@pytest.mark.django_db
-class TestMPFormPerformance:
-    def test_form_choices_no_of_queries(self, django_assert_num_queries):
-        model = models.MP_TestNode
-        model.objects.load_bulk(BASE_DATA)
-        form_class = movenodeform_factory(model)
-        form = form_class()
-        with django_assert_num_queries(2):
-            list(form.fields["treebeard_ref_node"].choices)
-
-
-@pytest.mark.django_db
-class TestMP_TreeDescendantsPerformance(TestTreeBase):
-    def test_get_descendants_no_of_queries(self, django_assert_num_queries):
-        model = models.MP_TestNode
-        model.objects.load_bulk(BASE_DATA)
-
-        data = [
-            ("2", 1),
-            ("23", 1),
-            ("231", 0),
-            ("1", 0),
-            ("4", 1),
-        ]
-
-        for desc, expected in data:
-            node = model.objects.get(desc=desc)
-            with django_assert_num_queries(expected):
-                # converting to list to force queryset evaluation
-                list(model.objects.get_descendants(node))
 
 
 @pytest.mark.django_db
 class TestLT_Insertion(TestTreeBase):
     def test_move_right(self, lt_model):
         with capture_signals() as signals:
-            node_a = lt_model.objects.add_root({"desc": "A"})
-            node_b = lt_model.objects.add_root({"desc": "B"})
-            node_a_a = lt_model.objects.add_child(node_a, {"desc": "A.A"})
-            lt_model.objects.add_child(node_a_a, {"desc": "A.A.A"})
-            lt_model.objects.add_child(node_b, {"desc": "B.A"})
+            node_a = lt_model.add_root(desc="A")
+            node_b = lt_model.add_root(desc="B")
+            node_a_a = node_a.add_child(desc="A.A")
+            node_a_a.add_child(desc="A.A.A")
+            node_b.add_child(desc="B.A")
 
             expected_paths = ["A", "A.A", "A.A.A", "B", "B.A"]
             actual_paths = [str(node.path) for node in lt_model.objects.all()]
             assert actual_paths == expected_paths
 
             # A sibling inserted before A.A gets path A.0; other paths are unchanged
-            node_a_0 = lt_model.objects.add_sibling(node_a_a, "first-sibling", {"desc": "A.0"})
+            node_a_0 = node_a_a.add_sibling("first-sibling", desc="A.0")
             expected_paths = ["A", "A.0", "A.A", "A.A.A", "B", "B.A"]
             actual_paths = [str(node.path) for node in lt_model.objects.all()]
             assert actual_paths == expected_paths
@@ -4763,7 +3329,7 @@ class TestLT_Insertion(TestTreeBase):
 
         # A sibling inserted before A.0 causes existing siblings to be moved right (i.e. 'A' appended to their labels)
         with capture_signals() as signals:
-            new_node_a_0 = lt_model.objects.add_sibling(node_a_0, "first-sibling", {"desc": "new A.0"})
+            new_node_a_0 = node_a_0.add_sibling("first-sibling", desc="new A.0")
 
         assert str(new_node_a_0.path) == "A.0"
         node_a_0.refresh_from_db()
@@ -4781,13 +3347,57 @@ class TestLT_Insertion(TestTreeBase):
 
 
 @pytest.mark.django_db
-class TestChecks:
-    def test_checks_warning_if_model_manager_doesnt_subclass_treebeard_manager(self, model, monkeypatch):
-        configs = [apps.get_app_config("tests")]
-        assert not check_all_models(configs)
-        # Monkey-patch default manager
-        monkeypatch.setattr(model._meta, "default_manager", Manager())
-        errors = check_all_models(configs)
-        assert len(errors) == 1
-        assert isinstance(errors[0], checks.Error)
-        assert "does not subclass treebeard." in errors[0].msg
+class TestMPHandlersDeprecated(TestTreeBase):
+    """
+    Check that direct use of deprecated MP_ handlers works.
+    """
+
+    def test_move(self, mp_model):
+        node = mp_model.objects.get(desc="4")
+        target = mp_model.objects.get(desc="23")
+        MP_MoveHandler(node, target, "left").process()
+
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 5),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("4", 2, 1),
+            ("41", 3, 0),
+            ("23", 2, 1),
+            ("231", 3, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+        ]
+        assert self.got(mp_model) == expected
+
+    def test_add_child(self, mp_model):
+        node = mp_model.objects.get(desc="231")
+        MP_AddChildHandler(node, {"desc": "2311"}).process()
+        expected = [
+            ("1", 1, 0),
+            ("2", 1, 4),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 1),
+            ("231", 3, 1),
+            ("2311", 4, 0),
+            ("24", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+        assert self.got(mp_model) == expected
+
+    def test_add_sibling(self, mp_model):
+        node_wchildren = mp_model.objects.get(desc="2")
+        obj = MP_AddSiblingHandler(node_wchildren, "last-sibling", {"desc": "5"}).process()
+        assert obj.get_depth() == 1
+        assert node_wchildren.get_last_sibling().desc == "5"
+
+    def test_add_root(self, mp_model):
+        obj = MP_AddRootHandler(mp_model, desc="5").process()
+        assert obj.get_depth() == 1
+        got = mp_model.get_last_root_node()
+        assert got.desc == "5"
+        assert isinstance(got, mp_model)

--- a/treebeard/admin.py
+++ b/treebeard/admin.py
@@ -91,7 +91,7 @@ class TreeAdmin(admin.ModelAdmin):
 
     def try_to_move_node(self, as_child, node, pos, request, target):
         try:
-            node.move(target, pos=pos)
+            self.model.objects.move(node, target, pos=pos)
             # Call the save method on the (reloaded) node in order to trigger
             # possible signal handlers etc.
             node = self.get_node(node.pk)

--- a/treebeard/al_tree.py
+++ b/treebeard/al_tree.py
@@ -1,15 +1,16 @@
 """Adjacency List"""
 
-from django.core import checks, serializers
+from django.core import serializers
 from django.db import models, transaction
 from django.db.models import Exists, Max, Min, OuterRef
 from django.utils.translation import gettext_noop as _
 
-from treebeard.exceptions import InvalidMoveToDescendant, NodeAlreadySaved
-from treebeard.models import Node
+from treebeard.exceptions import InvalidMoveToDescendant
+from treebeard.models import Node, NodeManager
+from treebeard.utils import check_create_args
 
 
-class AL_NodeManager(models.Manager):
+class AL_NodeManager(NodeManager):
     """Custom manager for nodes in an Adjacency List tree."""
 
     def get_queryset(self):
@@ -20,6 +21,253 @@ class AL_NodeManager(models.Manager):
             order_by = ["parent", "sib_order"]
         return super().get_queryset().order_by(*order_by)
 
+    def get_tree(self, parent=None):
+        """
+        :returns: A list of nodes ordered as DFS, including the parent. If
+                  no parent is given, the entire tree is returned.
+        """
+        if parent:
+            depth = parent.get_depth() + 1
+            parent.node_has_children = self.get_children(parent).exists()
+            results = [parent]
+        else:
+            depth = 1
+            results = []
+        self._get_tree_recursively(results, parent, depth)
+        return results
+
+    def _get_tree_recursively(self, results, parent, depth):
+        if parent:
+            qs = self.get_children(parent) if parent.node_has_children else self.none()
+        else:
+            qs = self.get_root_nodes()
+
+        # Annotate nodes with `node_has_children`, so that we can avoid unnecessary
+        # queries to fetch children on leaf nodes
+        qs = qs.annotate(node_has_children=Exists(self.tree_model.objects.filter(parent=OuterRef("pk"))))
+        for node in qs:
+            node._cached_depth = depth
+            results.append(node)
+            self._get_tree_recursively(results, node, depth + 1)
+
+    @transaction.atomic
+    @check_create_args
+    def add_root(self, create_kwargs=None, *, instance=None):
+        """Adds a root node to the tree."""
+        newobj = instance or self.model(**create_kwargs)
+        newobj._cached_depth = 1
+        if not self.model.node_order_by:
+            max = self.tree_model.objects.filter(parent=None).aggregate(max=Max("sib_order"))["max"] or 0
+            newobj.sib_order = max + 1
+        newobj.save(using=self._db)
+        return newobj
+
+    @transaction.atomic
+    @check_create_args
+    def add_child(self, target, create_kwargs=None, *, instance=None):
+        """Adds a child to the node."""
+        cls = self.tree_model
+
+        newobj = instance or cls(**create_kwargs)
+
+        try:
+            newobj._cached_depth = target._cached_depth + 1
+        except AttributeError:
+            pass
+        if not cls.node_order_by:
+            max = cls.objects.filter(parent=target).aggregate(max=Max("sib_order"))["max"] or 0
+            newobj.sib_order = max + 1
+        newobj.parent = target
+        newobj.save(using=self._db)
+        return newobj
+
+    @transaction.atomic
+    @check_create_args
+    def add_sibling(self, target, pos=None, create_kwargs=None, instance=None):
+        """Adds a new node as a sibling to the current node object."""
+        pos = self._prepare_pos_var_for_add_sibling(pos)
+
+        newobj = instance or self.tree_model(**create_kwargs)
+        if not target.node_order_by:
+            newobj.sib_order = self._get_new_sibling_order(pos, target)
+        newobj.parent_id = target.parent_id
+        newobj.save(using=self._db)
+        return newobj
+
+    @transaction.atomic
+    def move(self, node, target, pos=None):
+        """
+        Moves the current node and all it's descendants to a new position
+        relative to another node.
+        """
+
+        pos = self._prepare_pos_var_for_move(pos)
+
+        sib_order = None
+        parent = None
+
+        if pos in ("first-child", "last-child", "sorted-child"):
+            if node == target:
+                raise InvalidMoveToDescendant(_("Can't move node to itself."))
+
+            # moving to a child
+            if not target.is_leaf():
+                target = self.get_last_child(target)
+                pos = {"first-child": "first-sibling", "last-child": "last-sibling", "sorted-child": "sorted-sibling"}[
+                    pos
+                ]
+            else:
+                parent = target
+                if pos == "sorted-child":
+                    pos = "sorted-sibling"
+                else:
+                    pos = "first-sibling"
+                    sib_order = 1
+
+        if target.is_descendant_of(node):
+            raise InvalidMoveToDescendant(_("Can't move node to a descendant."))
+
+        if node == target and (
+            (pos == "left")
+            or (pos in ("right", "last-sibling") and target == self.get_last_sibling(target))
+            or (pos == "first-sibling" and target == self.get_first_sibling(target))
+        ):
+            # special cases, not actually moving the node, so nothing to do
+            return
+
+        node.parent = parent or target.parent
+        if pos != "sorted-sibling":  # sorted-sibling delegates to node_order_by
+            node.sib_order = sib_order or self._get_new_sibling_order(pos, target)
+
+        node.save(using=self._db)
+
+    def get_root_nodes(self):
+        """:returns: A queryset containing the root nodes in the tree."""
+        return self.tree_model.objects.filter(parent=None)
+
+    def dump_bulk(self, parent=None, keep_ids=True):
+        """Dumps a tree branch to a python data structure."""
+
+        # a list of nodes: not really a queryset, but it works
+        objs = self.get_tree(parent)
+
+        ret, lnk = [], {}
+        pk_field = self.model._meta.pk.attname
+        for node, pyobj in zip(objs, serializers.serialize("python", objs)):
+            depth = node.get_depth()
+            # django's serializer stores the attributes in 'fields'
+            fields = pyobj["fields"]
+            del fields["parent"]
+
+            # non-sorted trees have this
+            if "sib_order" in fields:
+                del fields["sib_order"]
+
+            if pk_field in fields:
+                del fields[pk_field]
+
+            newobj = {"data": fields}
+            if keep_ids:
+                newobj[pk_field] = pyobj["pk"]
+
+            if (not parent and depth == 1) or (parent and depth == parent.get_depth()):
+                ret.append(newobj)
+            else:
+                parentobj = lnk[node.parent_id]
+                if "children" not in parentobj:
+                    parentobj["children"] = []
+                parentobj["children"].append(newobj)
+            lnk[node.pk] = newobj
+        return ret
+
+    def get_children(self, node):
+        """:returns: A queryset of all the node's children"""
+        return self.tree_model.objects.filter(parent=node)
+
+    def get_siblings(self, node):
+        """
+        :returns: A queryset of all the node's siblings, including the node
+            itself.
+        """
+        if node.parent_id:
+            return self.tree_model.objects.filter(parent_id=node.parent_id)
+        return self.get_root_nodes()
+
+    def get_descendants(self, node, include_self=False):
+        """
+        :returns: A *list* of all the node's descendants, doesn't
+            include the node itself if `include_self` is False
+        """
+        tree = self.tree_model.objects.get_tree(node)
+        return tree if include_self else tree[1:]
+
+    def get_descendant_count(self, node):
+        """:returns: the number of descendants of a node"""
+        return len(self.get_descendants(node))
+
+    def get_prev_sibling(self, node):
+        return self.get_siblings(node).filter(sib_order__lt=node.sib_order).last()
+
+    def get_next_sibling(self, node):
+        return self.get_siblings(node).filter(sib_order__gt=node.sib_order).first()
+
+    def get_root(self, node):
+        """:returns: the root node for the current node object."""
+        if ancestors := self.get_ancestors(node):
+            return ancestors[0]
+        return node
+
+    def get_parent(self, node, update=False):
+        """:returns: the parent node of the supplied node object."""
+        if self.model._meta.proxy_for_model:
+            # the current node is a proxy model; the returned parent
+            # should be the same proxy model, so we need to explicitly
+            # fetch it as an instance of that model rather than simply
+            # following the 'parent' relation
+            if node.parent_id is None:
+                return None
+
+            return self.get(pk=node.parent_id)
+
+        return node.parent
+
+    def get_ancestors(self, node):
+        """
+        :returns: A *list* containing the current node object's ancestors,
+            starting by the root node and descending to the parent.
+        """
+        ancestors = []
+        # We use get_parent() instead of .parent because the method does handling of proxy models
+        node = self.get_parent(node)
+        while node:
+            ancestors.insert(0, node)
+            node = self.get_parent(node)
+        return ancestors
+
+    def _is_target_pos_the_last_sibling(self, pos, target):
+        return pos == "last-sibling" or (pos == "right" and target == self.get_last_sibling(target))
+
+    def _make_hole_and_get_sibling_order(self, pos, target_node):
+        siblings = self.get_siblings(target_node)
+        siblings = {
+            "left": siblings.filter(sib_order__gte=target_node.sib_order),
+            "right": siblings.filter(sib_order__gt=target_node.sib_order),
+            "first-sibling": siblings,
+        }[pos]
+        sib_order = {"left": target_node.sib_order, "right": target_node.sib_order + 1, "first-sibling": 1}[pos]
+        min = siblings.aggregate(min=Min("sib_order"))["min"] or 0
+        if min:
+            self.tree_model.objects.filter(sib_order__gte=min, parent_id=target_node.parent_id).update(
+                sib_order=models.F("sib_order") + 1
+            )
+        return sib_order
+
+    def _get_new_sibling_order(self, pos, target_node):
+        if self._is_target_pos_the_last_sibling(pos, target_node):
+            return self.get_last_sibling(target_node).sib_order + 1
+
+        return self._make_hole_and_get_sibling_order(pos, target_node)
+
 
 class AL_Node(Node):
     """Abstract model to create your own Adjacency List Trees."""
@@ -29,36 +277,12 @@ class AL_Node(Node):
 
     TREEBEARD_IDENTIFYING_FIELD = "parent"
     MOVENODE_FORM_EXCLUDED_FIELDS = ("sib_order", "parent")
+    _DEFAULT_TREEBEARD_MANAGER = AL_NodeManager
 
     _cached_attributes = (
         *Node._cached_attributes,
         "_cached_depth",
     )
-
-    @classmethod
-    @transaction.atomic
-    def add_root(cls, **kwargs):
-        """Adds a root node to the tree."""
-
-        if len(kwargs) == 1 and "instance" in kwargs:
-            # adding the passed (unsaved) instance to the tree
-            newobj = kwargs["instance"]
-            if not newobj._state.adding:
-                raise NodeAlreadySaved("Attempted to add a tree node that is already in the database")
-        else:
-            newobj = cls(**kwargs)
-
-        newobj._cached_depth = 1
-        if not cls.node_order_by:
-            max = cls.tree_model().objects.filter(parent=None).aggregate(max=Max("sib_order"))["max"] or 0
-            newobj.sib_order = max + 1
-        newobj.save()
-        return newobj
-
-    @classmethod
-    def get_root_nodes(cls):
-        """:returns: A queryset containing the root nodes in the tree."""
-        return cls.tree_model().objects.filter(parent=None)
 
     def get_depth(self, update=False):
         """
@@ -87,44 +311,6 @@ class AL_Node(Node):
         self._cached_depth = depth
         return depth
 
-    def get_children(self):
-        """:returns: A queryset of all the node's children"""
-        return self.tree_model().objects.filter(parent=self)
-
-    def get_parent(self, update=False):
-        """:returns: the parent node of the current node object."""
-        if self._meta.proxy_for_model:
-            # the current node is a proxy model; the returned parent
-            # should be the same proxy model, so we need to explicitly
-            # fetch it as an instance of that model rather than simply
-            # following the 'parent' relation
-            if self.parent_id is None:
-                return None
-
-            return self.__class__.objects.get(pk=self.parent_id)
-
-        return self.parent
-
-    def get_ancestors(self):
-        """
-        :returns: A *list* containing the current node object's ancestors,
-            starting by the root node and descending to the parent.
-        """
-        ancestors = []
-        # We use node.get_parent() instead of .parent because the method does handling of proxy models
-        node = self.get_parent()
-        while node:
-            ancestors.insert(0, node)
-            node = node.get_parent()
-        return ancestors
-
-    def get_root(self):
-        """:returns: the root node for the current node object."""
-        ancestors = self.get_ancestors()
-        if ancestors:
-            return ancestors[0]
-        return self
-
     def is_root(self):
         return self.parent_id is None
 
@@ -139,236 +325,7 @@ class AL_Node(Node):
         :returns: ``True`` if the node if a descendant of another node given
             as an argument, else, returns ``False``
         """
-        return self.pk in (obj.pk for obj in node.get_descendants())
-
-    @classmethod
-    def dump_bulk(cls, parent=None, keep_ids=True):
-        """Dumps a tree branch to a python data structure."""
-
-        # a list of nodes: not really a queryset, but it works
-        objs = cls.get_tree(parent)
-
-        ret, lnk = [], {}
-        pk_field = cls._meta.pk.attname
-        for node, pyobj in zip(objs, serializers.serialize("python", objs)):
-            depth = node.get_depth()
-            # django's serializer stores the attributes in 'fields'
-            fields = pyobj["fields"]
-            del fields["parent"]
-
-            # non-sorted trees have this
-            if "sib_order" in fields:
-                del fields["sib_order"]
-
-            if pk_field in fields:
-                del fields[pk_field]
-
-            newobj = {"data": fields}
-            if keep_ids:
-                newobj[pk_field] = pyobj["pk"]
-
-            if (not parent and depth == 1) or (parent and depth == parent.get_depth()):
-                ret.append(newobj)
-            else:
-                parentobj = lnk[node.parent_id]
-                if "children" not in parentobj:
-                    parentobj["children"] = []
-                parentobj["children"].append(newobj)
-            lnk[node.pk] = newobj
-        return ret
-
-    @transaction.atomic
-    def add_child(self, **kwargs):
-        """Adds a child to the node."""
-        cls = self.tree_model()
-
-        if len(kwargs) == 1 and "instance" in kwargs:
-            # adding the passed (unsaved) instance to the tree
-            newobj = kwargs["instance"]
-            if not newobj._state.adding:
-                raise NodeAlreadySaved("Attempted to add a tree node that is already in the database")
-        else:
-            newobj = cls(**kwargs)
-
-        try:
-            newobj._cached_depth = self._cached_depth + 1
-        except AttributeError:
-            pass
-        if not cls.node_order_by:
-            max = cls.objects.filter(parent=self).aggregate(max=Max("sib_order"))["max"] or 0
-            newobj.sib_order = max + 1
-        newobj.parent = self
-        newobj.save()
-        return newobj
-
-    @classmethod
-    def _get_tree_recursively(cls, results, parent, depth):
-        if parent:
-            qs = parent.get_children() if parent.node_has_children else cls.objects.none()
-        else:
-            qs = cls.get_root_nodes()
-
-        # Annotate nodes with `node_has_children`, so that we can avoid unnecessary
-        # queries to fetch children on leaf nodes
-        qs = qs.annotate(node_has_children=Exists(cls.tree_model().objects.filter(parent=OuterRef("pk"))))
-        for node in qs:
-            node._cached_depth = depth
-            results.append(node)
-            cls._get_tree_recursively(results, node, depth + 1)
-
-    @classmethod
-    def get_tree(cls, parent=None):
-        """
-        :returns: A list of nodes ordered as DFS, including the parent. If
-                  no parent is given, the entire tree is returned.
-        """
-        if parent:
-            depth = parent.get_depth() + 1
-            parent.node_has_children = parent.get_children().exists()
-            results = [parent]
-        else:
-            depth = 1
-            results = []
-        cls._get_tree_recursively(results, parent, depth)
-        return results
-
-    def get_descendants(self, include_self=False):
-        """
-        :returns: A *list* of all the node's descendants, doesn't
-            include the node itself if `include_self` is False
-        """
-        tree = self.tree_model().get_tree(self)
-        return tree if include_self else tree[1:]
-
-    def get_descendant_count(self):
-        """:returns: the number of descendants of a node"""
-        return len(self.get_descendants())
-
-    def get_siblings(self):
-        """
-        :returns: A queryset of all the node's siblings, including the node
-            itself.
-        """
-        if self.parent_id:
-            return self.tree_model().objects.filter(parent_id=self.parent_id)
-        return self.__class__.get_root_nodes()
-
-    def get_prev_sibling(self):
-        return self.get_siblings().filter(sib_order__lt=self.sib_order).last()
-
-    def get_next_sibling(self):
-        return self.get_siblings().filter(sib_order__gt=self.sib_order).first()
-
-    @transaction.atomic
-    def add_sibling(self, pos=None, **kwargs):
-        """Adds a new node as a sibling to the current node object."""
-        pos = self._prepare_pos_var_for_add_sibling(pos)
-
-        if len(kwargs) == 1 and "instance" in kwargs:
-            # adding the passed (unsaved) instance to the tree
-            newobj = kwargs["instance"]
-            if not newobj._state.adding:
-                raise NodeAlreadySaved("Attempted to add a tree node that is already in the database")
-        else:
-            # creating a new object
-            newobj = self.tree_model()(**kwargs)
-
-        if not self.node_order_by:
-            newobj.sib_order = self.__class__._get_new_sibling_order(pos, self)
-        newobj.parent_id = self.parent_id
-        newobj.save()
-        return newobj
-
-    @classmethod
-    def _is_target_pos_the_last_sibling(cls, pos, target):
-        return pos == "last-sibling" or (pos == "right" and target == target.get_last_sibling())
-
-    @classmethod
-    def _make_hole_and_get_sibling_order(cls, pos, target_node):
-        siblings = target_node.get_siblings()
-        siblings = {
-            "left": siblings.filter(sib_order__gte=target_node.sib_order),
-            "right": siblings.filter(sib_order__gt=target_node.sib_order),
-            "first-sibling": siblings,
-        }[pos]
-        sib_order = {"left": target_node.sib_order, "right": target_node.sib_order + 1, "first-sibling": 1}[pos]
-        min = siblings.aggregate(min=Min("sib_order"))["min"] or 0
-        if min:
-            cls.tree_model().objects.filter(sib_order__gte=min, parent_id=target_node.parent_id).update(
-                sib_order=models.F("sib_order") + 1
-            )
-        return sib_order
-
-    @classmethod
-    def _get_new_sibling_order(cls, pos, target_node):
-        if cls._is_target_pos_the_last_sibling(pos, target_node):
-            return target_node.get_last_sibling().sib_order + 1
-
-        return cls._make_hole_and_get_sibling_order(pos, target_node)
-
-    @transaction.atomic
-    def move(self, target, pos=None):
-        """
-        Moves the current node and all it's descendants to a new position
-        relative to another node.
-        """
-
-        pos = self._prepare_pos_var_for_move(pos)
-
-        sib_order = None
-        parent = None
-
-        if pos in ("first-child", "last-child", "sorted-child"):
-            if self == target:
-                raise InvalidMoveToDescendant(_("Can't move node to itself."))
-
-            # moving to a child
-            if not target.is_leaf():
-                target = target.get_last_child()
-                pos = {"first-child": "first-sibling", "last-child": "last-sibling", "sorted-child": "sorted-sibling"}[
-                    pos
-                ]
-            else:
-                parent = target
-                if pos == "sorted-child":
-                    pos = "sorted-sibling"
-                else:
-                    pos = "first-sibling"
-                    sib_order = 1
-
-        if target.is_descendant_of(self):
-            raise InvalidMoveToDescendant(_("Can't move node to a descendant."))
-
-        if self == target and (
-            (pos == "left")
-            or (pos in ("right", "last-sibling") and target == target.get_last_sibling())
-            or (pos == "first-sibling" and target == target.get_first_sibling())
-        ):
-            # special cases, not actually moving the node, so nothing to do
-            return
-
-        self.parent = parent or target.parent
-        if pos != "sorted-sibling":  # sorted-sibling delegates to node_order_by
-            self.sib_order = sib_order or self.__class__._get_new_sibling_order(pos, target)
-
-        self.save()
-
-    @classmethod
-    def check(cls, **kwargs):
-        errors = super().check(**kwargs)
-        manager_cls = cls._default_manager.__class__
-        # Raise a warning if the default manager for the model doesn't subclass AL_NodeManager
-        # This will allow us to move class-level methods into the manager in future (see issue #44)
-        if not issubclass(manager_cls, AL_NodeManager):
-            errors.append(
-                checks.Warning(
-                    f"{manager_cls.__module__}.{manager_cls.__name__} does not subclass "
-                    "treebeard.al_tree.AL_NodeManager. This will cause an error in Treebeard 6.",
-                    obj=manager_cls,
-                    id="treebeard.E001",
-                )
-            )
-        return errors
+        return self.pk in (obj.pk for obj in node.__class__.objects.get_descendants(node))
 
     class Meta:
         """Abstract model."""

--- a/treebeard/deprecation.py
+++ b/treebeard/deprecation.py
@@ -1,0 +1,48 @@
+import warnings
+from functools import partial, partialmethod
+
+
+class RemovedInTreebeard7Warning(DeprecationWarning): ...
+
+
+def _handle_moved_classmethod(cls, *args, treebeard_method, **kwargs):  # pragma: no cover
+    """
+    Backward compatibility for class methods that have moved to the model manager.
+
+    Logs a warning, and calls the manager method.
+
+    This backward-compatibility will be removed in Treebeard 7.
+    """
+    warnings.warn(
+        f"Using {cls.__name__}.{treebeard_method}() is deprecated. "
+        f"Use {cls.__name__}.objects.{treebeard_method}() instead.",
+        RemovedInTreebeard7Warning,
+        stacklevel=3,
+    )
+    return getattr(cls.objects, treebeard_method)(*args, **kwargs)
+
+
+def _handle_moved_method(self, *args, treebeard_method, **kwargs):  # pragma: no cover
+    """
+    Backward compatibility for methods that have moved to the model manager.
+
+    Logs a warning, and calls the manager method.
+
+    This backward-compatibility will be removed in Treebeard 7.
+    """
+    cls = self.__class__
+    warnings.warn(
+        f"Using {cls.__name__}.{treebeard_method}() is deprecated. "
+        f"Use {cls.__name__}.objects.{treebeard_method}() instead.",
+        RemovedInTreebeard7Warning,
+        stacklevel=2,
+    )
+    return getattr(cls.objects, treebeard_method)(self, *args, **kwargs)
+
+
+def get_moved_manager_classmethod(method_name):
+    return classmethod(partial(_handle_moved_classmethod, treebeard_method=method_name))
+
+
+def get_moved_manager_method(method_name):
+    return partialmethod(_handle_moved_method, treebeard_method=method_name)

--- a/treebeard/forms.py
+++ b/treebeard/forms.py
@@ -76,11 +76,12 @@ class MoveNodeForm(forms.ModelForm):
     )
 
     def _get_initial(self, instance):
+        manager = self._meta.model.objects
         if self.is_sorted:
             position = "sorted-child"
-            ref_node = instance.get_parent()
+            ref_node = manager.get_parent(instance)
         else:
-            prev_sibling = instance.get_prev_sibling()
+            prev_sibling = manager.get_prev_sibling(instance)
             if prev_sibling:
                 position = "right"
                 ref_node = prev_sibling
@@ -89,7 +90,7 @@ class MoveNodeForm(forms.ModelForm):
                 if instance.is_root():
                     ref_node = None
                 else:
-                    ref_node = instance.get_parent()
+                    ref_node = manager.get_parent(instance)
         return {"treebeard_ref_node": ref_node, "treebeard_position": position}
 
     def _set_ref_model_queryset(self, opts, instance):
@@ -102,8 +103,8 @@ class MoveNodeForm(forms.ModelForm):
         Excludes the instance and its descendants since a move relative to those would be invalid
         """
         if issubclass(opts.model, AL_Node):
-            choices = opts.model.get_tree()
-            descendants = instance.get_descendants(include_self=True) if instance else []
+            choices = opts.model.objects.get_tree()
+            descendants = opts.model.objects.get_descendants(instance, include_self=True) if instance else []
             field = self.fields["treebeard_ref_node"]
             self.fields["treebeard_ref_node"]._choices = [("", "--------")] + [
                 (field.prepare_value(node), field.label_from_instance(node))
@@ -116,8 +117,8 @@ class MoveNodeForm(forms.ModelForm):
             self.fields["treebeard_ref_node"].queryset = opts.model.objects.all()
             return
 
-        queryset = opts.model.get_tree()
-        descendants = instance.get_descendants(include_self=True) if instance else None
+        queryset = opts.model.objects.get_tree()
+        descendants = opts.model.objects.get_descendants(instance, include_self=True) if instance else None
         if descendants:
             queryset = queryset.exclude(pk__in=descendants.values_list("pk", flat=True))
 
@@ -159,29 +160,30 @@ class MoveNodeForm(forms.ModelForm):
 
         reference_node = self.cleaned_data.pop("treebeard_ref_node", None)
         position_type = self.cleaned_data.pop("treebeard_position")
+        manager = self._meta.model.objects
 
         # If no treebeard fields have been modified, skip treebeard-specific logic and delegate to parent class
         treebeard_fields = {
             "treebeard_ref_node",
             "treebeard_position",
-            *(self.instance.tree_model().node_order_by or []),
+            *(manager.tree_model.node_order_by or []),
         }
         if not set(self.changed_data) & treebeard_fields:
             return super().save(commit=commit)
 
         if self.instance._state.adding:
             if reference_node:
-                self.instance = reference_node.add_child(instance=self.instance)
-                self.instance.move(reference_node, pos=position_type)
+                self.instance = manager.add_child(reference_node, instance=self.instance)
+                manager.move(self.instance, reference_node, pos=position_type)
             else:
-                self.instance = self._meta.model.add_root(instance=self.instance)
+                self.instance = manager.add_root(instance=self.instance)
         else:
             self.instance.save()
             if reference_node:
-                self.instance.move(reference_node, pos=position_type)
+                manager.move(self.instance, reference_node, pos=position_type)
             else:
                 pos = "sorted-sibling" if self.is_sorted else "first-sibling"
-                self.instance.move(self._meta.model.get_first_root_node(), pos)
+                manager.move(self.instance, manager.get_first_root_node(), pos)
         # Reload the instance
         self.instance.refresh_from_db()
         super().save(commit=commit)

--- a/treebeard/ltree/__init__.py
+++ b/treebeard/ltree/__init__.py
@@ -5,17 +5,17 @@ import itertools
 import operator
 import string
 from collections.abc import Iterable
-from typing import Any
 
-from django.core import checks, serializers
+from django.core import serializers
 from django.db import models, transaction
 from django.db.models import F, Func, OuterRef, Q, Subquery, Value
 from django.db.models.functions import Concat
 from django.dispatch import Signal
 from django.utils.translation import gettext_noop as _
 
-from treebeard.exceptions import InvalidMoveToDescendant, NodeAlreadySaved, PathOverflow
-from treebeard.models import Node
+from treebeard.exceptions import InvalidMoveToDescendant, PathOverflow
+from treebeard.models import Node, NodeManager
+from treebeard.utils import check_create_args
 
 from .fields import Ltree2Text, PathField, PathValue, Subpath, Text2LTree
 
@@ -117,7 +117,7 @@ class LT_NodeQuerySet(models.query.QuerySet):
             if not found:
                 paths_to_remove.add(str(node.path))
 
-        model = self.model.tree_model()
+        model = self.model.objects.tree_model
 
         if not paths_to_remove:
             return super(LT_NodeQuerySet, model.objects.none()).delete(*args, **kwargs)
@@ -131,15 +131,270 @@ class LT_NodeQuerySet(models.query.QuerySet):
     delete.queryset_only = True
 
 
-class LT_NodeManager(models.Manager):
+class LT_NodeManager(NodeManager):
     """Custom manager for nodes in a Materialized Path tree."""
 
     def get_queryset(self):
         """Sets the custom queryset as the default."""
         return LT_NodeQuerySet(self.model, using=self._db).order_by("path")
 
+    def get_tree(self, parent=None):
+        """
+        :returns:
 
-class LT_ComplexAddMoveHandler:
+            A *queryset* of nodes ordered as DFS, including the parent.
+            If no parent is given, the entire tree is returned.
+        """
+        cls = self.tree_model
+
+        if parent is None:
+            # return the entire tree
+            return cls.objects.all()
+
+        return cls.objects.filter(path__descendants=parent.path)
+
+    @transaction.atomic
+    @check_create_args
+    def add_root(self, create_kwargs=None, *, instance=None):
+        """
+        Adds a root node to the tree.
+        """
+        # do we have a root node already?
+        last_root = self.get_last_root_node()
+
+        if last_root and last_root.node_order_by:
+            # There are root nodes and node_order_by has been set.
+            # Delegate sorted insertion to add_sibling.
+            # We must pass an instance here to ensure that the right object is created for
+            # models with multi-table inheritance.
+            return self.add_sibling(last_root, "sorted-sibling", instance=instance or self.model(**create_kwargs))
+
+        newobj = instance or self.model(**create_kwargs)
+
+        if last_root:
+            # adding the new root node as the last one
+            newobj.path = generate_path(skip=self.get_root_nodes().values_list("path", flat=True))
+        else:
+            # adding the first root node
+            newobj.path = generate_path()
+
+        # saving the instance before returning it
+        newobj.save(using=self._db)
+        return newobj
+
+    @transaction.atomic
+    @check_create_args
+    def add_child(self, target, create_kwargs=None, *, instance=None):
+        """
+        Adds a child to the node.
+
+        This method saves the node in database. The object is populated as if via:
+
+        ```
+        obj = self.__class__(**create_kwargs)
+        ```
+        """
+        # Lock parent row
+        self.tree_model.objects.filter(pk=target.pk).select_for_update().only("pk").get()
+        if self.model.node_order_by and not target.is_leaf():
+            # there are child nodes and node_order_by has been set
+            # delegate sorted insertion to add_sibling
+            return self.add_sibling(
+                self.get_last_child(target), "sorted-sibling", create_kwargs=create_kwargs, instance=instance
+            )
+
+        newobj = instance or self.model(**create_kwargs)
+
+        if target.is_leaf():
+            # the node had no children, adding the first child
+            newobj.path = generate_path(prefix=target.path)
+        else:
+            # adding the new child as the last one
+            newobj.path = generate_path(
+                prefix=target.path,
+                skip=self.get_children(target).values_list("path", flat=True),
+                after=self.get_children(target).last().path[-1],
+            )
+
+        # saving the instance before returning it
+        newobj.save(using=self._db)
+        return newobj
+
+    @transaction.atomic
+    @check_create_args
+    def add_sibling(self, target, pos=None, create_kwargs=None, *, instance=None):
+        """
+        Adds a new node as a sibling to the current node object.
+
+        This method saves the node in database. The object is populated as if via:
+
+        ```
+        obj = self.__class__(**create_kwargs)
+        ```
+        """
+        pos = self._prepare_pos_var_for_add_sibling(pos)
+
+        newobj = instance or self.model(**create_kwargs)
+
+        insert_before = None
+        insert_after = None
+        if pos == "sorted-sibling":
+            insert_before = self.get_sorted_pos_queryset(self.get_siblings(target), newobj).first()
+            if insert_before:
+                insert_after = self.get_prev_sibling(insert_before)
+        elif pos == "first-sibling":
+            insert_before = self.get_first_sibling(target)
+        elif pos == "left":
+            insert_before = target
+            insert_after = self.get_prev_sibling(target)
+        elif pos == "right":
+            insert_after = target
+            insert_before = self.get_next_sibling(target)
+        elif pos == "last-sibling":
+            insert_after = self.get_last_sibling(target)
+
+        newobj.path, _ = self._get_new_path(target.path[:-1], insert_before, insert_after)
+        newobj.save(using=self._db)
+        return newobj
+
+    @transaction.atomic
+    def move(self, node, target, pos=None):
+        """
+        Moves the current node and all it's descendants to a new position
+        relative to another node.
+        """
+        pos = self._prepare_pos_var_for_move(pos)
+
+        if pos in ("first-child", "last-child", "sorted-child"):
+            if target == node:
+                raise InvalidMoveToDescendant(_("Can't move node to itself."))
+
+        if target.is_descendant_of(node):
+            raise InvalidMoveToDescendant(_("Can't move node to a descendant."))
+
+        insert_before = None
+        insert_after = None
+        prefix = target.path[:-1]  # Assume initially that target is a sibling
+
+        if pos == "sorted-sibling":
+            insert_before = self.get_sorted_pos_queryset(self.get_siblings(target), node).first()
+            if insert_before:
+                insert_after = self.get_prev_sibling(insert_before)
+        elif pos == "sorted-child":
+            insert_before = self.get_sorted_pos_queryset(self.get_children(target), node).first()
+            if insert_before:
+                insert_after = self.get_prev_sibling(insert_before)
+            prefix = target.path
+        elif pos == "first-sibling":
+            insert_before = self.get_siblings(target).first()
+        elif pos == "last-sibling":
+            insert_after = self.get_siblings(target).last()
+        elif pos == "left":
+            insert_before = target
+            insert_after = self.get_prev_sibling(target)
+        elif pos == "right":
+            insert_after = target
+            insert_before = self.get_next_sibling(target)
+        elif pos == "first-child":
+            insert_before = self.get_children(target).first()
+            prefix = target.path
+        elif pos == "last-child":
+            insert_after = self.get_children(target).last()
+            prefix = target.path
+
+        new_path, nodes_moved = self._get_new_path(prefix, insert_before, insert_after)
+        if nodes_moved:
+            node.refresh_from_db()
+
+        # Update the path for all the descendants of the node
+        result_class = self.tree_model
+        old_path = node.path
+        queryset = result_class.objects.filter(path__descendants=old_path, path__depth__gt=len(old_path))
+        queryset.update(
+            path=Concat(
+                Value(new_path, output_field=PathField()),
+                Subpath(F("path"), len(old_path)),
+            )
+        )
+        # And update the path for the node itself
+        node.path = new_path
+        node.save()
+
+        subtree_moved.send(
+            sender=result_class,
+            old_path=old_path,
+            new_path=new_path,
+            using=queryset.db,
+        )
+
+    def get_root_nodes(self):
+        """:returns: A queryset containing the root nodes in the tree."""
+        return self.tree_model.objects.filter(path__depth=1).order_by("path")
+
+    def get_descendants_group_count(self, parent=None):
+        """
+        Helper for a very common case: get a group of siblings and the number
+        of *descendants* (not only children) in every sibling.
+
+        :param parent:
+
+            The parent of the siblings to return. If no parent is given, the
+            root nodes will be returned.
+
+        :returns:
+
+            A Queryset of node objects with an extra attribute: `descendants_count`.
+        """
+        qs = self.get_children(parent) if parent else self.get_root_nodes()
+        subquery = (
+            self.tree_model.objects.filter(path__descendants=OuterRef("path"))
+            .order_by()
+            .annotate(count=Func(F("pk"), function="Count"))
+            .values("count")
+        )
+        return qs.annotate(
+            descendants_count=Subquery(subquery, output_field=models.IntegerField()) - 1
+        )  # Subtract the parent node from the count
+
+    def dump_bulk(self, parent=None, keep_ids=True):
+        """Dumps a tree branch to a python data structure."""
+
+        cls = self.tree_model
+
+        # Because of fix_tree, this method assumes that the depth
+        # and numchild properties in the nodes can be incorrect,
+        # so no helper methods are used
+        qset = cls.objects.all()
+        if parent:
+            qset = qset.filter(path__descendants=parent.path)
+        ret, lnk = [], {}
+        pk_field = cls._meta.pk.attname
+        for pyobj in serializers.serialize("python", qset.iterator()):
+            # django's serializer stores the attributes in 'fields'
+            fields = pyobj["fields"]
+            path = PathValue(fields["path"])
+            depth = len(path)
+            # this will be useless in load_bulk
+            del fields["path"]
+            if pk_field in fields:
+                # this happens immediately after a load_bulk
+                del fields[pk_field]
+
+            newobj = {"data": fields}
+            if keep_ids:
+                newobj[pk_field] = pyobj["pk"]
+
+            if (not parent and depth == 1) or (parent and len(path) == len(parent.path)):
+                ret.append(newobj)
+            else:
+                parentpath = path[0 : depth - 1]
+                parentobj = lnk[str(parentpath)]
+                if "children" not in parentobj:
+                    parentobj["children"] = []
+                parentobj["children"].append(newobj)
+            lnk[str(path)] = newobj
+        return ret
+
     def _get_new_path(self, prefix, insert_before, insert_after, nodes_moved=False, num_iters=0):
         insert_before_path = insert_before.path[-1] if insert_before else None
         insert_after_path = insert_after.path[-1] if insert_after else None
@@ -147,7 +402,7 @@ class LT_ComplexAddMoveHandler:
         if insert_before_path and insert_after_path and insert_after_path > insert_before_path:
             raise ValueError("Invalid path constraints")
 
-        siblings = self.node_cls.tree_model().objects.filter(path__descendants=prefix, path__depth=len(prefix) + 1)
+        siblings = self.tree_model.objects.filter(path__descendants=prefix, path__depth=len(prefix) + 1)
 
         try:
             path = generate_path(
@@ -175,7 +430,7 @@ class LT_ComplexAddMoveHandler:
         Move the node and all siblings after it in the tree to the right. This is achieved simply by
         appending an extra character (A) to the topmost label in the path.
         """
-        result_class = self.node_cls.tree_model()
+        result_class = self.tree_model
         node_depth = len(start_node.path)
 
         if node_depth > 1:
@@ -213,203 +468,61 @@ class LT_ComplexAddMoveHandler:
             using=queryset.db,
         )
 
+    def get_children(self, node):
+        """:returns: A queryset of all the node's children"""
+        return self.tree_model.objects.filter(path__descendants=node.path, path__depth=len(node.path) + 1)
 
-class LT_AddRootHandler:
-    def __init__(self, cls, **kwargs):
-        super().__init__()
-        self.cls = cls
-        self.kwargs = kwargs
+    def get_siblings(self, node):
+        """
+        :returns: A queryset of all the node's siblings, including the node
+            itself.
+        """
+        return self.tree_model.objects.filter(path__descendants=node.path[:-1], path__depth=len(node.path))
 
-    def process(self):
-        # do we have a root node already?
-        last_root = self.cls.get_last_root_node()
+    def get_root(self, node):
+        """:returns: the root node for the current node object."""
+        return self.tree_model.objects.get(path=node.path[0])
 
-        if last_root and last_root.node_order_by:
-            # There are root nodes and node_order_by has been set.
-            # Delegate sorted insertion to add_sibling.
-            # We must pass an instance here to ensure that the right object is created for
-            # models with multi-table inheritance.
-            return last_root.add_sibling(
-                "sorted-sibling", instance=self.kwargs.get("instance") or self.cls(**self.kwargs)
-            )
+    def get_parent(self, node, update=False):
+        """
+        :returns: the parent node of the supplied node object.
+        """
+        if len(node.path) == 1:
+            return
 
-        if len(self.kwargs) == 1 and "instance" in self.kwargs:
-            # adding the passed (unsaved) instance to the tree
-            newobj = self.kwargs["instance"]
-            if not newobj._state.adding:
-                raise NodeAlreadySaved("Attempted to add a tree node that is already in the database")
-        else:
-            # creating the new object
-            newobj = self.cls(**self.kwargs)
+        return self.tree_model.objects.get(path=node.path[:-1])
 
-        if last_root:
-            # adding the new root node as the last one
-            newobj.path = generate_path(skip=self.cls.get_root_nodes().values_list("path", flat=True))
-        else:
-            # adding the first root node
-            newobj.path = generate_path()
+    def get_ancestors(self, node):
+        """
+        :returns: A queryset containing the node's ancestors,
+            starting by the root node and descending to the parent.
+        """
+        return self.tree_model.objects.filter(path__ancestors=node.path).exclude(pk=node.pk)
 
-        # saving the instance before returning it
-        newobj.save()
-        return newobj
+    def get_next_sibling(self, node):
+        """
+        :returns: The next node's sibling, or None if it was the rightmost
+            sibling.
+        """
+        return self.get_siblings(node).filter(path__gt=node.path).first()
 
+    def get_descendants(self, node, include_self=False):
+        """
+        :returns: A queryset of all the node's descendants as DFS, doesn't
+            include the node itself if `include_self` is False
+        """
+        manager = self.tree_model.objects
+        if include_self:
+            return manager.get_tree(node)
 
-class LT_AddChildHandler:
-    def __init__(self, node, creation_kwargs: dict[str, Any]):
-        super().__init__()
-        self.node = node
-        self.node_cls = node.__class__
-        # These are deliberately not extracted in the function signature to avoid collision with model field names
-        self.kwargs = creation_kwargs
+        return manager.get_tree(node).exclude(pk=node.pk)
 
-    def process(self):
-        # Lock parent row
-        self.node_cls.tree_model().objects.filter(pk=self.node.pk).select_for_update().only("pk").get()
-        if self.node_cls.node_order_by and not self.node.is_leaf():
-            # there are child nodes and node_order_by has been set
-            # delegate sorted insertion to add_sibling
-            return self.node.get_last_child().add_sibling("sorted-sibling", **self.kwargs)
-
-        if len(self.kwargs) == 1 and "instance" in self.kwargs:
-            # adding the passed (unsaved) instance to the tree
-            newobj = self.kwargs["instance"]
-            if not newobj._state.adding:
-                raise NodeAlreadySaved("Attempted to add a tree node that is already in the database")
-        else:
-            # creating a new object
-            newobj = self.node_cls(**self.kwargs)
-
-        if self.node.is_leaf():
-            # the node had no children, adding the first child
-            newobj.path = generate_path(prefix=self.node.path)
-        else:
-            # adding the new child as the last one
-            newobj.path = generate_path(
-                prefix=self.node.path,
-                skip=self.node.get_children().values_list("path", flat=True),
-                after=self.node.get_children().last().path[-1],
-            )
-
-        # saving the instance before returning it
-        newobj.save()
-        return newobj
-
-
-class LT_AddSiblingHandler(LT_ComplexAddMoveHandler):
-    def __init__(self, node, pos, creation_kwargs: dict[str, Any]):
-        super().__init__()
-        self.node = node
-        self.node_cls = node.__class__
-        self.pos = pos
-        # These are deliberately not extracted in the function signature to avoid collision with model field names
-        self.kwargs = creation_kwargs
-
-    def process(self):
-        self.pos = self.node._prepare_pos_var_for_add_sibling(self.pos)
-
-        if len(self.kwargs) == 1 and "instance" in self.kwargs:
-            # adding the passed (unsaved) instance to the tree
-            newobj = self.kwargs["instance"]
-            if not newobj._state.adding:
-                raise NodeAlreadySaved("Attempted to add a tree node that is already in the database")
-        else:
-            # creating a new object
-            newobj = self.node_cls(**self.kwargs)
-
-        insert_before = None
-        insert_after = None
-        if self.pos == "sorted-sibling":
-            insert_before = self.node.get_sorted_pos_queryset(self.node.get_siblings(), newobj).first()
-            if insert_before:
-                insert_after = insert_before.get_prev_sibling()
-        elif self.pos == "first-sibling":
-            insert_before = self.node.get_siblings().first()
-        elif self.pos == "left":
-            insert_before = self.node
-            insert_after = self.node.get_prev_sibling()
-        elif self.pos == "right":
-            insert_after = self.node
-            insert_before = self.node.get_next_sibling()
-        elif self.pos == "last-sibling":
-            insert_after = self.node.get_siblings().last()
-
-        newobj.path, _ = self._get_new_path(self.node.path[:-1], insert_before, insert_after)
-        newobj.save()
-        return newobj
-
-
-class LT_MoveHandler(LT_ComplexAddMoveHandler):
-    def __init__(self, node, target, pos=None):
-        super().__init__()
-        self.node = node
-        self.node_cls = node.__class__
-        self.target = target
-        self.pos = pos
-
-    def process(self):
-        self.pos = self.node._prepare_pos_var_for_move(self.pos)
-
-        if self.pos in ("first-child", "last-child", "sorted-child"):
-            if self.target == self.node:
-                raise InvalidMoveToDescendant(_("Can't move node to itself."))
-
-        if self.target.is_descendant_of(self.node):
-            raise InvalidMoveToDescendant(_("Can't move node to a descendant."))
-
-        insert_before = None
-        insert_after = None
-        prefix = self.target.path[:-1]  # Assume initially that target is a sibling
-
-        if self.pos == "sorted-sibling":
-            insert_before = self.node.get_sorted_pos_queryset(self.target.get_siblings(), self.node).first()
-            if insert_before:
-                insert_after = insert_before.get_prev_sibling()
-        elif self.pos == "sorted-child":
-            insert_before = self.node.get_sorted_pos_queryset(self.target.get_children(), self.node).first()
-            if insert_before:
-                insert_after = insert_before.get_prev_sibling()
-            prefix = self.target.path
-        elif self.pos == "first-sibling":
-            insert_before = self.target.get_siblings().first()
-        elif self.pos == "last-sibling":
-            insert_after = self.target.get_siblings().last()
-        elif self.pos == "left":
-            insert_before = self.target
-            insert_after = self.target.get_prev_sibling()
-        elif self.pos == "right":
-            insert_after = self.target
-            insert_before = self.target.get_next_sibling()
-        elif self.pos == "first-child":
-            insert_before = self.target.get_children().first()
-            prefix = self.target.path
-        elif self.pos == "last-child":
-            insert_after = self.target.get_children().last()
-            prefix = self.target.path
-
-        new_path, nodes_moved = self._get_new_path(prefix, insert_before, insert_after)
-        if nodes_moved:
-            self.node.refresh_from_db()
-
-        # Update the path for all the descendants of the node
-        result_class = self.node_cls.tree_model()
-        old_path = self.node.path
-        queryset = result_class.objects.filter(path__descendants=old_path, path__depth__gt=len(old_path))
-        queryset.update(
-            path=Concat(
-                Value(new_path, output_field=PathField()),
-                Subpath(F("path"), len(old_path)),
-            )
-        )
-        # And update the path for the node itself
-        self.node.path = new_path
-        self.node.save()
-
-        subtree_moved.send(
-            sender=result_class,
-            old_path=old_path,
-            new_path=new_path,
-            using=queryset.db,
-        )
+    def get_prev_sibling(self, node):
+        """
+        :returns: The node's previous sibling, or None if it was the leftmost
+            sibling.
+        """
+        return self.get_siblings(node).filter(path__lt=node.path).last()
 
 
 class LT_Node(Node):
@@ -420,158 +533,15 @@ class LT_Node(Node):
 
     TREEBEARD_IDENTIFYING_FIELD = "path"
     MOVENODE_FORM_EXCLUDED_FIELDS = ("path",)
+    _DEFAULT_TREEBEARD_MANAGER = LT_NodeManager
 
     objects = LT_NodeManager()
 
     _cached_attributes = (*Node._cached_attributes,)
 
-    @classmethod
-    @transaction.atomic
-    def add_root(cls, **kwargs):
-        """
-        Adds a root node to the tree.
-
-        This method saves the node in database. The object is populated as if via:
-
-        ```
-        obj = cls(**kwargs)
-        ```
-        """
-        return LT_AddRootHandler(cls, **kwargs).process()
-
-    @classmethod
-    def dump_bulk(cls, parent=None, keep_ids=True):
-        """Dumps a tree branch to a python data structure."""
-
-        cls = cls.tree_model()
-
-        # Because of fix_tree, this method assumes that the depth
-        # and numchild properties in the nodes can be incorrect,
-        # so no helper methods are used
-        qset = cls.objects.all()
-        if parent:
-            qset = qset.filter(path__descendants=parent.path)
-        ret, lnk = [], {}
-        pk_field = cls._meta.pk.attname
-        for pyobj in serializers.serialize("python", qset.iterator()):
-            # django's serializer stores the attributes in 'fields'
-            fields = pyobj["fields"]
-            path = PathValue(fields["path"])
-            depth = len(path)
-            # this will be useless in load_bulk
-            del fields["path"]
-            if pk_field in fields:
-                # this happens immediately after a load_bulk
-                del fields[pk_field]
-
-            newobj = {"data": fields}
-            if keep_ids:
-                newobj[pk_field] = pyobj["pk"]
-
-            if (not parent and depth == 1) or (parent and len(path) == len(parent.path)):
-                ret.append(newobj)
-            else:
-                parentpath = path[0 : depth - 1]
-                parentobj = lnk[str(parentpath)]
-                if "children" not in parentobj:
-                    parentobj["children"] = []
-                parentobj["children"].append(newobj)
-            lnk[str(path)] = newobj
-        return ret
-
-    @classmethod
-    def get_tree(cls, parent=None):
-        """
-        :returns:
-
-            A *queryset* of nodes ordered as DFS, including the parent.
-            If no parent is given, the entire tree is returned.
-        """
-        cls = cls.tree_model()
-
-        if parent is None:
-            # return the entire tree
-            return cls.objects.all()
-
-        return cls.objects.filter(path__descendants=parent.path)
-
-    @classmethod
-    def get_root_nodes(cls):
-        """:returns: A queryset containing the root nodes in the tree."""
-        return cls.tree_model().objects.filter(path__depth=1).order_by("path")
-
-    @classmethod
-    def get_descendants_group_count(cls, parent=None):
-        """
-        Helper for a very common case: get a group of siblings and the number
-        of *descendants* (not only children) in every sibling.
-
-        :param parent:
-
-            The parent of the siblings to return. If no parent is given, the
-            root nodes will be returned.
-
-        :returns:
-
-            A Queryset of node objects with an extra attribute: `descendants_count`.
-        """
-        cls = cls.tree_model()
-        qs = parent.get_children() if parent else cls.get_root_nodes()
-        subquery = (
-            cls.objects.filter(path__descendants=OuterRef("path"))
-            .order_by()
-            .annotate(count=Func(F("pk"), function="Count"))
-            .values("count")
-        )
-        return qs.annotate(
-            descendants_count=Subquery(subquery, output_field=models.IntegerField()) - 1
-        )  # Subtract the parent node from the count
-
     def get_depth(self):
         """:returns: the depth (level) of the node"""
         return len(self.path)
-
-    def get_siblings(self):
-        """
-        :returns: A queryset of all the node's siblings, including the node
-            itself.
-        """
-        return self.tree_model().objects.filter(path__descendants=self.path[:-1], path__depth=len(self.path))
-
-    def get_children(self):
-        """:returns: A queryset of all the node's children"""
-        return self.tree_model().objects.filter(path__descendants=self.path, path__depth=len(self.path) + 1)
-
-    def get_next_sibling(self):
-        """
-        :returns: The next node's sibling, or None if it was the rightmost
-            sibling.
-        """
-        return self.get_siblings().filter(path__gt=self.path).first()
-
-    def get_descendants(self, include_self=False):
-        """
-        :returns: A queryset of all the node's descendants as DFS, doesn't
-            include the node itself if `include_self` is False
-        """
-        if include_self:
-            return self.__class__.get_tree(self)
-
-        return self.__class__.get_tree(self).exclude(pk=self.pk)
-
-    def get_prev_sibling(self):
-        """
-        :returns: The previous node's sibling, or None if it was the leftmost
-            sibling.
-        """
-        return self.get_siblings().filter(path__lt=self.path).last()
-
-    def get_children_count(self):
-        """
-        :returns: The number the node's children, calculated in the most
-        efficient possible way.
-        """
-        return self.get_children().count()
 
     def is_sibling_of(self, node) -> bool:
         """
@@ -594,85 +564,13 @@ class LT_Node(Node):
         """
         return len(self.path) > len(node.path) and all([self.path[idx] == label for idx, label in enumerate(node.path)])
 
-    @transaction.atomic
-    def add_child(self, **kwargs):
-        """
-        Adds a child to the node.
-
-        This method saves the node in database. The object is populated as if via:
-
-        ```
-        obj = self.__class__(**kwargs)
-        ```
-        """
-        return LT_AddChildHandler(self, kwargs).process()
-
-    @transaction.atomic
-    def add_sibling(self, pos=None, **kwargs):
-        """
-        Adds a new node as a sibling to the current node object.
-
-        This method saves the node in database. The object is populated as if via:
-
-        ```
-        obj = self.__class__(**kwargs)
-        ```
-        """
-        return LT_AddSiblingHandler(self, pos, kwargs).process()
-
-    def get_root(self):
-        """:returns: the root node for the current node object."""
-        return self.tree_model().objects.get(path=self.path[0])
-
     def is_root(self):
         """:returns: True if the node is a root node (else, returns False)"""
         return len(self.path) == 1
 
     def is_leaf(self):
         """:returns: True if the node is a leaf node (else, returns False)"""
-        return not self.get_children().exists()
-
-    def get_ancestors(self):
-        """
-        :returns: A queryset containing the current node object's ancestors,
-            starting by the root node and descending to the parent.
-        """
-        return self.tree_model().objects.filter(path__ancestors=self.path).exclude(pk=self.pk)
-
-    def get_parent(self, update=False):
-        """
-        :returns: the parent node of the current node object.
-        """
-        if len(self.path) == 1:
-            return
-
-        parentpath = self.path[:-1]
-        return self.tree_model().objects.get(path=parentpath)
-
-    @transaction.atomic
-    def move(self, target, pos=None):
-        """
-        Moves the current node and all it's descendants to a new position
-        relative to another node.
-        """
-        return LT_MoveHandler(self, target, pos).process()
-
-    @classmethod
-    def check(cls, **kwargs):
-        errors = super().check(**kwargs)
-        manager_cls = cls._default_manager.__class__
-        # Raise a warning if the default manager for the model doesn't subclass LT_NodeManager
-        # This will allow us to move class-level methods into the manager in future (see issue #44)
-        if not issubclass(manager_cls, LT_NodeManager):
-            errors.append(
-                checks.Warning(
-                    f"{manager_cls.__module__}.{manager_cls.__name__} does not subclass "
-                    "treebeard.ltree.LT_NodeManager. This will cause an error in Treebeard 6.",
-                    obj=manager_cls,
-                    id="treebeard.E001",
-                )
-            )
-        return errors
+        return not self.__class__.objects.get_children(self).exists()
 
     class Meta:
         abstract = True

--- a/treebeard/models.py
+++ b/treebeard/models.py
@@ -3,11 +3,14 @@
 import operator
 import warnings
 from contextlib import suppress
-from functools import cache, reduce
+from functools import reduce
 
+from django.core import checks
 from django.db import models, transaction
 from django.db.models import Q
+from django.utils.functional import cached_property
 
+from treebeard.deprecation import RemovedInTreebeard7Warning, get_moved_manager_classmethod, get_moved_manager_method
 from treebeard.exceptions import InvalidPosition, MissingNodeOrderBy
 from treebeard.utils import prepare_dumpdata_for_loading, save_m2m
 
@@ -22,17 +25,201 @@ class Node(models.Model):
     MOVENODE_FORM_EXCLUDED_FIELDS = ()
     _cached_attributes = ()
 
+    def get_depth(self):  # pragma: no cover
+        """:returns: the depth (level) of the node"""
+        raise NotImplementedError
+
+    def is_root(self):
+        """:returns: True if the node is a root node (else, returns False)"""
+        raise NotImplementedError
+
+    def is_leaf(self):
+        """:returns: True if the node is a leaf node (else, returns False)"""
+        return not self.__class__.objects.get_children(self).exists()
+
+    def is_sibling_of(self, node):
+        """
+        :returns: ``True`` if the node is a sibling of the supplied node, otherwise ``False``
+        """
+        return self.__class__.objects.get_siblings(self).filter(pk=node.pk).exists()
+
+    def is_child_of(self, node):
+        """
+        :returns: ``True`` if the node is a child of the supplied node, otherwise ``False``
+        """
+        return self.__class__.objects.get_children(node).filter(pk=self.pk).exists()
+
+    def is_descendant_of(self, node):  # pragma: no cover
+        """
+        :returns: ``True`` if the node is a descendant of the supplied node, otherwise ``False``
+        """
+        raise NotImplementedError
+
     @classmethod
-    def add_root(cls, **kwargs):  # pragma: no cover
+    def add_root(cls, **kwargs):
+        warnings.warn(
+            f"Using {cls.__name__}.add_root() is deprecated. Use {cls.__name__}.objects.add_root() instead.",
+            RemovedInTreebeard7Warning,
+            stacklevel=2,
+        )
+        instance = kwargs.pop("instance", None)
+        return cls.objects.add_root(create_kwargs=kwargs, instance=instance)
+
+    def add_child(self, **kwargs):
+        cls = self.__class__
+        warnings.warn(
+            f"Using {cls.__name__}.add_child() is deprecated. Use {cls.__name__}.objects.add_child(target) instead.",
+            RemovedInTreebeard7Warning,
+            stacklevel=2,
+        )
+        instance = kwargs.pop("instance", None)
+        return self.__class__.objects.add_child(self, create_kwargs=kwargs, instance=instance)
+
+    def add_sibling(self, pos=None, **kwargs):  # pragma: no cover
+        cls = self.__class__
+        warnings.warn(
+            f"Using {cls.__name__}.add_sibling() is deprecated. Use {cls.__name__}.objects.add_sibling() instead.",
+            RemovedInTreebeard7Warning,
+            stacklevel=2,
+        )
+        instance = kwargs.pop("instance", None)
+        return self.__class__.objects.add_sibling(self, pos, create_kwargs=kwargs, instance=instance)
+
+    def move(self, target, pos=None):  # pragma: no cover
+        cls = self.__class__
+        warnings.warn(
+            f"Using {cls.__name__}.move() is deprecated. Use {cls.__name__}.objects.move() instead.",
+            RemovedInTreebeard7Warning,
+            stacklevel=2,
+        )
+        return cls.objects.move(self, target, pos)
+
+    def delete(self, *args, **kwargs):
+        """Removes a node and all it's descendants."""
+        # Call the queryset delete method, which handles deletion of descendants
+        return self.__class__.objects.filter(pk=self.pk).delete(*args, **kwargs)
+
+    delete.alters_data = True
+    delete.queryset_only = True
+
+    def _clear_cached_attributes(self):
+        for attr in self._cached_attributes:
+            with suppress(AttributeError):
+                delattr(self, attr)
+
+    def refresh_from_db(self, *args, **kwargs):
+        super().refresh_from_db(*args, **kwargs)
+        self._clear_cached_attributes()
+
+    @classmethod
+    def check(cls, **kwargs):
+        errors = super().check(**kwargs)
+        manager_cls = cls._default_manager.__class__
+        # Raise an error if the default manager for the model doesn't subclass Treebeard's manager
+        if not issubclass(manager_cls, cls._DEFAULT_TREEBEARD_MANAGER):
+            errors.append(
+                checks.Error(
+                    f"{manager_cls.__module__}.{manager_cls.__name__} does not subclass "
+                    f"{cls._DEFAULT_TREEBEARD_MANAGER.__module__}.{cls._DEFAULT_TREEBEARD_MANAGER.__name__}.",
+                    obj=manager_cls,
+                    id="treebeard.E001",
+                )
+            )
+        return errors
+
+    class Meta:
+        """Abstract model."""
+
+        abstract = True
+
+
+# Deprecated class methods that have moved to the model manager. Will be removed in Treebeard 7
+def _inject_moved_method_back_compat():
+    moved_classmethods = [
+        "load_bulk",
+        "dump_bulk",
+        "get_root_nodes",
+        "get_first_root_node",
+        "get_last_root_node",
+        "find_problems",
+        "fix_tree",
+        "get_tree",
+        "get_descendants_group_count",
+        "get_annotated_list_qs",
+        "get_annotated_list",
+    ]
+
+    for method in moved_classmethods:
+        setattr(Node, method, get_moved_manager_classmethod(method))
+
+    moved_methods = [
+        "get_children",
+        "get_children_count",
+        "get_siblings",
+        "get_descendants",
+        "get_descendant_count",
+        "get_first_child",
+        "get_last_child",
+        "get_first_sibling",
+        "get_last_sibling",
+        "get_prev_sibling",
+        "get_next_sibling",
+        "get_root",
+        "get_parent",
+        "get_ancestors",
+    ]
+
+    for method in moved_methods:
+        setattr(Node, method, get_moved_manager_method(method))
+
+
+_inject_moved_method_back_compat()
+
+
+class NodeManager(models.Manager):
+    @cached_property
+    def tree_model(self):
+        """
+        Determine what class we should use for the
+        nodes returned by its tree methods (such as get_children).
+
+        Usually this will be trivially the same as the initial model class,
+        but there are special cases when model inheritance is in use:
+
+        * If the model extends another via multi-table inheritance, we need to
+        use whichever ancestor originally implemented the tree behaviour (i.e.
+        the one which defines the fields used by Treebeard). We can't use the
+        subclass, because it's not guaranteed that the other nodes reachable
+        from the current one will be instances of the same subclass.
+
+        * If the model is a proxy model, the returned nodes should also use
+        the proxy class.
+        """
+        cls = self.model
+        base_class = cls._meta.get_field(cls.TREEBEARD_IDENTIFYING_FIELD).model
+        if cls._meta.proxy_for_model == base_class:
+            return cls
+
+        return base_class
+
+    def get_tree(self, parent=None):  # pragma: no cover
+        """
+        :returns:
+
+            A list of nodes ordered as DFS, including the parent. If
+            no parent is given, the entire tree is returned.
+        """
+        raise NotImplementedError
+
+    def add_root(self, create_kwargs=None, *, instance=None):  # pragma: no cover
         """
         Adds a root node to the tree. The new root node will be the new
         rightmost root node. If you want to insert a root node at a specific
         position, use :meth:`add_sibling` in an already existing root node
         instead.
 
-        :param `**kwargs`: object creation data that will be passed to the
-            inherited Node model
-        :param instance: Instead of passing object creation data, you can
+        :param `create_kwargs`: dictionary of values to set on the model object.
+        :param instance: Instead of passing `create_kwargs`, you can
             pass an already-constructed (but not yet saved) model instance to
             be inserted into the tree.
 
@@ -43,291 +230,14 @@ class Node(models.Model):
         """
         raise NotImplementedError
 
-    @classmethod
-    @transaction.atomic
-    def load_bulk(cls, bulk_data, parent=None, keep_ids=False):
-        """
-        Loads a list/dictionary structure to the tree.
-
-        :param bulk_data:
-
-            The data that will be loaded, the structure is a list of
-            dictionaries with 2 keys:
-
-            - ``data``: will store arguments that will be passed for object
-              creation, and
-
-            - ``children``: a list of dictionaries, each one has it's own
-              ``data`` and ``children`` keys (a recursive structure)
-
-
-        :param parent:
-
-            The node that will receive the structure as children, if not
-            specified the first level of the structure will be loaded as root
-            nodes
-
-        :param keep_ids:
-
-            If enabled, loads the nodes with the same primary keys that are
-            given in the structure. Will error if there are nodes without
-            primary key info or if the primary keys are already used.
-
-        :returns: A list of the added node PKs.
-        """
-
-        # tree, iterative preorder
-        added = []
-        bulk_data = prepare_dumpdata_for_loading(cls, data=bulk_data, keep_ids=keep_ids)
-        # stack of nodes to analyze
-        stack = [(parent, deserialized_obj) for deserialized_obj in bulk_data[::-1]]
-
-        while stack:
-            parent, deserialized_obj = stack.pop()
-            node_obj = deserialized_obj.object = (
-                parent.add_child(instance=deserialized_obj.object)
-                if parent
-                else cls.add_root(instance=deserialized_obj.object)
-            )
-            save_m2m(node_obj, deserialized_obj)
-            added.append(node_obj.pk)
-            # extending the stack with the current node as the parent of the new nodes
-            stack.extend([(node_obj, child) for child in deserialized_obj.children[::-1]])
-        return added
-
-    @classmethod
-    def dump_bulk(cls, parent=None, keep_ids=True):  # pragma: no cover
-        """
-        Dumps a tree branch to a python data structure.
-
-        :param parent:
-
-            The node whose descendants will be dumped. The node itself will be
-            included in the dump. If not given, the entire tree will be dumped.
-
-        :param keep_ids:
-
-            Stores the pk value (primary key) of every node. Enabled by
-            default.
-
-        :returns: A python data structure, described with detail in
-                  :meth:`load_bulk`
-        """
-        raise NotImplementedError
-
-    @classmethod
-    def get_root_nodes(cls):  # pragma: no cover
-        """:returns: A queryset containing the root nodes in the tree."""
-        raise NotImplementedError
-
-    @classmethod
-    def get_first_root_node(cls):
-        """
-        :returns:
-
-            The first root node in the tree or ``None`` if it is empty.
-        """
-        return cls.get_root_nodes().first()
-
-    @classmethod
-    def get_last_root_node(cls):
-        """
-        :returns:
-
-            The last root node in the tree or ``None`` if it is empty.
-        """
-        return cls.get_root_nodes().last()
-
-    @classmethod
-    def find_problems(cls, parent=None):  # pragma: no cover
-        """Checks for problems in the tree structure.
-
-        :param parent:
-
-            If provided, limits the check to the descendants of this node.
-            If not provided, the entire tree will be checked.
-        """
-        raise NotImplementedError
-
-    @classmethod
-    def fix_tree(cls):  # pragma: no cover
-        """
-        Solves problems that can appear when transactions are not used and
-        a piece of code breaks, leaving the tree in an inconsistent state.
-        """
-        raise NotImplementedError
-
-    @classmethod
-    def get_tree(cls, parent=None):
-        """
-        :returns:
-
-            A list of nodes ordered as DFS, including the parent. If
-            no parent is given, the entire tree is returned.
-        """
-        raise NotImplementedError
-
-    @classmethod
-    def get_descendants_group_count(cls, parent=None):
-        """
-        Helper for a very common case: get a group of siblings and the number
-        of *descendants* (not only children) in every sibling.
-
-        :param parent:
-
-            The parent of the siblings to return. If no parent is given, the
-            root nodes will be returned.
-
-        :returns:
-
-            A `list` (**NOT** a Queryset) of node objects with an extra
-            attribute: `descendants_count`.
-        """
-        if parent is None:
-            qset = cls.get_root_nodes()
-        else:
-            qset = parent.get_children()
-        nodes = list(qset)
-        for node in nodes:
-            node.descendants_count = node.get_descendant_count()
-        return nodes
-
-    def get_depth(self):  # pragma: no cover
-        """:returns: the depth (level) of the node"""
-        raise NotImplementedError
-
-    def get_siblings(self):  # pragma: no cover
-        """
-        :returns:
-
-            A queryset of all the node's siblings, including the node
-            itself.
-        """
-        raise NotImplementedError
-
-    def get_children(self):  # pragma: no cover
-        """:returns: A queryset of all the node's children"""
-        raise NotImplementedError
-
-    def get_children_count(self):
-        """:returns: The number of the node's children"""
-        return self.get_children().count()
-
-    def get_descendants(self):
-        """
-        :returns:
-
-            A queryset of all the node's descendants, doesn't
-            include the node itself (some subclasses may return a list).
-        """
-        raise NotImplementedError
-
-    def get_descendant_count(self):
-        """:returns: the number of descendants of a node."""
-        return self.get_descendants().count()
-
-    def get_first_child(self):
-        """
-        :returns:
-
-            The leftmost node's child, or None if it has no children.
-        """
-        return self.get_children().first()
-
-    def get_last_child(self):
-        """
-        :returns:
-
-            The rightmost node's child, or None if it has no children.
-        """
-        return self.get_children().last()
-
-    def get_first_sibling(self):
-        """
-        :returns:
-
-            The leftmost node's sibling, can return the node itself if
-            it was the leftmost sibling.
-        """
-        return self.get_siblings().first()
-
-    def get_last_sibling(self):
-        """
-        :returns:
-
-            The rightmost node's sibling, can return the node itself if
-            it was the rightmost sibling.
-        """
-        return self.get_siblings().last()
-
-    def get_prev_sibling(self):
-        """
-        :returns:
-
-            The previous node's sibling, or None if it was the leftmost
-            sibling.
-        """
-        ids = list(self.get_siblings().values_list("pk", flat=True))
-        idx = ids.index(self.pk)
-        if idx > 0:
-            return self.get_siblings().get(pk=ids[idx - 1])
-
-    def get_next_sibling(self):
-        """
-        :returns:
-
-            The next node's sibling, or None if it was the rightmost
-            sibling.
-        """
-        ids = list(self.get_siblings().values_list("pk", flat=True))
-        idx = ids.index(self.pk)
-        if idx < len(ids) - 1:
-            return self.get_siblings().get(pk=ids[idx + 1])
-
-    def is_sibling_of(self, node):
-        """
-        :returns: ``True`` if the node is a sibling of another node given as an
-            argument, else, returns ``False``
-
-        :param node:
-
-            The node that will be checked as a sibling
-        """
-        return self.get_siblings().filter(pk=node.pk).exists()
-
-    def is_child_of(self, node):
-        """
-        :returns: ``True`` if the node is a child of another node given as an
-            argument, else, returns ``False``
-
-        :param node:
-
-            The node that will be checked as a parent
-        """
-        return node.get_children().filter(pk=self.pk).exists()
-
-    def is_descendant_of(self, node):  # pragma: no cover
-        """
-        :returns: ``True`` if the node is a descendant of another node given
-            as an argument, else, returns ``False``
-
-        :param node:
-
-            The node that will be checked as an ancestor
-        """
-        raise NotImplementedError
-
-    def add_child(self, **kwargs):  # pragma: no cover
+    def add_child(self, target, create_kwargs=None, *, instance=None):  # pragma: no cover
         """
         Adds a child to the node. The new node will be the new rightmost
         child. If you want to insert a node at a specific position,
         use the :meth:`add_sibling` method of an already existing
         child node instead.
 
-        :param `**kwargs`:
-
-            Object creation data that will be passed to the inherited Node
-            model
+        :param `create_kwargs`: dictionary of values to set on the model object.
         :param instance: Instead of passing object creation data, you can
             pass an already-constructed (but not yet saved) model instance to
             be inserted into the tree.
@@ -339,10 +249,9 @@ class Node(models.Model):
         """
         raise NotImplementedError
 
-    def add_sibling(self, pos=None, **kwargs):  # pragma: no cover
+    def add_sibling(self, target, pos=None, create_kwargs=None, *, instance=None):  # pragma: no cover
         """
         Adds a new node as a sibling to the current node object.
-
 
         :param pos:
             The position, relative to the current node object, where the
@@ -356,10 +265,7 @@ class Node(models.Model):
             - ``sorted-sibling``: the new node will be at the right position
               according to the value of node_order_by
 
-        :param `**kwargs`:
-
-            Object creation data that will be passed to the inherited
-            Node model
+        :param `create_kwargs`: dictionary of values to set on the model object.
         :param instance: Instead of passing object creation data, you can
             pass an already-constructed (but not yet saved) model instance to
             be inserted into the tree.
@@ -378,41 +284,13 @@ class Node(models.Model):
         """
         raise NotImplementedError
 
-    def get_root(self):  # pragma: no cover
-        """:returns: the root node for the current node object."""
-        raise NotImplementedError
-
-    def is_root(self):
-        """:returns: True if the node is a root node (else, returns False)"""
-        raise NotImplementedError
-
-    def is_leaf(self):
-        """:returns: True if the node is a leaf node (else, returns False)"""
-        return not self.get_children().exists()
-
-    def get_ancestors(self):  # pragma: no cover
+    def move(self, node, target, pos=None):  # pragma: no cover
         """
-        :returns:
+        Moves a node and all it's descendants to a new position relative to another node.
 
-            A queryset containing the current node object's ancestors,
-            starting by the root node and descending to the parent.
-            (some subclasses may return a list)
-        """
-        raise NotImplementedError
+        :param node:
 
-    def get_parent(self, update=False):  # pragma: no cover
-        """
-        :returns: the parent node of the current node object.
-            Caches the result in the object itself to help in loops.
-
-        :param update: Updates the cached value.
-        """
-        raise NotImplementedError
-
-    def move(self, target, pos=None):  # pragma: no cover
-        """
-        Moves the current node and all it's descendants to a new position
-        relative to another node.
+            The node to move.
 
         :param target:
 
@@ -461,26 +339,293 @@ class Node(models.Model):
         """
         raise NotImplementedError
 
-    def delete(self, *args, **kwargs):
-        """Removes a node and all it's descendants."""
-        return self.__class__.objects.filter(pk=self.pk).delete(*args, **kwargs)
+    def get_root_nodes(self):  # pragma: no cover
+        """:returns: A queryset containing the root nodes in the tree."""
+        raise NotImplementedError
 
-    delete.alters_data = True
-    delete.queryset_only = True
+    def get_first_root_node(self):
+        """
+        :returns:
+
+            The first root node in the tree or ``None`` if it is empty.
+        """
+        return self.get_root_nodes().first()
+
+    def get_last_root_node(self):
+        """
+        :returns:
+
+            The last root node in the tree or ``None`` if it is empty.
+        """
+        return self.get_root_nodes().last()
+
+    def get_descendants_group_count(self, parent=None):
+        """
+        Helper for a very common case: get a group of siblings and the number
+        of *descendants* (not only children) in every sibling.
+
+        :param parent:
+
+            The parent of the siblings to return. If no parent is given, the
+            root nodes will be returned.
+
+        :returns:
+
+            A `list` (**NOT** a Queryset) of node objects with an extra
+            attribute: `descendants_count`.
+        """
+        if parent is None:
+            qset = self.get_root_nodes()
+        else:
+            qset = self.get_children(parent)
+        nodes = list(qset)
+        for node in nodes:
+            node.descendants_count = self.get_descendant_count(node)
+        return nodes
+
+    def get_annotated_list_qs(self, qs):
+        """
+        Efficiently generates an annotated list from a queryset.
+
+        The queryset MUST be ordered by path, otherwise it will yield
+        incorrect results. The queryset must also represent the entirety of
+        a branch of a tree: excluded objects will not be fetched and will
+        result in gaps in the tree.
+        """
+        result, info = [], {}
+        start_depth, prev_depth = (None, None)
+        for node in qs:
+            depth = node.get_depth()
+            if start_depth is None:
+                start_depth = depth
+            open = depth and (prev_depth is None or depth > prev_depth)
+            if prev_depth is not None and depth < prev_depth:
+                info["close"] = list(range(0, prev_depth - depth))
+            info = {"open": open, "close": [], "level": depth - start_depth}
+            result.append(
+                (
+                    node,
+                    info,
+                )
+            )
+            prev_depth = depth
+        if start_depth and start_depth > 0:
+            info["close"] = list(range(0, prev_depth - start_depth + 1))
+        return result
+
+    def get_annotated_list(self, parent=None, max_depth=None):
+        """
+        Gets an annotated list from a tree branch.
+
+        :param parent:
+
+            The node whose descendants will be annotated. The node itself
+            will be included in the list. If not given, the entire tree
+            will be annotated.
+
+        :param max_depth:
+
+            Optionally limit to specified depth
+        """
+        qs = self.get_tree(parent)
+        if max_depth:
+            qs = qs.filter(depth__lte=max_depth)
+        return self.get_annotated_list_qs(qs)
+
+    @transaction.atomic
+    def load_bulk(self, bulk_data, parent=None, keep_ids=False):
+        """
+        Loads a list/dictionary structure to the tree.
+
+        :param bulk_data:
+
+            The data that will be loaded, the structure is a list of
+            dictionaries with 2 keys:
+
+            - ``data``: will store arguments that will be passed for object
+              creation, and
+
+            - ``children``: a list of dictionaries, each one has it's own
+              ``data`` and ``children`` keys (a recursive structure)
+
+
+        :param parent:
+
+            The node that will receive the structure as children, if not
+            specified the first level of the structure will be loaded as root
+            nodes
+
+        :param keep_ids:
+
+            If enabled, loads the nodes with the same primary keys that are
+            given in the structure. Will error if there are nodes without
+            primary key info or if the primary keys are already used.
+
+        :returns: A list of the added node PKs.
+        """
+
+        # tree, iterative preorder
+        added = []
+        bulk_data = prepare_dumpdata_for_loading(self.model, data=bulk_data, keep_ids=keep_ids)
+        # stack of nodes to analyze
+        stack = [(parent, deserialized_obj) for deserialized_obj in bulk_data[::-1]]
+
+        while stack:
+            parent, deserialized_obj = stack.pop()
+            node_obj = deserialized_obj.object = (
+                self.add_child(parent, instance=deserialized_obj.object)
+                if parent
+                else self.add_root(instance=deserialized_obj.object)
+            )
+            save_m2m(node_obj, deserialized_obj)
+            added.append(node_obj.pk)
+            # extending the stack with the current node as the parent of the new nodes
+            stack.extend([(node_obj, child) for child in deserialized_obj.children[::-1]])
+        return added
+
+    def dump_bulk(self, parent=None, keep_ids=True):  # pragma: no cover
+        """
+        Dumps a tree branch to a python data structure.
+
+        :param parent:
+
+            The node whose descendants will be dumped. The node itself will be
+            included in the dump. If not given, the entire tree will be dumped.
+
+        :param keep_ids:
+
+            Stores the pk value (primary key) of every node. Enabled by
+            default.
+
+        :returns: A python data structure, described with detail in
+                  :meth:`load_bulk`
+        """
+        raise NotImplementedError
+
+    def get_children(self, node):  # pragma: no cover
+        """:returns: A queryset of all the node's children"""
+        raise NotImplementedError
+
+    def get_children_count(self, node):
+        """:returns: The number of the node's children"""
+        return self.get_children(node).count()
+
+    def get_siblings(self, node):  # pragma: no cover
+        """
+        :returns:
+
+            A queryset of all the node's siblings, including the node
+            itself.
+        """
+        raise NotImplementedError
+
+    def get_descendants(self, node, include_self=False):
+        """
+        :returns:
+
+            A queryset of all the node's descendants, doesn't
+            include the node itself if include_self is False.
+        """
+        raise NotImplementedError
+
+    def get_descendant_count(self, node):
+        """:returns: the number of descendants of a node."""
+        return self.get_descendants(node).count()
+
+    def get_first_child(self, node):
+        """
+        :returns:
+
+            The node's leftmost child, or None if it has no children.
+        """
+        return self.get_children(node).first()
+
+    def get_last_child(self, node):
+        """
+        :returns:
+
+            The node's rightmost child, or None if it has no children.
+        """
+        return self.get_children(node).last()
+
+    def get_first_sibling(self, node):
+        """
+        :returns:
+
+            The node's leftmost sibling. Can return the node itself if
+            it was the leftmost sibling.
+        """
+        return self.get_siblings(node).first()
+
+    def get_last_sibling(self, node):
+        """
+        :returns:
+
+            The rightmost node's sibling, can return the node itself if
+            it was the rightmost sibling.
+        """
+        return self.get_siblings(node).last()
+
+    def get_prev_sibling(self, node):
+        """
+        :returns:
+
+            The node's previous sibling, or None if it was the leftmost
+            sibling.
+        """
+        ids = list(self.get_siblings(node).values_list("pk", flat=True))
+        idx = ids.index(node.pk)
+        if idx > 0:
+            return self.get_siblings(node).get(pk=ids[idx - 1])
+
+    def get_next_sibling(self, node):
+        """
+        :returns:
+
+            The next node's sibling, or None if it was the rightmost
+            sibling.
+        """
+        ids = list(self.get_siblings(node).values_list("pk", flat=True))
+        idx = ids.index(node.pk)
+        if idx < len(ids) - 1:
+            return self.get_siblings(node).get(pk=ids[idx + 1])
+
+    def get_root(self, node):  # pragma: no cover
+        """:returns: the root node for supplied node object."""
+        raise NotImplementedError
+
+    def get_parent(self, node, update=False):  # pragma: no cover
+        """
+        :returns: the parent node of the supplied node object.
+            Caches the result in the object itself to help in loops.
+
+        :param update: Updates the cached value.
+        """
+        raise NotImplementedError
+
+    def get_ancestors(self, node):  # pragma: no cover
+        """
+        :returns:
+
+            A queryset containing the node's ancestors,
+            starting by the root node and descending to the parent.
+            (some subclasses may return a list)
+        """
+        raise NotImplementedError
 
     def _prepare_pos_var(self, pos, method_name, valid_pos, valid_sorted_pos):
         if pos is None:
-            if self.node_order_by:
+            if self.model.node_order_by:
                 pos = "sorted-sibling"
             else:
                 pos = "last-sibling"
         if pos not in valid_pos:
             raise InvalidPosition(f"Invalid relative position: {pos}")
-        if self.node_order_by and pos not in valid_sorted_pos:
+        if self.model.node_order_by and pos not in valid_sorted_pos:
             raise InvalidPosition(
                 f"Must use {' or '.join(valid_sorted_pos)} in {method_name} when node_order_by is enabled"
             )
-        if pos in valid_sorted_pos and not self.node_order_by:
+        if pos in valid_sorted_pos and not self.model.node_order_by:
             raise MissingNodeOrderBy("Missing node_order_by attribute.")
         return pos
 
@@ -513,7 +658,7 @@ class Node(models.Model):
         """
 
         fields, filters = [], []
-        for field in self.node_order_by:
+        for field in self.model.node_order_by:
             comparator = "gt"
             if field.startswith("-"):
                 field = field[1:]
@@ -523,7 +668,7 @@ class Node(models.Model):
             if value is None:
                 warnings.warn(
                     f"Received a null value for field '{field}', which is used "
-                    f"by '{self.__class__.__name__}.node_order_by'. "
+                    f"by '{self.model.__name__}.node_order_by'. "
                     "This field will be ignored when sorting the object.",
                     category=RuntimeWarning,
                 )
@@ -536,93 +681,3 @@ class Node(models.Model):
             return siblings
 
         return siblings.filter(reduce(operator.or_, filters))
-
-    def _clear_cached_attributes(self):
-        for attr in self._cached_attributes:
-            with suppress(AttributeError):
-                delattr(self, attr)
-
-    def refresh_from_db(self, *args, **kwargs):
-        super().refresh_from_db(*args, **kwargs)
-        self._clear_cached_attributes()
-
-    @classmethod
-    def get_annotated_list_qs(cls, qs):
-        """
-        Efficiently generates an annotated list from a queryset.
-
-        The queryset MUST be ordered by path, otherwise it will yield
-        incorrect results. The queryset must also represent the entirety of
-        a branch of a tree: excluded objects will not be fetched and will
-        result in gaps in the tree.
-        """
-        result, info = [], {}
-        start_depth, prev_depth = (None, None)
-        for node in qs:
-            depth = node.get_depth()
-            if start_depth is None:
-                start_depth = depth
-            open = depth and (prev_depth is None or depth > prev_depth)
-            if prev_depth is not None and depth < prev_depth:
-                info["close"] = list(range(0, prev_depth - depth))
-            info = {"open": open, "close": [], "level": depth - start_depth}
-            result.append(
-                (
-                    node,
-                    info,
-                )
-            )
-            prev_depth = depth
-        if start_depth and start_depth > 0:
-            info["close"] = list(range(0, prev_depth - start_depth + 1))
-        return result
-
-    @classmethod
-    def get_annotated_list(cls, parent=None, max_depth=None):
-        """
-        Gets an annotated list from a tree branch.
-
-        :param parent:
-
-            The node whose descendants will be annotated. The node itself
-            will be included in the list. If not given, the entire tree
-            will be annotated.
-
-        :param max_depth:
-
-            Optionally limit to specified depth
-        """
-        qs = cls.get_tree(parent)
-        if max_depth:
-            qs = qs.filter(depth__lte=max_depth)
-        return cls.get_annotated_list_qs(qs)
-
-    @classmethod
-    @cache
-    def tree_model(cls):
-        """
-        Determine what class we should use for the
-        nodes returned by its tree methods (such as get_children).
-
-        Usually this will be trivially the same as the initial model class,
-        but there are special cases when model inheritance is in use:
-
-        * If the model extends another via multi-table inheritance, we need to
-        use whichever ancestor originally implemented the tree behaviour (i.e.
-        the one which defines the fields used by Treebeard). We can't use the
-        subclass, because it's not guaranteed that the other nodes reachable
-        from the current one will be instances of the same subclass.
-
-        * If the model is a proxy model, the returned nodes should also use
-        the proxy class.
-        """
-        base_class = cls._meta.get_field(cls.TREEBEARD_IDENTIFYING_FIELD).model
-        if cls._meta.proxy_for_model == base_class:
-            return cls
-
-        return base_class
-
-    class Meta:
-        """Abstract model."""
-
-        abstract = True

--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -1,20 +1,22 @@
 """Materialized Path Trees"""
 
 import collections
+import warnings
 from functools import cache
 from typing import Any
 
-from django.core import checks, serializers
+from django.core import serializers
 from django.db import connections, models, router, transaction
 from django.db.models import F, Func, OuterRef, Q, Subquery, Value
 from django.db.models.functions import Concat, Greatest, Length, Substr
 from django.dispatch import Signal
 from django.utils.translation import gettext_noop as _
 
-from treebeard.exceptions import InvalidMoveToDescendant, NodeAlreadySaved, PathOverflow
-from treebeard.models import Node
+from treebeard.deprecation import RemovedInTreebeard7Warning
+from treebeard.exceptions import InvalidMoveToDescendant, PathOverflow
+from treebeard.models import Node, NodeManager
 from treebeard.numconv import NumConv
-from treebeard.utils import prepare_dumpdata_for_loading, save_m2m
+from treebeard.utils import check_create_args, prepare_dumpdata_for_loading, save_m2m
 
 path_updated = Signal()
 nodes_deleted = Signal()
@@ -65,7 +67,7 @@ class MP_NodeQuerySet(models.query.QuerySet):
             else:
                 paths_to_remove.append(node.path)
 
-        model = self.model.tree_model()
+        model = self.model.objects.tree_model
 
         # Save the updated numchild of all parents
         for path, num_lost in parents.items():
@@ -87,563 +89,30 @@ class MP_NodeQuerySet(models.query.QuerySet):
     delete.queryset_only = True
 
 
-class MP_NodeManager(models.Manager):
+class MP_NodeManager(NodeManager):
     """Custom manager for nodes in a Materialized Path tree."""
 
     def get_queryset(self):
         """Sets the custom queryset as the default."""
         return MP_NodeQuerySet(self.model, using=self._db).order_by("path")
 
-
-class MP_ComplexAddMoveHandler:
-    def increment_numchild(self, path):
-        self.node_cls.tree_model().objects.filter(path=path).update(numchild=F("numchild") + 1)
-
-    def decrement_numchild(self, path):
-        self.node_cls.tree_model().objects.filter(path=path).update(numchild=F("numchild") - 1)
-
-    def reorder_nodes_before_add_or_move(self, pos, newpos, newdepth, target, siblings, oldpath=None, movebranch=False):
+    def get_tree(self, parent=None):
         """
-        Handles the reordering of nodes and branches when adding/moving
-        nodes.
+        :returns:
 
-        :returns: A tuple containing the old path and the new path.
+            A *queryset* of nodes ordered as DFS, including the parent.
+            If no parent is given, the entire tree is returned.
         """
-        if (pos == "last-sibling") or (pos == "right" and target == target.get_last_sibling()):
-            # easy, the last node
-            last = target.get_last_sibling()
-            newpath = last._inc_path()
-            if movebranch:
-                self.set_newpath_in_branches(oldpath, newpath)
-            return oldpath, newpath
-
-        if newpos is None:
-            siblings = target.get_siblings()
-            siblings = {
-                "left": siblings.filter(path__gte=target.path),
-                "right": siblings.filter(path__gt=target.path),
-                "first-sibling": siblings,
-            }[pos]
-            basenum = target._get_lastpos_in_path()
-            newpos = {"first-sibling": 1, "left": basenum, "right": basenum + 1}[pos]
-
-        newpath = self.node_cls._get_path(target.path, newdepth, newpos)
-
-        # If the move is amongst siblings and is to the left and there
-        # are siblings to the right of its new position then to be on
-        # the safe side we temporarily dump it on the end of the list
-        tempnewpath = None
-        if movebranch and len(oldpath) == len(newpath):
-            parentoldpath = self.node_cls._get_basepath(oldpath, int(len(oldpath) / self.node_cls.steplen) - 1)
-            parentnewpath = self.node_cls._get_basepath(newpath, newdepth - 1)
-            if parentoldpath == parentnewpath and siblings and newpath < oldpath:
-                last = target.get_last_sibling()
-                basenum = last._get_lastpos_in_path()
-                tempnewpath = self.node_cls._get_path(newpath, newdepth, basenum + 2)
-                self.set_newpath_in_branches(oldpath, tempnewpath)
-
-        # Optimisation to only move siblings which need moving
-        # (i.e. if we've got holes, allow them to compress)
-        movesiblings = []
-        priorpath = newpath
-        for node in siblings:
-            # If the path of the node is already greater than the path
-            # of the previous node it doesn't need shifting
-            if node.path > priorpath:
-                break
-            # It does need shifting, so add to the list
-            movesiblings.append(node)
-            # Calculate the path that it would be moved to, as that's
-            # the next "priorpath"
-            priorpath = node._inc_path()
-        movesiblings.reverse()
-
-        for node in movesiblings:
-            # moving the siblings (and their branches) at the right of the
-            # related position one step to the right
-            _inc_path = node._inc_path()
-            self.set_newpath_in_branches(node.path, node._inc_path())
-
-            if movebranch:
-                if oldpath.startswith(node.path):
-                    # if moving to a parent, update oldpath since we just
-                    # increased the path of the entire branch
-                    oldpath = _inc_path + oldpath[len(_inc_path) :]
-                if target.path.startswith(node.path):
-                    # and if we moved the target, update the object
-                    # django made for us, since the update won't do it
-                    # maybe useful in loops
-                    target.path = _inc_path + target.path[len(_inc_path) :]
-        if movebranch:
-            # node to move
-            self.set_newpath_in_branches(tempnewpath or oldpath, newpath)
-        return oldpath, newpath
-
-    def set_newpath_in_branches(self, oldpath, newpath):
-        """
-        .. note::
-
-           The query will only update depth values if needed.
-
-        """
-
-        new_path_value = Concat(Value(newpath), Substr("path", len(oldpath) + 1))
-        update_kwargs = {}
-
-        # Warning: MySQL processes multiple assigments left to right, using the updated value
-        # for any column that is referenced in a subsequent assignment. This behavior differs from standard SQL.
-        # See https://dev.mysql.com/doc/refman/8.4/en/update.html
-        # For a table with schema name (VARCHAR), length (INT) and row (name="bob", length=3), the query:
-        # `UPDATE table SET name='alice', length=LENGTH(name);`
-        # would set `length` to 5 in MySQL, but 3 on other databases, because they use the original source value.
-        # To avoid having to special case for MySQL, we need to supply the depth as the first parameter to
-        # update_kwargs.
-
-        if len(oldpath) != len(newpath):
-            update_kwargs["depth"] = Length(new_path_value) / self.node_cls.steplen
-        update_kwargs["path"] = new_path_value
-
-        model = self.node_cls.tree_model()
-        queryset = model.objects.filter(path__startswith=oldpath)
-        update_count = queryset.update(**update_kwargs)
-        if update_count > 0:
-            path_updated.send(sender=model, old_path=oldpath, new_path=newpath, using=queryset.db)
-
-
-class MP_AddRootHandler:
-    def __init__(self, cls, **kwargs):
-        super().__init__()
-        self.cls = cls
-        self.kwargs = kwargs
-
-    def process(self):
-        # do we have a root node already?
-        last_root = self.cls.get_last_root_node()
-
-        if last_root and last_root.node_order_by:
-            # There are root nodes and node_order_by has been set.
-            # Delegate sorted insertion to add_sibling.
-            # We must pass an instance here to ensure that the right object is created for
-            # models with multi-table inheritance.
-            return last_root.add_sibling(
-                "sorted-sibling", instance=self.kwargs.get("instance") or self.cls(**self.kwargs)
-            )
-
-        if last_root:
-            # adding the new root node as the last one
-            newpath = last_root._inc_path()
-        else:
-            # adding the first root node
-            newpath = self.cls._get_path(None, 1, 1)
-
-        if len(self.kwargs) == 1 and "instance" in self.kwargs:
-            # adding the passed (unsaved) instance to the tree
-            newobj = self.kwargs["instance"]
-            if not newobj._state.adding:
-                raise NodeAlreadySaved("Attempted to add a tree node that is already in the database")
-        else:
-            # creating the new object
-            newobj = self.cls(**self.kwargs)
-
-        newobj.depth = 1
-        newobj.path = newpath
-        # saving the instance before returning it
-        newobj.save()
-        return newobj
-
-
-class MP_AddChildHandler:
-    def __init__(self, node, creation_kwargs: dict[str, Any]):
-        super().__init__()
-        self.node = node
-        self.node_cls = node.__class__
-        # These are deliberately not extracted in the function signature to avoid collision with model field names
-        self.kwargs = creation_kwargs
-
-    def process(self):
-        # Lock the parent row
-        node = self.node_cls.objects.select_for_update().get(pk=self.node.pk)
-        if self.node_cls.node_order_by and not node.is_leaf():
-            # there are child nodes and node_order_by has been set
-            # delegate sorted insertion to add_sibling
-            self.node.numchild += 1
-            return node.get_last_child().add_sibling("sorted-sibling", **self.kwargs)
-
-        if len(self.kwargs) == 1 and "instance" in self.kwargs:
-            # adding the passed (unsaved) instance to the tree
-            newobj = self.kwargs["instance"]
-            if not newobj._state.adding:
-                raise NodeAlreadySaved("Attempted to add a tree node that is already in the database")
-        else:
-            # creating a new object
-            newobj = self.node_cls(**self.kwargs)
-
-        newobj.depth = node.depth + 1
-        if node.is_leaf():
-            # the node had no children, adding the first child
-            newobj.path = self.node_cls._get_path(node.path, newobj.depth, 1)
-            max_length = self.node_cls._meta.get_field("path").max_length
-            if len(newobj.path) > max_length:
-                raise PathOverflow(
-                    _(
-                        "The new node is too deep in the tree, try"
-                        " increasing the path.max_length property"
-                        " and UPDATE your database"
-                    )
-                )
-        else:
-            # adding the new child as the last one
-            newobj.path = node.get_last_child()._inc_path()
-
-        # Increment numchild on the parent, and also update the object in memory in case the caller reuses it
-        self.node_cls.tree_model().objects.filter(pk=node.pk).update(numchild=F("numchild") + 1)
-        self.node.numchild = node.numchild + 1
-
-        # saving the instance before returning it
-        newobj._cached_parent_obj = self.node
-        newobj.save()
-
-        return newobj
-
-
-class MP_AddSiblingHandler(MP_ComplexAddMoveHandler):
-    def __init__(self, node, pos, creation_kwargs: dict[str, Any]):
-        super().__init__()
-        self.node = node
-        self.node_cls = node.__class__
-        self.pos = pos
-        # These are deliberately not extracted in the function signature to avoid collision with model field names
-        self.kwargs = creation_kwargs
-
-    def process(self):
-        self.pos = self.node._prepare_pos_var_for_add_sibling(self.pos)
-
-        if len(self.kwargs) == 1 and "instance" in self.kwargs:
-            # adding the passed (unsaved) instance to the tree
-            newobj = self.kwargs["instance"]
-            if not newobj._state.adding:
-                raise NodeAlreadySaved("Attempted to add a tree node that is already in the database")
-        else:
-            # creating a new object
-            newobj = self.node_cls(**self.kwargs)
-
-        newobj.depth = self.node.depth
-
-        if self.pos == "sorted-sibling":
-            siblings = self.node.get_sorted_pos_queryset(self.node.get_siblings(), newobj)
-            first = siblings.first()
-            newpos = first._get_lastpos_in_path() if first else None
-            if newpos is None:
-                self.pos = "last-sibling"
-        else:
-            newpos, siblings = None, []
-
-        _, newpath = self.reorder_nodes_before_add_or_move(
-            self.pos, newpos, self.node.depth, self.node, siblings, None, False
-        )
-
-        parentpath = self.node._get_basepath(newpath, self.node.depth - 1)
-
-        if parentpath:
-            self.increment_numchild(parentpath)
-
-        # saving the instance before returning it
-        newobj.path = newpath
-        newobj.save()
-
-        return newobj
-
-
-class MP_MoveHandler(MP_ComplexAddMoveHandler):
-    def __init__(self, node, target, pos=None):
-        super().__init__()
-        self.node = node
-        self.node_cls = node.__class__
-        self.target = target
-        self.pos = pos
-
-    def process(self):
-        self.pos = self.node._prepare_pos_var_for_move(self.pos)
-
-        # initialize variables and if moving to a child, updates "move to
-        # child" to become a "move to sibling" if possible (if it can't
-        # be done, it means that we are  adding the first child)
-        newdepth, siblings, newpos = self.update_move_to_child_vars()
-
-        if self.target.is_descendant_of(self.node):
-            raise InvalidMoveToDescendant(_("Can't move node to a descendant."))
-
-        if self.pos == "sorted-sibling":
-            siblings = self.node.get_sorted_pos_queryset(self.target.get_siblings(), self.node)
-            if first := siblings.first():
-                newpos = first._get_lastpos_in_path()
-                if self.node._get_lastpos_in_path() == newpos - 1:
-                    # The node is already in the right place, nothing to do
-                    return
-            else:
-                newpos = None
-                self.pos = "last-sibling"
-
-        # Handle special cases where nothing needs to be done
-        if newdepth == self.node.get_depth():
-            if self.pos == "first-sibling" and self.node == self.target.get_first_sibling():
-                return
-
-            if self.pos == "last-sibling" and self.node == self.target.get_last_sibling():
-                return
-
-        if self.node == self.target and (
-            # Moving a node to left/right of itself is a noop
-            self.pos == "left"
-            or (self.pos in ("right", "last-sibling") and self.target == self.target.get_last_sibling())
-        ):
-            return
-
-        # Move nodes
-        oldpath, newpath = self.reorder_nodes_before_add_or_move(
-            self.pos, newpos, newdepth, self.target, siblings, self.node.path, True
-        )
-
-        self.update_parent_counts_after_move(oldpath, newpath)
-        self.node.refresh_from_db()  # Node path and depth will have changed
-        self.target.refresh_from_db()
-
-    def update_parent_counts_after_move(self, oldpath, newpath):
-        """
-        Update the numchild value of parent nodes after performing a move.
-        """
-        oldparentpath = self.node_cls._get_parent_path_from_path(oldpath)
-        newparentpath = self.node_cls._get_parent_path_from_path(newpath)
-        if oldparentpath != newparentpath:
-            # node changed parent, updating counts
-            if oldparentpath:
-                self.decrement_numchild(oldparentpath)
-            if newparentpath:
-                self.increment_numchild(newparentpath)
-
-    def update_move_to_child_vars(self):
-        """Update preliminary vars in :meth:`move` when moving to a child"""
-        newdepth = self.target.depth
-        newpos = None
-        siblings = []
-        if self.pos in ("first-child", "last-child", "sorted-child"):
-            if self.target == self.node:
-                raise InvalidMoveToDescendant(_("Can't move node to itself."))
-
-            # moving to a child
-            parent = self.target
-            newdepth += 1
-            if self.target.is_leaf():
-                # moving as a target's first child
-                newpos = 1
-                self.pos = "first-sibling"
-                siblings = self.node_cls.tree_model().objects.none()
-            else:
-                self.target = self.target.get_last_child()
-                self.pos = {
-                    "first-child": "first-sibling",
-                    "last-child": "last-sibling",
-                    "sorted-child": "sorted-sibling",
-                }[self.pos]
-
-            # this is not for save(), since if needed, will be handled with a
-            # custom UPDATE, this is only here to update django's object,
-            # should be useful in loops
-            parent.numchild += 1
-
-        return newdepth, siblings, newpos
-
-
-class MP_Node(Node):
-    """Abstract model to create your own Materialized Path Trees."""
-
-    steplen = 4
-    alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    node_order_by = []
-    path = models.CharField(max_length=255, unique=True)
-    depth = models.PositiveIntegerField()
-    numchild = models.PositiveIntegerField(default=0)
-
-    TREEBEARD_IDENTIFYING_FIELD = "path"
-    MOVENODE_FORM_EXCLUDED_FIELDS = ("path", "depth", "numchild")
-
-    objects = MP_NodeManager()
-
-    numconv_obj_ = None
-
-    _cached_attributes = (
-        *Node._cached_attributes,
-        "_cached_parent_obj",
-    )
-
-    @classmethod
-    def _int2str(cls, num):
-        return cls.numconv_obj().int2str(num)
-
-    @classmethod
-    def _str2int(cls, num):
-        return cls.numconv_obj().str2int(num)
-
-    @classmethod
-    @cache
-    def numconv_obj(cls):
-        return NumConv(cls.alphabet)
-
-    @classmethod
-    @transaction.atomic
-    def add_root(cls, **kwargs):
-        """
-        Adds a root node to the tree.
-
-        This method saves the node in database. The object is populated as if via:
-
-        ```
-        obj = cls(**kwargs)
-        ```
-
-        :raise PathOverflow: when no more root objects can be added
-        """
-        return MP_AddRootHandler(cls, **kwargs).process()
-
-    @classmethod
-    def dump_bulk(cls, parent=None, keep_ids=True):
-        """Dumps a tree branch to a python data structure."""
-
-        cls = cls.tree_model()
-
-        # Because of fix_tree, this method assumes that the depth
-        # and numchild properties in the nodes can be incorrect,
-        # so no helper methods are used
-        qset = cls.objects.all().order_by("depth", "path")
-        if parent:
-            qset = qset.filter(path__startswith=parent.path)
-        ret, lnk = [], {}
-        pk_field = cls._meta.pk.attname
-        for pyobj in serializers.serialize("python", qset.iterator()):
-            # django's serializer stores the attributes in 'fields'
-            fields = pyobj["fields"]
-            path = fields["path"]
-            depth = int(len(path) / cls.steplen)
-            # this will be useless in load_bulk
-            del fields["depth"]
-            del fields["path"]
-            del fields["numchild"]
-            if pk_field in fields:
-                # this happens immediately after a load_bulk
-                del fields[pk_field]
-
-            newobj = {"data": fields}
-            if keep_ids:
-                newobj[pk_field] = pyobj["pk"]
-
-            if (not parent and depth == 1) or (parent and len(path) == len(parent.path)):
-                ret.append(newobj)
-            else:
-                parentpath = cls._get_basepath(path, depth - 1)
-                parentobj = lnk[parentpath]
-                if "children" not in parentobj:
-                    parentobj["children"] = []
-                parentobj["children"].append(newobj)
-            lnk[path] = newobj
-        return ret
-
-    @classmethod
-    def find_problems(cls, parent=None):
-        """
-        Checks for problems in the tree structure, problems can occur when:
-
-           1. your code breaks and you get incomplete transactions (always
-              use transactions!)
-           2. changing the ``steplen`` value in a model (you must
-              :meth:`dump_bulk` first, change ``steplen`` and then
-              :meth:`load_bulk`
-
-        :param parent:
-
-            If provided, limits the check to the descendants of this node.
-            If not provided, the entire tree will be checked.
-
-        :returns: A tuple of five lists:
-
-                  1. a list of ids of nodes with characters not found in the
-                     ``alphabet``
-                  2. a list of ids of nodes when a wrong ``path`` length
-                     according to ``steplen``
-                  3. a list of ids of orphaned nodes
-                  4. a list of ids of nodes with the wrong depth value for
-                     their path
-                  5. a list of ids nodes that report a wrong number of children
-        """
-        cls = cls.tree_model()
-
-        if parent is not None:
-            qs = cls.objects.filter(path__startswith=parent.path)
-        else:
-            qs = cls.objects.all()
-
-        evil_chars, bad_steplen, orphans = [], [], []
-        wrong_depth, wrong_numchild = [], []
-        for node in qs.iterator():
-            found_error = False
-            for char in node.path:
-                if char not in cls.alphabet:
-                    evil_chars.append(node.pk)
-                    found_error = True
-                    break
-            if found_error:
-                continue
-            if len(node.path) % cls.steplen:
-                bad_steplen.append(node.pk)
-                continue
-            try:
-                node.get_parent(True)
-            except cls.DoesNotExist:
-                orphans.append(node.pk)
-                continue
-
-            if node.depth != int(len(node.path) / cls.steplen):
-                wrong_depth.append(node.pk)
-                continue
-
-            real_numchild = (
-                cls.objects.alias(computed_depth=Length("path") / cls.steplen)
-                .filter(path__range=cls._get_children_path_interval(node.path), computed_depth=node.depth + 1)
-                .count()
-            )
-            if real_numchild != node.numchild:
-                wrong_numchild.append(node.pk)
-                continue
-
-        return evil_chars, bad_steplen, orphans, wrong_depth, wrong_numchild
-
-    @classmethod
-    def _fix_numchild(cls, result_class, qs):
-        vendor = connections[router.db_for_write(result_class)].vendor
-        child_subquery = (
-            result_class.objects.alias(path_length=Length("path"))
-            .order_by()
-            .filter(path__startswith=OuterRef("path"), path_length=Length(OuterRef("path")) + cls.steplen)
-            .annotate(count=Func(F("pk"), function="Count"))
-            .values("count")
-        )
-        qs = qs.annotate(real_numchild=Subquery(child_subquery, output_field=models.IntegerField())).exclude(
-            numchild=F("real_numchild")
-        )
-
-        if vendor != "mysql":
-            qs.update(numchild=F("real_numchild"))
-        else:
-            # Our friend MySQL doesn't support update queries that use a select from the same table
-            # So we have to update each object individually
-            to_update = []
-            for node in qs.iterator():
-                node.numchild = node.real_numchild
-                to_update.append(node)
-
-            result_class.objects.bulk_update(to_update, ["numchild"])
-
-    @classmethod
-    def fix_tree(cls, fix_paths=False, parent=None):
+        cls = self.tree_model
+
+        if parent is None:
+            # return the entire tree
+            return cls.objects.all()
+        if parent.is_leaf():
+            return cls.objects.filter(pk=parent.pk)
+        return cls.objects.filter(path__startswith=parent.path, depth__gte=parent.depth).order_by("path")
+
+    def fix_tree(self, fix_paths=False, parent=None):
         """
         Solves some problems that can appear when transactions are not used and
         a piece of code breaks, leaving the tree in an inconsistent state.
@@ -674,7 +143,7 @@ class MP_Node(Node):
 
             Fixing only part of a tree will only work if the parent itself is valid.
         """
-        cls = cls.tree_model()
+        cls = self.tree_model
 
         qs = cls.objects.filter(path__startswith=parent.path) if parent else cls.objects.all()
 
@@ -682,7 +151,7 @@ class MP_Node(Node):
         qs.exclude(depth=Length("path") / cls.steplen).update(depth=Length("path") / cls.steplen)
 
         # fix the numchild field
-        cls._fix_numchild(cls, qs)
+        self._fix_numchild(qs)
 
         if fix_paths:
             with transaction.atomic():
@@ -738,7 +207,7 @@ class MP_Node(Node):
                                     previous_max_path = cls._get_path(parent_path, depth, max_position - 1)
                                     raise PathOverflow(_(f"Path Overflow from: '{previous_max_path}'"))
 
-                                cls._rewrite_node_path(old_path, new_path)
+                                self._rewrite_node_path(old_path, new_path)
                                 # update actual_sequence to reflect the new position
                                 actual_sequence[max_position] = occupant
                                 del actual_sequence[desired_position]
@@ -747,7 +216,7 @@ class MP_Node(Node):
                             # move item into the (now vacated) desired position
                             old_path = item["path"]
                             new_path = cls._get_path(parent_path, depth, desired_position)
-                            cls._rewrite_node_path(old_path, new_path)
+                            self._rewrite_node_path(old_path, new_path)
                             # update actual_sequence to reflect the new position
                             actual_sequence[desired_position] = item
                             del actual_sequence[actual_position]
@@ -758,37 +227,349 @@ class MP_Node(Node):
                             # node into its final position, so it's safe to add to children_to_fix
                             children_to_fix.append((item["path"], depth + 1))
 
-    @classmethod
-    def _rewrite_node_path(cls, old_path, new_path):
-        queryset = cls.objects.filter(path__startswith=old_path)
+    def _rewrite_node_path(self, old_path, new_path):
+        queryset = self.tree_model.objects.filter(path__startswith=old_path)
         update_count = queryset.update(path=Concat(Value(new_path), Substr("path", len(old_path) + 1)))
         if update_count > 0:
-            path_updated.send(sender=cls, old_path=old_path, new_path=new_path, using=queryset.db)
+            path_updated.send(sender=self.tree_model, old_path=old_path, new_path=new_path, using=queryset.db)
 
-    @classmethod
-    def get_tree(cls, parent=None):
+    def _fix_numchild(self, qs):
+        vendor = connections[router.db_for_write(self.tree_model)].vendor
+        child_subquery = (
+            self.tree_model.objects.alias(path_length=Length("path"))
+            .order_by()
+            .filter(path__startswith=OuterRef("path"), path_length=Length(OuterRef("path")) + self.model.steplen)
+            .annotate(count=Func(F("pk"), function="Count"))
+            .values("count")
+        )
+        qs = qs.annotate(real_numchild=Subquery(child_subquery, output_field=models.IntegerField())).exclude(
+            numchild=F("real_numchild")
+        )
+
+        if vendor != "mysql":
+            qs.update(numchild=F("real_numchild"))
+        else:  # pragma: no cover
+            # Our friend MySQL doesn't support update queries that use a select from the same table
+            # So we have to update each object individually
+            to_update = []
+            for node in qs.iterator():
+                node.numchild = node.real_numchild
+                to_update.append(node)
+
+            self.tree_model.objects.bulk_update(to_update, ["numchild"])
+
+    def find_problems(self, parent=None):
         """
-        :returns:
+        Checks for problems in the tree structure, problems can occur when:
 
-            A *queryset* of nodes ordered as DFS, including the parent.
-            If no parent is given, the entire tree is returned.
+           1. your code breaks and you get incomplete transactions (always
+              use transactions!)
+           2. changing the ``steplen`` value in a model (you must
+              :meth:`dump_bulk` first, change ``steplen`` and then
+              :meth:`load_bulk`
+
+        :param parent:
+
+            If provided, limits the check to the descendants of this node.
+            If not provided, the entire tree will be checked.
+
+        :returns: A tuple of five lists:
+
+                  1. a list of ids of nodes with characters not found in the
+                     ``alphabet``
+                  2. a list of ids of nodes when a wrong ``path`` length
+                     according to ``steplen``
+                  3. a list of ids of orphaned nodes
+                  4. a list of ids of nodes with the wrong depth value for
+                     their path
+                  5. a list of ids nodes that report a wrong number of children
         """
-        cls = cls.tree_model()
+        cls = self.tree_model
 
-        if parent is None:
-            # return the entire tree
-            return cls.objects.all()
-        if parent.is_leaf():
-            return cls.objects.filter(pk=parent.pk)
-        return cls.objects.filter(path__startswith=parent.path, depth__gte=parent.depth).order_by("path")
+        if parent is not None:
+            qs = cls.objects.filter(path__startswith=parent.path)
+        else:
+            qs = cls.objects.all()
 
-    @classmethod
-    def get_root_nodes(cls):
+        evil_chars, bad_steplen, orphans = [], [], []
+        wrong_depth, wrong_numchild = [], []
+        for node in qs.iterator():
+            found_error = False
+            for char in node.path:
+                if char not in cls.alphabet:
+                    evil_chars.append(node.pk)
+                    found_error = True
+                    break
+            if found_error:
+                continue
+            if len(node.path) % cls.steplen:
+                bad_steplen.append(node.pk)
+                continue
+            try:
+                self.get_parent(node, update=True)
+            except cls.DoesNotExist:
+                orphans.append(node.pk)
+                continue
+
+            if node.depth != int(len(node.path) / cls.steplen):
+                wrong_depth.append(node.pk)
+                continue
+
+            real_numchild = (
+                cls.objects.alias(computed_depth=Length("path") / cls.steplen)
+                .filter(path__range=cls._get_children_path_interval(node.path), computed_depth=node.depth + 1)
+                .count()
+            )
+            if real_numchild != node.numchild:
+                wrong_numchild.append(node.pk)
+                continue
+
+        return evil_chars, bad_steplen, orphans, wrong_depth, wrong_numchild
+
+    @transaction.atomic
+    @check_create_args
+    def add_root(self, create_kwargs=None, *, instance=None):
+        """
+        Adds a root node to the tree.
+
+        This method saves the node in database. The object is populated as if via:
+
+        ```
+        obj = self.model(**create_kwargs)
+        ```
+
+        if create_kwargs are supplied. If an unsaved model `instance` is supplied, it is used directly.
+
+        :raise PathOverflow: when no more root objects can be added
+        """
+        # do we have a root node already?
+        last_root = self.get_last_root_node()
+
+        if last_root and last_root.node_order_by:
+            # There are root nodes and node_order_by has been set.
+            # Delegate sorted insertion to add_sibling.
+            # We must pass an instance here to ensure that the right object is created for
+            # models with multi-table inheritance.
+            return self.add_sibling(
+                last_root,
+                "sorted-sibling",
+                instance=instance or self.model(**create_kwargs),
+            )
+
+        if last_root:
+            # adding the new root node as the last one
+            newpath = last_root._inc_path()
+        else:
+            # adding the first root node
+            newpath = self.model._get_path(None, 1, 1)
+
+        newobj = instance or self.model(**create_kwargs)
+        newobj.depth = 1
+        newobj.path = newpath
+        # saving the instance before returning it
+        newobj.save(using=self._db)
+        return newobj
+
+    @transaction.atomic
+    @check_create_args
+    def add_child(self, target, create_kwargs=None, *, instance=None):
+        """
+        Adds a child to the node.
+
+        This method saves the node in database. The object is populated as if via:
+
+        ```
+        obj = self.__class__(**create_kwargs)
+        ```
+
+        if `create_kwargs` are supplied. If an unsaved model `instance` is supplied, it is used directly.
+
+        :raise PathOverflow: when no more child nodes can be added
+        """
+        # Lock the parent row
+        node = self.select_for_update().get(pk=target.pk)
+        if self.model.node_order_by and not node.is_leaf():
+            # there are child nodes and node_order_by has been set
+            # delegate sorted insertion to add_sibling
+            target.numchild += 1
+            return self.add_sibling(self.get_last_child(node), "sorted-sibling", create_kwargs, instance=instance)
+
+        newobj = instance or self.model(**create_kwargs)
+        newobj.depth = node.depth + 1
+
+        if node.is_leaf():
+            # the node had no children, adding the first child
+            newobj.path = self.model._get_path(node.path, newobj.depth, 1)
+            max_length = self.model._meta.get_field("path").max_length
+            if len(newobj.path) > max_length:
+                raise PathOverflow(
+                    _(
+                        "The new node is too deep in the tree, try"
+                        " increasing the path.max_length property"
+                        " and UPDATE your database"
+                    )
+                )
+        else:
+            # adding the new child as the last one
+            newobj.path = self.get_last_child(node)._inc_path()
+
+        # Increment numchild on the parent, and also update the object in memory in case the caller reuses it
+        self.tree_model.objects.filter(pk=node.pk).update(numchild=F("numchild") + 1)
+        target.numchild = node.numchild + 1
+
+        # saving the instance before returning it
+        newobj._cached_parent_obj = target
+        newobj.save(using=self._db)
+
+        return newobj
+
+    @transaction.atomic
+    @check_create_args
+    def add_sibling(self, target, pos=None, create_kwargs=None, *, instance=None):
+        """
+        Adds a new node as a sibling to the current node object.
+
+        This method saves the node in database. The object is populated as if via:
+
+        ```
+        obj = self.__class__(**create_kwargs)
+        ```
+
+        if `create_kwargs` are supplied. If an unsaved model `instance` is supplied, it is used directly.
+
+        :raise PathOverflow: when the library can't make room for the
+           node's new position
+        """
+        pos = self._prepare_pos_var_for_add_sibling(pos)
+
+        newobj = instance or self.model(**create_kwargs)
+        newobj.depth = target.depth
+
+        if pos == "sorted-sibling":
+            siblings = self.get_sorted_pos_queryset(self.get_siblings(target), newobj)
+            first = siblings.first()
+            newpos = first._get_lastpos_in_path() if first else None
+            if newpos is None:
+                pos = "last-sibling"
+        else:
+            newpos, siblings = None, []
+
+        _, newpath = self._reorder_nodes_before_add_or_move(pos, newpos, target.depth, target, siblings, None, False)
+
+        parentpath = target._get_basepath(newpath, target.depth - 1)
+
+        if parentpath:
+            self._increment_numchild(parentpath)
+
+        # saving the instance before returning it
+        newobj.path = newpath
+        newobj.save(using=self._db)
+
+        return newobj
+
+    @transaction.atomic
+    def move(self, node, target, pos=None):
+        """
+        Moves node and all its descendants to a new position
+        relative to another node.
+
+        :raise PathOverflow: when the library can't make room for the
+           node's new position
+        """
+        pos = self._prepare_pos_var_for_move(pos)
+
+        # initialize variables and if moving to a child, updates "move to
+        # child" to become a "move to sibling" if possible (if it can't
+        # be done, it means that we are  adding the first child)
+        target, newdepth, siblings, newpos, pos = self.update_move_to_child_vars(node=node, target=target, pos=pos)
+
+        if target.is_descendant_of(node):
+            raise InvalidMoveToDescendant(_("Can't move node to a descendant."))
+
+        if pos == "sorted-sibling":
+            siblings = self.get_sorted_pos_queryset(self.get_siblings(target), node)
+            if first := siblings.first():
+                newpos = first._get_lastpos_in_path()
+                if node._get_lastpos_in_path() == newpos - 1:
+                    # The node is already in the right place, nothing to do
+                    return
+            else:
+                newpos = None
+                pos = "last-sibling"
+
+        # Handle special cases where nothing needs to be done
+        if newdepth == node.get_depth():
+            if pos == "first-sibling" and node == self.get_first_sibling(target):
+                return
+
+            if pos == "last-sibling" and node == self.get_last_sibling(target):
+                return
+
+        if node == target and (
+            # Moving a node to left/right of itself is a noop
+            pos == "left" or (pos in ("right", "last-sibling") and target == self.get_last_sibling(target))
+        ):
+            return
+
+        # Move nodes
+        oldpath, newpath = self._reorder_nodes_before_add_or_move(
+            pos, newpos, newdepth, target, siblings, node.path, True
+        )
+
+        self.update_parent_counts_after_move(oldpath, newpath)
+        node.refresh_from_db()  # Node path and depth will have changed
+        target.refresh_from_db()
+
+    def update_parent_counts_after_move(self, oldpath, newpath):
+        """
+        Update the numchild value of parent nodes after performing a move.
+        """
+        oldparentpath = self.model._get_parent_path_from_path(oldpath)
+        newparentpath = self.model._get_parent_path_from_path(newpath)
+        if oldparentpath != newparentpath:
+            # node changed parent, updating counts
+            if oldparentpath:
+                self._decrement_numchild(oldparentpath)
+            if newparentpath:
+                self._increment_numchild(newparentpath)
+
+    def update_move_to_child_vars(self, node, target, pos):
+        """Update preliminary vars in :meth:`move` when moving to a child"""
+        newdepth = target.depth
+        newpos = None
+        siblings = []
+        if pos in ("first-child", "last-child", "sorted-child"):
+            if target == node:
+                raise InvalidMoveToDescendant(_("Can't move node to itself."))
+
+            # moving to a child
+            parent = target
+            newdepth += 1
+            if target.is_leaf():
+                # moving as a target's first child
+                newpos = 1
+                pos = "first-sibling"
+                siblings = self.tree_model.objects.none()
+            else:
+                target = self.get_last_child(target)
+                pos = {
+                    "first-child": "first-sibling",
+                    "last-child": "last-sibling",
+                    "sorted-child": "sorted-sibling",
+                }[pos]
+
+            # this is not for save(), since if needed, will be handled with a
+            # custom UPDATE, this is only here to update django's object,
+            # should be useful in loops
+            parent.numchild += 1
+
+        return target, newdepth, siblings, newpos, pos
+
+    def get_root_nodes(self):
         """:returns: A queryset containing the root nodes in the tree."""
-        return cls.tree_model().objects.filter(depth=1).order_by("path")
+        return self.tree_model.objects.filter(depth=1).order_by("path")
 
-    @classmethod
-    def get_descendants_group_count(cls, parent=None):
+    def get_descendants_group_count(self, parent=None):
         """
         Helper for a very common case: get a group of siblings and the number
         of *descendants* (not only children) in every sibling.
@@ -802,9 +583,9 @@ class MP_Node(Node):
 
             A Queryset of node objects with an extra attribute: `descendants_count`.
         """
-        cls = cls.tree_model()
+        cls = self.tree_model
 
-        qs = parent.get_children() if parent else cls.get_root_nodes()
+        qs = self.get_children(parent) if parent else cls.objects.get_root_nodes()
         subquery = (
             cls.objects.filter(path__startswith=OuterRef("path"))
             .order_by()
@@ -816,228 +597,9 @@ class MP_Node(Node):
         )  # Subtract the parent node from the count
         return qs
 
-    def get_depth(self):
-        """:returns: the depth (level) of the node"""
-        return self.depth
-
-    def get_siblings(self):
-        """
-        :returns: A queryset of all the node's siblings, including the node
-            itself.
-        """
-        qset = self.tree_model().objects.filter(depth=self.depth).order_by("path")
-        if self.depth > 1:
-            # making sure the non-root nodes share a parent
-            parentpath = self._get_basepath(self.path, self.depth - 1)
-            qset = qset.filter(path__range=self._get_children_path_interval(parentpath))
-        return qset
-
-    def get_children(self):
-        """:returns: A queryset of all the node's children"""
-        if self.is_leaf():
-            return self.tree_model().objects.none()
-        return (
-            self.tree_model()
-            .objects.filter(depth=self.depth + 1, path__range=self._get_children_path_interval(self.path))
-            .order_by("path")
-        )
-
-    def get_next_sibling(self):
-        """
-        :returns: The next node's sibling, or None if it was the rightmost
-            sibling.
-        """
-        return self.get_siblings().filter(path__gt=self.path).first()
-
-    def get_descendants(self, include_self=False):
-        """
-        :returns: A queryset of all the node's descendants as DFS, doesn't
-            include the node itself if `include_self` is False
-        """
-        if include_self:
-            return self.__class__.get_tree(self)
-        if self.is_leaf():
-            return self.tree_model().objects.none()
-        return self.__class__.get_tree(self).exclude(pk=self.pk)
-
-    def get_prev_sibling(self):
-        """
-        :returns: The previous node's sibling, or None if it was the leftmost
-            sibling.
-        """
-        return self.get_siblings().filter(path__lt=self.path).last()
-
-    def get_children_count(self):
-        """
-        :returns: The number the node's children, calculated in the most
-        efficient possible way.
-        """
-        return self.numchild
-
-    def is_sibling_of(self, node):
-        """
-        :returns: ``True`` if the node is a sibling of another node given as an
-            argument, else, returns ``False``
-        """
-        if self.depth != node.depth:
-            return False
-
-        if self.depth == 1:
-            return True  # Root nodes are always siblings
-
-        # making sure the non-root nodes share a parent
-        return node.path.startswith(self._get_basepath(self.path, self.depth - 1))
-
-    def is_child_of(self, node):
-        """
-        :returns: ``True`` is the node if a child of another node given as an
-            argument, else, returns ``False``
-        """
-        return self.path.startswith(node.path) and self.depth == node.depth + 1
-
-    def is_descendant_of(self, node):
-        """
-        :returns: ``True`` if the node is a descendant of another node given
-            as an argument, else, returns ``False``
-        """
-        return self.path.startswith(node.path) and self.depth > node.depth
-
-    @transaction.atomic
-    def add_child(self, **kwargs):
-        """
-        Adds a child to the node.
-
-        This method saves the node in database. The object is populated as if via:
-
-        ```
-        obj = self.__class__(**kwargs)
-        ```
-
-        :raise PathOverflow: when no more child nodes can be added
-        """
-        return MP_AddChildHandler(self, kwargs).process()
-
-    @transaction.atomic
-    def add_sibling(self, pos=None, **kwargs):
-        """
-        Adds a new node as a sibling to the current node object.
-
-        This method saves the node in database. The object is populated as if via:
-
-        ```
-        obj = self.__class__(**kwargs)
-        ```
-
-        :raise PathOverflow: when the library can't make room for the
-           node's new position
-        """
-        return MP_AddSiblingHandler(self, pos, kwargs).process()
-
-    def get_root(self):
-        """:returns: the root node for the current node object."""
-        if self.is_root():
-            return self
-
-        return self.tree_model().objects.get(path=self.path[0 : self.steplen])
-
-    def is_root(self):
-        """:returns: True if the node is a root node (else, returns False)"""
-        return self.depth == 1
-
-    def is_leaf(self):
-        """:returns: True if the node is a leaf node (else, returns False)"""
-        return self.numchild == 0
-
-    def get_ancestors(self):
-        """
-        :returns: A queryset containing the current node object's ancestors,
-            starting by the root node and descending to the parent.
-        """
-        if self.is_root():
-            return self.tree_model().objects.none()
-
-        # This is necessary to ensure the index is used as opposed to a table scan
-        paths = [self.path[0:pos] for pos in range(0, len(self.path), self.steplen)[1:]]
-        return self.tree_model().objects.filter(path__in=paths).order_by("depth")
-
-    def get_parent(self, update=False):
-        """
-        :returns: the parent node of the current node object.
-            Caches the result in the object itself to help in loops.
-        """
-        depth = int(len(self.path) / self.steplen)
-        if depth <= 1:
-            return
-        try:
-            if update:
-                del self._cached_parent_obj
-            else:
-                return self._cached_parent_obj
-        except AttributeError:
-            pass
-        parentpath = self._get_basepath(self.path, depth - 1)
-        self._cached_parent_obj = self.tree_model().objects.get(path=parentpath)
-        return self._cached_parent_obj
-
-    @transaction.atomic
-    def move(self, target, pos=None):
-        """
-        Moves the current node and all it's descendants to a new position
-        relative to another node.
-
-        :raise PathOverflow: when the library can't make room for the
-           node's new position
-        """
-        return MP_MoveHandler(self, target, pos).process()
-
-    @classmethod
-    def _get_basepath(cls, path, depth):
-        """:returns: The base path of another path up to a given depth"""
-        if path:
-            return path[0 : depth * cls.steplen]
-        return ""
-
-    @classmethod
-    def _get_path(cls, path, depth, newstep):
-        """
-        Builds a path given some values
-
-        :param path: the base path
-        :param depth: the depth of the  node
-        :param newstep: the value (integer) of the new step
-        """
-        parentpath = cls._get_basepath(path, depth - 1)
-        key = cls._int2str(newstep)
-        return f"{parentpath}{cls.alphabet[0] * (cls.steplen - len(key))}{key}"
-
-    def _inc_path(self):
-        """:returns: The path of the next sibling of a given node path."""
-        newpos = self._str2int(self.path[-self.steplen :]) + 1
-        key = self._int2str(newpos)
-        if len(key) > self.steplen:
-            raise PathOverflow(_(f"Path Overflow from: '{self.path}'"))
-        return f"{self.path[: -self.steplen]}{self.alphabet[0] * (self.steplen - len(key))}{key}"
-
-    def _get_lastpos_in_path(self):
-        """:returns: The integer value of the last step in a path."""
-        return self._str2int(self.path[-self.steplen :])
-
-    @classmethod
-    def _get_parent_path_from_path(cls, path):
-        """:returns: The parent path for a given path"""
-        if path:
-            return path[0 : len(path) - cls.steplen]
-        return ""
-
-    @classmethod
-    def _get_children_path_interval(cls, path):
-        """:returns: An interval of all possible children paths for a node."""
-        return (path + cls.alphabet[0] * cls.steplen, path + cls.alphabet[-1] * cls.steplen)
-
-    @classmethod
     @transaction.atomic
     def load_bulk(
-        cls,
+        self,
         bulk_data,
         parent=None,
         keep_ids=False,
@@ -1091,12 +653,12 @@ class MP_Node(Node):
         if not bulk_create:
             return super().load_bulk(bulk_data, parent=parent, keep_ids=keep_ids)
 
-        conn = connections[router.db_for_write(cls)]
+        conn = connections[router.db_for_write(self.model)]
         if not conn.features.can_return_rows_from_bulk_insert or conn.vendor == "microsoft":
             raise ValueError("Database backend does not support bulk load. Use load_bulk without bulk_create=True.")
 
         added = []
-        bulk_data = prepare_dumpdata_for_loading(cls, data=bulk_data, keep_ids=keep_ids)
+        bulk_data = prepare_dumpdata_for_loading(self.model, data=bulk_data, keep_ids=keep_ids)
         children_to_create = []
 
         def _build_children(parent_node, children) -> None:
@@ -1105,7 +667,7 @@ class MP_Node(Node):
             for i, child in enumerate(children):
                 child.object.depth = child_depth
                 child.object.numchild = len(child.children)
-                child.object.path = cls._get_path(parent_node.path, child_depth, i + 1)
+                child.object.path = self.model._get_path(parent_node.path, child_depth, i + 1)
 
                 children_to_create.append(child)
 
@@ -1116,16 +678,16 @@ class MP_Node(Node):
         for deserialized_obj in bulk_data:
             deserialized_obj.object.numchild = len(deserialized_obj.children)  # Set numchild manually
             node_obj = (
-                parent.add_child(instance=deserialized_obj.object)
+                self.add_child(parent, instance=deserialized_obj.object)
                 if parent
-                else cls.add_root(instance=deserialized_obj.object)
+                else self.add_root(instance=deserialized_obj.object)
             )
             save_m2m(node_obj, deserialized_obj)
             added.append(node_obj.pk)
             _build_children(node_obj, deserialized_obj.children)
 
         # Bulk create descendants
-        created = cls.objects.bulk_create([obj.object for obj in children_to_create], batch_size=batch_size)
+        created = self.bulk_create([obj.object for obj in children_to_create], batch_size=batch_size)
 
         # Save m2m relationships
         for obj, source in zip(created, children_to_create):
@@ -1135,22 +697,431 @@ class MP_Node(Node):
 
         return added
 
+    def dump_bulk(self, parent=None, keep_ids=True):
+        """Dumps a tree branch to a python data structure."""
+
+        cls = self.tree_model
+
+        # Because of fix_tree, this method assumes that the depth
+        # and numchild properties in the nodes can be incorrect,
+        # so no helper methods are used
+        qset = cls.objects.all().order_by("depth", "path")
+        if parent:
+            qset = qset.filter(path__startswith=parent.path)
+        ret, lnk = [], {}
+        pk_field = cls._meta.pk.attname
+        for pyobj in serializers.serialize("python", qset.iterator()):
+            # django's serializer stores the attributes in 'fields'
+            fields = pyobj["fields"]
+            path = fields["path"]
+            depth = int(len(path) / cls.steplen)
+            # this will be useless in load_bulk
+            del fields["depth"]
+            del fields["path"]
+            del fields["numchild"]
+            fields.pop(pk_field, None)  # this happens immediately after a load_bulk
+
+            newobj = {"data": fields}
+            if keep_ids:
+                newobj[pk_field] = pyobj["pk"]
+
+            if (not parent and depth == 1) or (parent and len(path) == len(parent.path)):
+                ret.append(newobj)
+            else:
+                parentpath = cls._get_basepath(path, depth - 1)
+                parentobj = lnk[parentpath]
+                if "children" not in parentobj:
+                    parentobj["children"] = []
+                parentobj["children"].append(newobj)
+            lnk[path] = newobj
+        return ret
+
+    def _increment_numchild(self, path):
+        self.tree_model.objects.filter(path=path).update(numchild=F("numchild") + 1)
+
+    def _decrement_numchild(self, path):
+        self.tree_model.objects.filter(path=path).update(numchild=F("numchild") - 1)
+
+    def _reorder_nodes_before_add_or_move(
+        self, pos, newpos, newdepth, target, siblings, oldpath=None, movebranch=False
+    ):
+        """
+        Handles the reordering of nodes and branches when adding/moving
+        nodes.
+
+        :returns: A tuple containing the old path and the new path.
+        """
+        if (pos == "last-sibling") or (pos == "right" and target == self.get_last_sibling(target)):
+            # easy, the last node
+            last = self.get_last_sibling(target)
+            newpath = last._inc_path()
+            if movebranch:
+                self._set_newpath_in_branches(oldpath, newpath)
+            return oldpath, newpath
+
+        if newpos is None:
+            siblings = self.get_siblings(target)
+            siblings = {
+                "left": siblings.filter(path__gte=target.path),
+                "right": siblings.filter(path__gt=target.path),
+                "first-sibling": siblings,
+            }[pos]
+            basenum = target._get_lastpos_in_path()
+            newpos = {"first-sibling": 1, "left": basenum, "right": basenum + 1}[pos]
+
+        newpath = self.model._get_path(target.path, newdepth, newpos)
+
+        # If the move is amongst siblings and is to the left and there
+        # are siblings to the right of its new position then to be on
+        # the safe side we temporarily dump it on the end of the list
+        tempnewpath = None
+        if movebranch and len(oldpath) == len(newpath):
+            parentoldpath = self.model._get_basepath(oldpath, int(len(oldpath) / self.model.steplen) - 1)
+            parentnewpath = self.model._get_basepath(newpath, newdepth - 1)
+            if parentoldpath == parentnewpath and siblings and newpath < oldpath:
+                last = self.get_last_sibling(target)
+                basenum = last._get_lastpos_in_path()
+                tempnewpath = self.model._get_path(newpath, newdepth, basenum + 2)
+                self._set_newpath_in_branches(oldpath, tempnewpath)
+
+        # Optimisation to only move siblings which need moving
+        # (i.e. if we've got holes, allow them to compress)
+        movesiblings = []
+        priorpath = newpath
+        for node in siblings:
+            # If the path of the node is already greater than the path
+            # of the previous node it doesn't need shifting
+            if node.path > priorpath:
+                break
+            # It does need shifting, so add to the list
+            movesiblings.append(node)
+            # Calculate the path that it would be moved to, as that's
+            # the next "priorpath"
+            priorpath = node._inc_path()
+        movesiblings.reverse()
+
+        for node in movesiblings:
+            # moving the siblings (and their branches) at the right of the
+            # related position one step to the right
+            _inc_path = node._inc_path()
+            self._set_newpath_in_branches(node.path, node._inc_path())
+
+            if movebranch:
+                if oldpath.startswith(node.path):
+                    # if moving to a parent, update oldpath since we just
+                    # increased the path of the entire branch
+                    oldpath = _inc_path + oldpath[len(_inc_path) :]
+                if target.path.startswith(node.path):
+                    # and if we moved the target, update the object
+                    # django made for us, since the update won't do it
+                    # maybe useful in loops
+                    target.path = _inc_path + target.path[len(_inc_path) :]
+        if movebranch:
+            # node to move
+            self._set_newpath_in_branches(tempnewpath or oldpath, newpath)
+        return oldpath, newpath
+
+    def _set_newpath_in_branches(self, oldpath, newpath):
+        """
+        .. note::
+
+           The query will only update depth values if needed.
+
+        """
+
+        new_path_value = Concat(Value(newpath), Substr("path", len(oldpath) + 1))
+        update_kwargs = {}
+
+        # Warning: MySQL processes multiple assigments left to right, using the updated value
+        # for any column that is referenced in a subsequent assignment. This behavior differs from standard SQL.
+        # See https://dev.mysql.com/doc/refman/8.4/en/update.html
+        # For a table with schema name (VARCHAR), length (INT) and row (name="bob", length=3), the query:
+        # `UPDATE table SET name='alice', length=LENGTH(name);`
+        # would set `length` to 5 in MySQL, but 3 on other databases, because they use the original source value.
+        # To avoid having to special case for MySQL, we need to supply the depth as the first parameter to
+        # update_kwargs.
+
+        if len(oldpath) != len(newpath):
+            update_kwargs["depth"] = Length(new_path_value) / self.model.steplen
+        update_kwargs["path"] = new_path_value
+
+        model = self.tree_model
+        queryset = model.objects.filter(path__startswith=oldpath)
+        update_count = queryset.update(**update_kwargs)
+        if update_count > 0:
+            path_updated.send(sender=model, old_path=oldpath, new_path=newpath, using=queryset.db)
+
+    def get_children(self, node):
+        """:returns: A queryset of all the node's children"""
+        if node.is_leaf():
+            return self.tree_model.objects.none()
+        return self.tree_model.objects.filter(
+            depth=node.depth + 1, path__range=node._get_children_path_interval(node.path)
+        ).order_by("path")
+
+    def get_children_count(self, node):
+        """
+        :returns: The number the node's children, calculated in the most
+        efficient possible way.
+        """
+        return node.numchild
+
+    def get_siblings(self, node):
+        """
+        :returns: A queryset of all the node's siblings, including the node
+            itself.
+        """
+        qset = self.tree_model.objects.filter(depth=node.depth).order_by("path")
+        if node.depth > 1:
+            # making sure the non-root nodes share a parent
+            parentpath = node._get_basepath(node.path, node.depth - 1)
+            qset = qset.filter(path__range=node._get_children_path_interval(parentpath))
+        return qset
+
+    def get_descendants(self, node, include_self=False):
+        """
+        :returns: A queryset of all the node's descendants as DFS, doesn't
+            include the node itself if `include_self` is False
+        """
+        manager = self.tree_model.objects
+        if include_self:
+            return manager.get_tree(node)
+        if node.is_leaf():
+            return manager.none()
+        return manager.get_tree(node).exclude(pk=node.pk)
+
+    def get_root(self, node):
+        """:returns: the root node for the current node object."""
+        if node.is_root():
+            return node
+
+        return self.tree_model.objects.get(path=node.path[0 : node.steplen])
+
+    def get_parent(self, node, update=False):
+        """
+        :returns: the parent node of the current node object.
+            Caches the result in the object itself to help in loops.
+        """
+        depth = int(len(node.path) / node.steplen)
+        if depth <= 1:
+            return
+        try:
+            if update:
+                del node._cached_parent_obj
+            else:
+                return node._cached_parent_obj
+        except AttributeError:
+            pass
+        parentpath = node._get_basepath(node.path, depth - 1)
+        node._cached_parent_obj = self.tree_model.objects.get(path=parentpath)
+        return node._cached_parent_obj
+
+    def get_ancestors(self, node):
+        """
+        :returns: A queryset containing the current node object's ancestors,
+            starting by the root node and descending to the parent.
+        """
+        if node.is_root():
+            return self.tree_model.objects.none()
+
+        # This is necessary to ensure the index is used as opposed to a table scan
+        paths = [node.path[0:pos] for pos in range(0, len(node.path), node.steplen)[1:]]
+        return self.tree_model.objects.filter(path__in=paths).order_by("depth")
+
+    def get_next_sibling(self, node):
+        """
+        :returns: The node's next sibling, or None if it was the rightmost
+            sibling.
+        """
+        return self.get_siblings(node).filter(path__gt=node.path).first()
+
+    def get_prev_sibling(self, node):
+        """
+        :returns: The node's previous sibling, or None if it was the leftmost
+            sibling.
+        """
+        return self.get_siblings(node).filter(path__lt=node.path).last()
+
+
+class MP_AddRootHandler:
+    def __init__(self, cls, **kwargs):
+        warnings.warn(
+            "MP_AddRootHandler is deprecated. Use Node.objects.add_root() instead.",
+            RemovedInTreebeard7Warning,
+            stacklevel=2,
+        )
+        self.cls = cls
+        self.kwargs = kwargs
+
+    def process(self):
+        instance = self.kwargs.pop("instance", None)
+        return self.cls.objects.add_root(self.kwargs, instance=instance)
+
+
+class MP_AddChildHandler:
+    def __init__(self, node, creation_kwargs: dict[str, Any]):
+        warnings.warn(
+            "MP_AddChildHandler is deprecated. Use Node.objects.add_child() instead.",
+            RemovedInTreebeard7Warning,
+            stacklevel=2,
+        )
+        self.node = node
+        self.kwargs = creation_kwargs
+
+    def process(self):
+        instance = self.kwargs.pop("instance", None)
+        return self.node.__class__.objects.add_child(self.node, self.kwargs, instance=instance)
+
+
+class MP_AddSiblingHandler:
+    def __init__(self, node, pos, creation_kwargs: dict[str, Any]):
+        warnings.warn(
+            "MP_AddSiblingHandler is deprecated. Use Node.objects.add_child() instead.",
+            RemovedInTreebeard7Warning,
+            stacklevel=2,
+        )
+        self.node = node
+        self.pos = pos
+        self.kwargs = creation_kwargs
+
+    def process(self):
+        instance = self.kwargs.pop("instance", None)
+        return self.node.__class__.objects.add_sibling(self.node, self.pos, self.kwargs, instance=instance)
+
+
+class MP_MoveHandler:
+    def __init__(self, node, target, pos=None):
+        warnings.warn(
+            "MP_MoveHandler is deprecated. Use Node.objects.move() instead.", RemovedInTreebeard7Warning, stacklevel=2
+        )
+        self.node = node
+        self.node_cls = node.__class__
+        self.target = target
+        self.pos = pos
+
+    def process(self):
+        return self.node.__class__.objects.move(self.node, self.target, self.pos)
+
+
+class MP_Node(Node):
+    """Abstract model to create your own Materialized Path Trees."""
+
+    steplen = 4
+    alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    node_order_by = []
+    path = models.CharField(max_length=255, unique=True)
+    depth = models.PositiveIntegerField()
+    numchild = models.PositiveIntegerField(default=0)
+
+    TREEBEARD_IDENTIFYING_FIELD = "path"
+    MOVENODE_FORM_EXCLUDED_FIELDS = ("path", "depth", "numchild")
+    _DEFAULT_TREEBEARD_MANAGER = MP_NodeManager
+
+    objects = MP_NodeManager()
+
+    numconv_obj_ = None
+
+    _cached_attributes = (
+        *Node._cached_attributes,
+        "_cached_parent_obj",
+    )
+
     @classmethod
-    def check(cls, **kwargs):
-        errors = super().check(**kwargs)
-        manager_cls = cls._default_manager.__class__
-        # Raise a warning if the default manager for the model doesn't subclass MP_NodeManager
-        # This will allow us to move class-level methods into the manager in future (see issue #44)
-        if not issubclass(manager_cls, MP_NodeManager):
-            errors.append(
-                checks.Warning(
-                    f"{manager_cls.__module__}.{manager_cls.__name__} does not subclass "
-                    "treebeard.mp_tree.MP_NodeManager. This will cause an error in Treebeard 6.",
-                    obj=manager_cls,
-                    id="treebeard.E001",
-                )
-            )
-        return errors
+    def _int2str(cls, num):
+        return cls.numconv_obj().int2str(num)
+
+    @classmethod
+    def _str2int(cls, num):
+        return cls.numconv_obj().str2int(num)
+
+    @classmethod
+    @cache
+    def numconv_obj(cls):
+        return NumConv(cls.alphabet)
+
+    def get_depth(self):
+        """:returns: the depth (level) of the node"""
+        return self.depth
+
+    def is_sibling_of(self, node):
+        """
+        :returns: ``True`` if the node is a sibling of another node given as an
+            argument, else, returns ``False``
+        """
+        if self.depth != node.depth:
+            return False
+
+        if self.depth == 1:
+            return True  # Root nodes are always siblings
+
+        # making sure the non-root nodes share a parent
+        return node.path.startswith(self._get_basepath(self.path, self.depth - 1))
+
+    def is_child_of(self, node):
+        """
+        :returns: ``True`` is the node if a child of another node given as an
+            argument, else, returns ``False``
+        """
+        return self.path.startswith(node.path) and self.depth == node.depth + 1
+
+    def is_descendant_of(self, node):
+        """
+        :returns: ``True`` if the node is a descendant of another node given
+            as an argument, else, returns ``False``
+        """
+        return self.path.startswith(node.path) and self.depth > node.depth
+
+    def is_root(self):
+        """:returns: True if the node is a root node (else, returns False)"""
+        return self.depth == 1
+
+    def is_leaf(self):
+        """:returns: True if the node is a leaf node (else, returns False)"""
+        return self.numchild == 0
+
+    @classmethod
+    def _get_basepath(cls, path, depth):
+        """:returns: The base path of another path up to a given depth"""
+        if path:
+            return path[0 : depth * cls.steplen]
+        return ""
+
+    @classmethod
+    def _get_path(cls, path, depth, newstep):
+        """
+        Builds a path given some values
+
+        :param path: the base path
+        :param depth: the depth of the  node
+        :param newstep: the value (integer) of the new step
+        """
+        parentpath = cls._get_basepath(path, depth - 1)
+        key = cls._int2str(newstep)
+        return f"{parentpath}{cls.alphabet[0] * (cls.steplen - len(key))}{key}"
+
+    def _inc_path(self):
+        """:returns: The path of the next sibling of a given node path."""
+        newpos = self._str2int(self.path[-self.steplen :]) + 1
+        key = self._int2str(newpos)
+        if len(key) > self.steplen:
+            raise PathOverflow(_(f"Path Overflow from: '{self.path}'"))
+        return f"{self.path[: -self.steplen]}{self.alphabet[0] * (self.steplen - len(key))}{key}"
+
+    def _get_lastpos_in_path(self):
+        """:returns: The integer value of the last step in a path."""
+        return self._str2int(self.path[-self.steplen :])
+
+    @classmethod
+    def _get_parent_path_from_path(cls, path):
+        """:returns: The parent path for a given path"""
+        if path:
+            return path[0 : len(path) - cls.steplen]
+        return ""
+
+    @classmethod
+    def _get_children_path_interval(cls, path):
+        """:returns: An interval of all possible children paths for a node."""
+        return (path + cls.alphabet[0] * cls.steplen, path + cls.alphabet[-1] * cls.steplen)
 
     class Meta:
         """Abstract model."""

--- a/treebeard/ns_tree.py
+++ b/treebeard/ns_tree.py
@@ -4,14 +4,15 @@ import operator
 from functools import reduce
 from itertools import groupby
 
-from django.core import checks, serializers
+from django.core import serializers
 from django.db import models, transaction
 from django.db.models import Case, F, Q, When
 from django.dispatch import Signal
 from django.utils.translation import gettext_noop as _
 
-from treebeard.exceptions import InvalidMoveToDescendant, NodeAlreadySaved
-from treebeard.models import Node
+from treebeard.exceptions import InvalidMoveToDescendant
+from treebeard.models import Node, NodeManager
+from treebeard.utils import check_create_args
 
 gap_altered = Signal()
 tree_ids_incremented = Signal()
@@ -34,7 +35,7 @@ class NS_NodeQuerySet(models.query.QuerySet):
         :returns: tuple of the number of objects deleted and a dictionary
                   with the number of deletions per object type
         """
-        model = self.model.tree_model()
+        model = self.model.objects.tree_model
 
         last_node = None
         toremove = []
@@ -68,53 +69,48 @@ class NS_NodeQuerySet(models.query.QuerySet):
         # cheaper precalculating the gapsize per intervals, or just do a
         # complete reordering of the tree (uses COUNT)...
         for tree_id, drop_lft, drop_rgt in sorted(ranges, reverse=True):
-            model._close_gap(drop_lft, drop_rgt, tree_id)
+            model.objects._close_gap(drop_lft, drop_rgt, tree_id)
         return result
 
     delete.alters_data = True
     delete.queryset_only = True
 
 
-class NS_NodeManager(models.Manager):
+class NS_NodeManager(NodeManager):
     """Custom manager for nodes in a Nested Sets tree."""
 
     def get_queryset(self):
         """Sets the custom queryset as the default."""
         return NS_NodeQuerySet(self.model, using=self._db).order_by("tree_id", "lft")
 
+    def get_tree(self, parent=None):
+        """
+        :returns:
 
-class NS_Node(Node):
-    """Abstract model to create your own Nested Sets Trees."""
+            A *queryset* of nodes ordered as DFS, including the parent.
+            If no parent is given, all trees are returned.
+        """
+        cls = self.tree_model
 
-    node_order_by = []
+        if parent is None:
+            # return the entire tree
+            return cls.objects.all()
+        if parent.is_leaf():
+            return cls.objects.filter(pk=parent.pk)
+        return cls.objects.filter(tree_id=parent.tree_id, lft__range=(parent.lft, parent.rgt - 1))
 
-    lft = models.PositiveIntegerField(db_index=True)
-    rgt = models.PositiveIntegerField(db_index=True)
-    tree_id = models.PositiveIntegerField(db_index=True)
-    depth = models.PositiveIntegerField(db_index=True)
-
-    TREEBEARD_IDENTIFYING_FIELD = "lft"
-    MOVENODE_FORM_EXCLUDED_FIELDS = ("depth", "lft", "rgt", "tree_id")
-
-    objects = NS_NodeManager()
-
-    _cached_attributes = (
-        *Node._cached_attributes,
-        "_cached_parent_obj",
-    )
-
-    @classmethod
     @transaction.atomic
-    def add_root(cls, **kwargs):
+    @check_create_args
+    def add_root(self, create_kwargs=None, *, instance=None):
         """Adds a root node to the tree."""
 
         # do we have a root node already?
-        last_root = cls.get_last_root_node()
+        last_root = self.get_last_root_node()
 
         if last_root and last_root.node_order_by:
             # there are root nodes and node_order_by has been set
             # delegate sorted insertion to add_sibling
-            return last_root.add_sibling("sorted-sibling", **kwargs)
+            return self.add_sibling(last_root, "sorted-sibling", create_kwargs=create_kwargs, instance=instance)
 
         if last_root:
             # adding the new root node as the last one
@@ -123,148 +119,102 @@ class NS_Node(Node):
             # adding the first root node
             newtree_id = 1
 
-        if len(kwargs) == 1 and "instance" in kwargs:
-            # adding the passed (unsaved) instance to the tree
-            newobj = kwargs["instance"]
-            if not newobj._state.adding:
-                raise NodeAlreadySaved("Attempted to add a tree node that is already in the database")
-        else:
-            # creating the new object
-            newobj = cls.tree_model()(**kwargs)
-
+        newobj = instance or self.tree_model(**create_kwargs)
         newobj.depth = 1
         newobj.tree_id = newtree_id
         newobj.lft = 1
         newobj.rgt = 2
         # saving the instance before returning it
-        newobj.save()
+        newobj.save(using=self._db)
         return newobj
 
-    @classmethod
-    def _alter_gap(cls, tree_id, start_index, offset):
-        """
-        Open or close a gap in the lft/rgt sequence by changing all lft/rgt values greater than or equal to
-        start_index within the given tree by the given offset.
-        """
-        output_field = models.PositiveIntegerField()
-        queryset = cls.objects.filter(rgt__gte=start_index, tree_id=tree_id)
-        update_count = queryset.update(
-            lft=Case(When(lft__gte=start_index, then=F("lft") + offset), default=F("lft"), output_field=output_field),
-            rgt=F("rgt") + offset,
-        )
-        if update_count > 0:
-            gap_altered.send(sender=cls, tree_id=tree_id, start_index=start_index, offset=offset, using=queryset.db)
-
-    @classmethod
-    def _move_tree_right(cls, tree_id):
-        queryset = cls.objects.filter(tree_id__gte=tree_id)
-        update_count = queryset.update(tree_id=F("tree_id") + 1)
-        if update_count > 0:
-            tree_ids_incremented.send(sender=cls, min_tree_id=tree_id, using=queryset.db)
-
     @transaction.atomic
-    def add_child(self, **kwargs):
-        """Adds a child to the node."""
+    @check_create_args
+    def add_child(self, target, create_kwargs=None, *, instance=None):
+        """Adds a child to the target."""
         # Fetch the parent afresh from the database and lock the row
         # This guards against race conditions and state drift when adding multiple children,
         # and also ensures that we're working with the base tree model in the case of inherited models
-        cls = self.tree_model()
-        node = cls.objects.filter(pk=self.pk).select_for_update().get()
+        cls = self.tree_model
+        node = self.filter(pk=target.pk).select_for_update().get()
         if not node.is_leaf():
             # there are child nodes, delegate insertion to add_sibling
-            if self.node_order_by:
+            if node.node_order_by:
                 pos = "sorted-sibling"
             else:
                 pos = "last-sibling"
-            last_child = node.get_last_child()
+            last_child = self.get_last_child(node)
             last_child._cached_parent_obj = node
-            new_sibling = last_child.add_sibling(pos, **kwargs)
+            new_sibling = self.add_sibling(last_child, pos, create_kwargs=create_kwargs, instance=instance)
             node.rgt += 2
-            self.rgt = node.rgt + 2  # Update the rgt of the parent object, which may be used again in a loop
+            target.rgt = node.rgt + 2  # Update the rgt of the parent object, which may be used again in a loop
             return new_sibling
 
         # we're adding the first child of this node
-        cls._alter_gap(node.tree_id, node.rgt, 2)
+        self._alter_gap(node.tree_id, node.rgt, 2)
 
-        if len(kwargs) == 1 and "instance" in kwargs:
-            # adding the passed (unsaved) instance to the tree
-            newobj = kwargs["instance"]
-            if not newobj._state.adding:
-                raise NodeAlreadySaved("Attempted to add a tree node that is already in the database")
-        else:
-            # creating a new object
-            newobj = cls(**kwargs)
-
+        newobj = instance or cls(**create_kwargs)
         newobj.tree_id = node.tree_id
         newobj.depth = node.depth + 1
         newobj.lft = node.lft + 1
         newobj.rgt = node.lft + 2
 
         # this is just to update the cache
-        self.rgt = node.rgt + 2
+        target.rgt = node.rgt + 2
 
-        newobj._cached_parent_obj = self
+        newobj._cached_parent_obj = target
 
         # saving the instance before returning it
-        newobj.save()
+        newobj.save(using=self._db)
 
         return newobj
 
     @transaction.atomic
-    def add_sibling(self, pos=None, **kwargs):
-        """Adds a new node as a sibling to the current node object."""
+    @check_create_args
+    def add_sibling(self, target, pos=None, create_kwargs=None, *, instance=None):
+        """Adds a new node as a sibling to the target."""
 
         pos = self._prepare_pos_var_for_add_sibling(pos)
-        cls = self.tree_model()
+        cls = self.tree_model
 
-        if len(kwargs) == 1 and "instance" in kwargs:
-            # adding the passed (unsaved) instance to the tree
-            newobj = kwargs["instance"]
-            if not newobj._state.adding:
-                raise NodeAlreadySaved("Attempted to add a tree node that is already in the database")
-        else:
-            # creating a new object
-            newobj = cls(**kwargs)
-
-        newobj.depth = self.depth
-
-        target = self
+        newobj = instance or cls(**create_kwargs)
+        newobj.depth = target.depth
 
         if target.is_root():
             newobj.lft = 1
             newobj.rgt = 2
             if pos == "sorted-sibling":
-                siblings = list(target.get_sorted_pos_queryset(target.get_siblings(), newobj))
-                if siblings:
+                siblings = self.get_sorted_pos_queryset(self.get_siblings(target), newobj)
+                if siblings.exists():
                     pos = "left"
-                    target = siblings[0]
+                    target = siblings.first()
                 else:
                     pos = "last-sibling"
 
-            last_root = cls.get_last_root_node()
+            last_root = self.get_last_root_node()
             if (pos == "last-sibling") or (pos == "right" and target == last_root):
                 newobj.tree_id = last_root.tree_id + 1
             else:
                 newpos = {"first-sibling": 1, "left": target.tree_id, "right": target.tree_id + 1}[pos]
-                cls._move_tree_right(newpos)
+                self._move_tree_right(newpos)
 
                 newobj.tree_id = newpos
         else:
             newobj.tree_id = target.tree_id
 
             if pos == "sorted-sibling":
-                siblings = list(target.get_sorted_pos_queryset(target.get_siblings(), newobj))
-                if siblings:
+                siblings = self.get_sorted_pos_queryset(self.get_siblings(target), newobj)
+                if siblings.exists():
                     pos = "left"
-                    target = siblings[0]
+                    target = siblings.first()
                 else:
                     pos = "last-sibling"
 
             if pos in ("left", "right", "first-sibling"):
-                siblings = list(target.get_siblings())
+                siblings = self.get_siblings(target)
 
                 if pos == "right":
-                    if target == siblings[-1]:
+                    if target == siblings.last():
                         pos = "last-sibling"
                     else:
                         pos = "left"
@@ -276,41 +226,41 @@ class NS_Node(Node):
                             elif node == target:
                                 found = True
                 if pos == "left":
-                    if target == siblings[0]:
+                    if target == siblings.first():
                         pos = "first-sibling"
                 if pos == "first-sibling":
-                    target = siblings[0]
+                    target = siblings.first()
 
             if pos == "last-sibling":
-                newpos = target.get_parent().rgt
-                cls._alter_gap(target.tree_id, newpos, 2)
+                newpos = self.get_parent(target).rgt
+                self._alter_gap(target.tree_id, newpos, 2)
             elif pos == "first-sibling" or pos == "left":
                 newpos = target.lft
-                cls._alter_gap(target.tree_id, newpos, 2)
+                self._alter_gap(target.tree_id, newpos, 2)
 
             newobj.lft = newpos
             newobj.rgt = newpos + 1
 
         # saving the instance before returning it
-        newobj.save()
+        newobj.save(using=self._db)
 
         return newobj
 
     @transaction.atomic
-    def move(self, target, pos=None):
+    def move(self, node, target, pos=None):
         """
         Moves the current node and all it's descendants to a new position
         relative to another node.
         """
 
         pos = self._prepare_pos_var_for_move(pos)
-        cls = self.tree_model()
+        cls = self.tree_model
         original_target = target
 
         parent = None
 
         if pos in ("first-child", "last-child", "sorted-child"):
-            if self == target:
+            if node == target:
                 raise InvalidMoveToDescendant(_("Can't move node to itself."))
 
             # moving to a child
@@ -318,85 +268,85 @@ class NS_Node(Node):
                 parent = target
                 pos = "last-child"
             else:
-                target = target.get_last_child()
+                target = self.get_last_child(target)
                 pos = {"first-child": "first-sibling", "last-child": "last-sibling", "sorted-child": "sorted-sibling"}[
                     pos
                 ]
 
-        if target.is_descendant_of(self):
+        if target.is_descendant_of(node):
             raise InvalidMoveToDescendant(_("Can't move node to a descendant."))
 
-        if self == target and (
+        if node == target and (
             (pos == "left")
-            or (pos in ("right", "last-sibling") and target == target.get_last_sibling())
-            or (pos == "first-sibling" and target == target.get_first_sibling())
+            or (pos in ("right", "last-sibling") and target == self.get_last_sibling(target))
+            or (pos == "first-sibling" and target == self.get_first_sibling(target))
         ):
             # special cases, not actually moving the node so nothing to do
             return
 
         if pos == "sorted-sibling":
-            siblings = list(target.get_sorted_pos_queryset(target.get_siblings(), self))
-            if siblings:
+            siblings = self.get_sorted_pos_queryset(self.get_siblings(target), node)
+            if siblings.exists():
                 pos = "left"
-                target = siblings[0]
+                target = siblings.first()
             else:
                 pos = "last-sibling"
         if pos in ("left", "right", "first-sibling"):
-            siblings = list(target.get_siblings())
+            siblings = self.get_siblings(target)
 
             if pos == "right":
-                if target == siblings[-1]:
+                if target == siblings.last():
                     pos = "last-sibling"
                 else:
                     pos = "left"
                     found = False
-                    for node in siblings:
+                    for sib in siblings:
                         if found:
-                            target = node
+                            target = sib
                             break
-                        elif node == target:
+                        elif sib == target:
                             found = True
             if pos == "left":
-                if target == siblings[0]:
+                if target == siblings.first():
                     pos = "first-sibling"
             if pos == "first-sibling":
-                target = siblings[0]
+                target = siblings.first()
 
         # ok let's move this
-        gap = self.rgt - self.lft + 1
+        gap = node.rgt - node.lft + 1
         target_tree = target.tree_id
 
         # first make a hole
         if pos == "last-child":
             newpos = parent.rgt
-            cls._alter_gap(target.tree_id, newpos, gap)
+            self._alter_gap(target.tree_id, newpos, gap)
         elif target.is_root():
             newpos = 1
             if pos == "last-sibling":
-                target_tree = target.get_siblings().reverse()[0].tree_id + 1
+                target_tree = self.get_siblings(target).reverse()[0].tree_id + 1
             elif pos == "first-sibling":
                 target_tree = 1
-                cls._move_tree_right(1)
+                self._move_tree_right(1)
             elif pos == "left":
-                cls._move_tree_right(target.tree_id)
+                self._move_tree_right(target.tree_id)
         else:
             if pos == "last-sibling":
-                newpos = target.get_parent().rgt
-                cls._alter_gap(target.tree_id, newpos, gap)
+                newpos = self.get_parent(target).rgt
+                self._alter_gap(target.tree_id, newpos, gap)
             elif pos == "first-sibling" or pos == "left":
                 newpos = target.lft
-                cls._alter_gap(target.tree_id, newpos, gap)
+                self._alter_gap(target.tree_id, newpos, gap)
 
         # we refresh 'self' because lft/rgt may have changed
-        self.refresh_from_db()
+        node.refresh_from_db()
 
-        depthdiff = target.depth - self.depth
+        depthdiff = target.depth - node.depth
         if parent:
             depthdiff += 1
 
         # move the tree to the hole
-        jump = newpos - self.lft
-        queryset = cls.objects.filter(tree_id=self.tree_id, lft__range=(self.lft, self.rgt))
+        jump = newpos - node.lft
+        queryset = cls.objects.filter(tree_id=node.tree_id, lft__range=(node.lft, node.rgt))
         update_count = queryset.update(
             tree_id=target_tree,
             lft=F("lft") + jump,
@@ -406,9 +356,9 @@ class NS_Node(Node):
         if update_count > 0:
             subtree_moved.send(
                 sender=cls,
-                tree_id=self.tree_id,
-                lft=self.lft,
-                rgt=self.rgt,
+                tree_id=node.tree_id,
+                lft=node.lft,
+                rgt=node.rgt,
                 target_tree_id=target_tree,
                 index_offset=jump,
                 depth_offset=depthdiff,
@@ -416,52 +366,19 @@ class NS_Node(Node):
             )
 
         # close the gap
-        cls._close_gap(self.lft, self.rgt, self.tree_id)
-        self.refresh_from_db()  # Tree params will have changed
+        self._close_gap(node.lft, node.rgt, node.tree_id)
+        node.refresh_from_db()  # Tree params will have changed
         original_target.refresh_from_db()
 
-    @classmethod
-    def _close_gap(cls, drop_lft, drop_rgt, tree_id):
-        gapsize = drop_rgt - drop_lft + 1
-        cls._alter_gap(tree_id, drop_lft, -gapsize)
+    def get_root_nodes(self):
+        """:returns: A queryset containing the root nodes in the tree."""
+        return self.tree_model.objects.filter(lft=1)
 
-    def get_children(self):
-        """:returns: A queryset of all the node's children"""
-        return self.get_descendants().filter(depth=self.depth + 1)
-
-    def get_depth(self):
-        """:returns: the depth (level) of the node"""
-        return self.depth
-
-    def is_leaf(self):
-        """:returns: True if the node is a leaf node (else, returns False)"""
-        return self.rgt - self.lft == 1
-
-    def get_root(self):
-        """:returns: the root node for the current node object."""
-        if self.lft == 1:
-            return self
-        return self.tree_model().objects.get(tree_id=self.tree_id, lft=1)
-
-    def is_root(self):
-        """:returns: True if the node is a root node (else, returns False)"""
-        return self.lft == 1
-
-    def get_siblings(self):
-        """
-        :returns: A queryset of all the node's siblings, including the node
-            itself.
-        """
-        if self.lft == 1:
-            return self.get_root_nodes()
-        return self.get_parent(True).get_children()
-
-    @classmethod
-    def dump_bulk(cls, parent=None, keep_ids=True):
+    def dump_bulk(self, parent=None, keep_ids=True):
         """Dumps a tree branch to a python data structure."""
-        qset = cls.get_tree(parent)
+        qset = self.get_tree(parent)
         ret, lnk = [], {}
-        pk_field = cls._meta.pk.attname
+        pk_field = self.model._meta.pk.attname
         for pyobj in qset.iterator():
             serobj = serializers.serialize("python", [pyobj])[0]
             # django's serializer stores the attributes in 'fields'
@@ -483,7 +400,7 @@ class NS_Node(Node):
             if (not parent and depth == 1) or (parent and depth == parent.depth):
                 ret.append(newobj)
             else:
-                parentobj = pyobj.get_parent()
+                parentobj = self.model.objects.get_parent(pyobj)
                 parentser = lnk[parentobj.pk]
                 if "children" not in parentser:
                     parentser["children"] = []
@@ -491,79 +408,7 @@ class NS_Node(Node):
             lnk[pyobj.pk] = newobj
         return ret
 
-    @classmethod
-    def get_tree(cls, parent=None):
-        """
-        :returns:
-
-            A *queryset* of nodes ordered as DFS, including the parent.
-            If no parent is given, all trees are returned.
-        """
-        cls = cls.tree_model()
-
-        if parent is None:
-            # return the entire tree
-            return cls.objects.all()
-        if parent.is_leaf():
-            return cls.objects.filter(pk=parent.pk)
-        return cls.objects.filter(tree_id=parent.tree_id, lft__range=(parent.lft, parent.rgt - 1))
-
-    def get_descendants(self, include_self=False):
-        """
-        :returns: A queryset of all the node's descendants as DFS, doesn't
-            include the node itself if `include_self` is `False`
-        """
-        if include_self:
-            return self.__class__.get_tree(self)
-        if self.is_leaf():
-            return self.tree_model().objects.none()
-        return self.__class__.get_tree(self).exclude(pk=self.pk)
-
-    def get_descendant_count(self):
-        """:returns: the number of descendants of a node."""
-        return (self.rgt - self.lft - 1) / 2
-
-    def get_ancestors(self):
-        """
-        :returns: A queryset containing the current node object's ancestors,
-            starting by the root node and descending to the parent.
-        """
-        if self.is_root():
-            return self.tree_model().objects.none()
-        return self.tree_model().objects.filter(tree_id=self.tree_id, lft__lt=self.lft, rgt__gt=self.rgt)
-
-    def is_descendant_of(self, node):
-        """
-        :returns: ``True`` if the node if a descendant of another node given
-            as an argument, else, returns ``False``
-        """
-        return self.tree_id == node.tree_id and self.lft > node.lft and self.rgt < node.rgt
-
-    def get_parent(self, update=False):
-        """
-        :returns: the parent node of the current node object.
-            Caches the result in the object itself to help in loops.
-        """
-        if self.is_root():
-            return
-        try:
-            if update:
-                del self._cached_parent_obj
-            else:
-                return self._cached_parent_obj
-        except AttributeError:
-            pass
-        # parent = our most direct ancestor
-        self._cached_parent_obj = self.get_ancestors().reverse()[0]
-        return self._cached_parent_obj
-
-    @classmethod
-    def get_root_nodes(cls):
-        """:returns: A queryset containing the root nodes in the tree."""
-        return cls.tree_model().objects.filter(lft=1)
-
-    @classmethod
-    def find_problems(cls, parent=None):
+    def find_problems(self, parent=None):
         """
         Checks for inconsistencies in the tree structure.
 
@@ -584,11 +429,11 @@ class NS_Node(Node):
                   4. a list of ids of nodes with the wrong depth value for
                      their nesting level as defined by ``lft`` and ``rgt``
         """
-        cls = cls.tree_model()
+        cls = self.tree_model
 
         if parent is not None:
             qs = cls.objects.filter(tree_id=parent.tree_id, lft__gte=parent.lft, rgt__lte=parent.rgt)
-            initial_depth = parent.get_ancestors().count()
+            initial_depth = self.get_ancestors(parent).count()
         else:
             qs = cls.objects.all()
             initial_depth = 0
@@ -638,22 +483,134 @@ class NS_Node(Node):
 
         return reversed_lft_rgt, overlapping_nodes, duplicate_tree_ids, wrong_depth
 
-    @classmethod
-    def check(cls, **kwargs):
-        errors = super().check(**kwargs)
-        manager_cls = cls._default_manager.__class__
-        # Raise a warning if the default manager for the model doesn't subclass NS_NodeManager
-        # This will allow us to move class-level methods into the manager in future (see issue #44)
-        if not issubclass(manager_cls, NS_NodeManager):
-            errors.append(
-                checks.Warning(
-                    f"{manager_cls.__module__}.{manager_cls.__name__} does not subclass "
-                    "treebeard.ns_tree.NS_NodeManager. This will cause an error in Treebeard 6.",
-                    obj=manager_cls,
-                    id="treebeard.E001",
-                )
+    def get_children(self, node):
+        """:returns: A queryset of all the node's children"""
+        return self.get_descendants(node).filter(depth=node.depth + 1)
+
+    def get_siblings(self, node):
+        """
+        :returns: A queryset of all the node's siblings, including the node
+            itself.
+        """
+        if node.lft == 1:
+            return self.get_root_nodes()
+        return self.get_children(self.get_parent(node, True))
+
+    def get_descendant_count(self, node):
+        """:returns: the number of descendants of a node."""
+        return (node.rgt - node.lft - 1) / 2
+
+    def get_root(self, node):
+        """:returns: the root node for the supplied node object."""
+        if node.lft == 1:
+            return node
+        return self.tree_model.objects.get(tree_id=node.tree_id, lft=1)
+
+    def get_parent(self, node, update=False):
+        """
+        :returns: the parent node of the supplied node object.
+            Caches the result in the object itself to help in loops.
+        """
+        if node.is_root():
+            return
+        try:
+            if update:
+                del node._cached_parent_obj
+            else:
+                return node._cached_parent_obj
+        except AttributeError:
+            pass
+        # parent = our most direct ancestor
+        node._cached_parent_obj = self.get_ancestors(node).reverse()[0]
+        return node._cached_parent_obj
+
+    def get_ancestors(self, node):
+        """
+        :returns: A queryset containing the node's ancestors,
+            starting by the root node and descending to the parent.
+        """
+        if node.is_root():
+            return self.tree_model.objects.none()
+        return self.tree_model.objects.filter(tree_id=node.tree_id, lft__lt=node.lft, rgt__gt=node.rgt)
+
+    def get_descendants(self, node, include_self=False):
+        """
+        :returns: A queryset of all the node's descendants as DFS, doesn't
+            include the node itself if `include_self` is `False`
+        """
+        manager = self.tree_model.objects
+        if include_self:
+            return manager.get_tree(node)
+        if node.is_leaf():
+            return manager.none()
+        return manager.get_tree(node).exclude(pk=node.pk)
+
+    def _alter_gap(self, tree_id, start_index, offset):
+        """
+        Open or close a gap in the lft/rgt sequence by changing all lft/rgt values greater than or equal to
+        start_index within the given tree by the given offset.
+        """
+        output_field = models.PositiveIntegerField()
+        queryset = self.tree_model.objects.filter(rgt__gte=start_index, tree_id=tree_id)
+        update_count = queryset.update(
+            lft=Case(When(lft__gte=start_index, then=F("lft") + offset), default=F("lft"), output_field=output_field),
+            rgt=F("rgt") + offset,
+        )
+        if update_count > 0:
+            gap_altered.send(
+                sender=self.tree_model, tree_id=tree_id, start_index=start_index, offset=offset, using=queryset.db
             )
-        return errors
+
+    def _move_tree_right(self, tree_id):
+        queryset = self.tree_model.objects.filter(tree_id__gte=tree_id)
+        update_count = queryset.update(tree_id=F("tree_id") + 1)
+        if update_count > 0:
+            tree_ids_incremented.send(sender=self.tree_model, min_tree_id=tree_id, using=queryset.db)
+
+    def _close_gap(self, drop_lft, drop_rgt, tree_id):
+        gapsize = drop_rgt - drop_lft + 1
+        self._alter_gap(tree_id, drop_lft, -gapsize)
+
+
+class NS_Node(Node):
+    """Abstract model to create your own Nested Sets Trees."""
+
+    node_order_by = []
+
+    lft = models.PositiveIntegerField(db_index=True)
+    rgt = models.PositiveIntegerField(db_index=True)
+    tree_id = models.PositiveIntegerField(db_index=True)
+    depth = models.PositiveIntegerField(db_index=True)
+
+    TREEBEARD_IDENTIFYING_FIELD = "lft"
+    MOVENODE_FORM_EXCLUDED_FIELDS = ("depth", "lft", "rgt", "tree_id")
+    _DEFAULT_TREEBEARD_MANAGER = NS_NodeManager
+
+    objects = NS_NodeManager()
+
+    _cached_attributes = (
+        *Node._cached_attributes,
+        "_cached_parent_obj",
+    )
+
+    def get_depth(self):
+        """:returns: the depth (level) of the node"""
+        return self.depth
+
+    def is_leaf(self):
+        """:returns: True if the node is a leaf node (else, returns False)"""
+        return self.rgt - self.lft == 1
+
+    def is_root(self):
+        """:returns: True if the node is a root node (else, returns False)"""
+        return self.lft == 1
+
+    def is_descendant_of(self, node):
+        """
+        :returns: ``True`` if the node if a descendant of another node given
+            as an argument, else, returns ``False``
+        """
+        return self.tree_id == node.tree_id and self.lft > node.lft and self.rgt < node.rgt
 
     class Meta:
         """Abstract model."""

--- a/treebeard/templatetags/admin_tree.py
+++ b/treebeard/templatetags/admin_tree.py
@@ -4,11 +4,11 @@ from django.template import Library
 register = Library()
 
 
-def _get_parent_id(node):
+def _get_parent_id(node, model):
     """Return the node's parent id or 0 if node is a root node."""
     if node.is_root():
         return 0
-    return node.get_parent().pk
+    return model.objects.get_parent(node).pk
 
 
 @register.inclusion_tag("admin/change_list_results.html")
@@ -26,7 +26,7 @@ def tree_context(cl):
     return [
         {
             "node-id": str(obj.pk),
-            "parent-id": _get_parent_id(obj),
+            "parent-id": _get_parent_id(obj, cl.model),
             "level": obj.get_depth(),
             "has-children": int(not obj.is_leaf()),
         }

--- a/treebeard/templatetags/admin_tree_list.py
+++ b/treebeard/templatetags/admin_tree_list.py
@@ -28,7 +28,7 @@ def _line(context, node, request):
 
 def _subtree(context, node, request):
     tree = ""
-    for subnode in node.get_children():
+    for subnode in node._meta.model.objects.get_children(node):
         tree += format_html("<li>{}</li>", mark_safe(_subtree(context, subnode, request)))
     if tree:
         tree = format_html("<ul>{}</ul>", mark_safe(tree))
@@ -38,6 +38,6 @@ def _subtree(context, node, request):
 @register.simple_tag(takes_context=True)
 def result_tree(context, cl, request):
     tree = ""
-    for root_node in cl.model.get_root_nodes():
+    for root_node in cl.model.objects.get_root_nodes():
         tree += format_html("<li>{}</li>", mark_safe(_subtree(context, root_node, request)))
     return format_html("<ul>{}</ul>", mark_safe(tree))

--- a/treebeard/utils.py
+++ b/treebeard/utils.py
@@ -1,8 +1,11 @@
+import inspect
 from typing import Any, TypedDict
 
 from django.core import serializers
 from django.core.serializers.base import DeserializedObject
 from django.db import models
+
+from treebeard.exceptions import NodeAlreadySaved
 
 
 class DumpData(TypedDict):
@@ -36,3 +39,32 @@ def save_m2m(node: models.Model, deserialized_obj: DeserializedObject):
         for accessor_name, object_list in deserialized_obj.m2m_data.items():
             getattr(node, accessor_name).set(object_list)
         deserialized_obj.m2m_data = None  # Avoid accidental reuse of m2m_data if save() is called on the object
+
+
+def check_create_args(func):
+    """
+    Decorator to validate `create_kwargs` and `instance` parameters for methods that
+    create new model objects.
+
+    - Ensures that only one of `create_kwargs` and `instance` are set.
+    - If `instance` is provided, ensures that is it an unsaved model object
+    """
+    sig = inspect.signature(func)
+
+    def wrapper(*args, **kwargs):
+        bound = sig.bind(*args, **kwargs)
+        instance = bound.arguments.get("instance")
+        create_kwargs = bound.arguments.get("create_kwargs")
+
+        if instance and create_kwargs:
+            raise ValueError("Only one of create_kwargs and instance is allowed.")
+
+        if instance is None and create_kwargs is None:
+            raise ValueError("Either create_kwargs or instance must be supplied")
+
+        if instance and not instance._state.adding:
+            raise NodeAlreadySaved("Attempted to add a tree node that is already in the database")
+
+        return func(*args, **kwargs)
+
+    return wrapper


### PR DESCRIPTION
Moves table-level functionality that was previously implemented as methods on the model class, to methods on the model manager, which is the [preferred pattern](https://docs.djangoproject.com/en/stable/topics/db/managers/#adding-extra-manager-methods) with Django. Retains backward-compatibility on the old methods, which will be dropped in the next major release.

This change will be shipped as a major release.

The backward compatibility only works if a project using Treebeard has not replaced the default model manager with one that doesn't subclass Treebeard's manager. A [warning was added for this case](https://github.com/django-treebeard/django-treebeard/commit/bd8b2483c359f0ad459b0c36f21e5a5b6e0036b1) in the previous release, which here is changed to an error. We are relying on such projects pinning at least major versions for this not to break things.

I have duplicated the old test suite to use the deprecated API, to make sure back-compat works.

Most of the diff here is just functions moving from one place to another. I have noted in comments the areas that I think would benefit from review.

Fixes #44