### PR TITLE
Add max_depth param to tree and descendant query APIs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+Next release (in development)
+-----------------------------
+
+- Added a `max_depth` argument to the `get_tree` and `get_descendant` methods, 
+  to allow control over the depth of the tree that is returned.
+- Improved the efficiency of `get_descendant_count()` to use a database count instead
+  of fetching the entire queryset (for MP, NS and LT implementations).
+
 
 Release 6.0.0 (Jul 20, 2026)
 ------------------------------

--- a/docs/source/al_tree.rst
+++ b/docs/source/al_tree.rst
@@ -111,3 +111,9 @@ slow reads. If you read more than you write, use
 
 .. autoclass:: AL_NodeManager
   :show-inheritance:
+
+  .. automethod:: get_tree
+
+     .. note::
+
+        This method returns a list, not a queryset.

--- a/docs/source/mp_tree.rst
+++ b/docs/source/mp_tree.rst
@@ -215,14 +215,6 @@ extra steps, materialized path is more efficient than other approaches.
 .. autoclass:: MP_NodeManager
   :show-inheritance:
 
-  .. automethod:: get_tree
-
-     See: :meth:`treebeard.models.NodeManager.get_tree`
-
-     .. note::
-
-        This method returns a queryset.
-
   .. automethod:: find_problems
 
    Example:

--- a/tests/test_treebeard.py
+++ b/tests/test_treebeard.py
@@ -368,6 +368,50 @@ class TestClassMethods(TestNonEmptyTree):
         assert got == UNCHANGED
         assert all(isinstance(o, model) for o in nodes)
 
+    def test_get_tree_max_depth(self, model, django_assert_max_num_queries):
+        # Max depth of 2
+        max_queries = 3 if issubclass(model, AL_Node) else 1
+        with django_assert_max_num_queries(max_queries):
+            nodes = model.objects.get_tree(max_depth=2)
+        got = [(o.desc, o.get_depth(), model.objects.get_children_count(o)) for o in nodes]
+        assert got == [
+            ("1", 1, 0),
+            ("2", 1, 4),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 1),
+            ("24", 2, 0),
+            ("3", 1, 0),
+            ("4", 1, 1),
+            ("41", 2, 0),
+        ]
+
+        # Max depth of 1
+        max_queries = 2 if issubclass(model, AL_Node) else 1
+        with django_assert_max_num_queries(max_queries):
+            nodes = model.objects.get_tree(max_depth=1)
+        got = [(o.desc, o.get_depth(), model.objects.get_children_count(o)) for o in nodes]
+        assert got == [
+            ("1", 1, 0),
+            ("2", 1, 4),
+            ("3", 1, 0),
+            ("4", 1, 1),
+        ]
+
+    def test_get_tree_max_depth_relative_to_parent(self, model, django_assert_max_num_queries):
+        parent = model.objects.get(desc="2")
+        max_queries = 3 if issubclass(model, AL_Node) else 1
+        with django_assert_max_num_queries(max_queries):
+            nodes = model.objects.get_tree(parent=parent, max_depth=1)
+        got = [(o.desc, o.get_depth(), model.objects.get_children_count(o)) for o in nodes]
+        assert got == [
+            ("2", 1, 4),
+            ("21", 2, 0),
+            ("22", 2, 0),
+            ("23", 2, 1),
+            ("24", 2, 0),
+        ]
+
     def test_dump_bulk_all(self, model):
         assert model.objects.dump_bulk(keep_ids=False) == BASE_DATA
 
@@ -806,6 +850,22 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
             assert [node.desc for node in nodes] == expected
             assert all(isinstance(node, model) for node in nodes)
 
+    def test_get_descendants_max_depth(self, model, django_assert_max_num_queries):
+        data = [
+            ("2", ["21", "22", "23", "24"]),
+            ("23", ["231"]),
+            ("231", []),
+            ("1", []),
+            ("4", ["41"]),
+        ]
+        for desc, expected in data:
+            parent = model.objects.get(desc=desc)
+            max_queries = 3 if issubclass(model, AL_Node) else 1
+            with django_assert_max_num_queries(max_queries):
+                nodes = model.objects.get_descendants(parent, max_depth=1)
+            assert [node.desc for node in nodes] == expected
+            assert all(isinstance(node, model) for node in nodes)
+
     def test_get_descendants_include_self(self, model, django_assert_max_num_queries):
         data = [
             ("2", ["2", "21", "22", "23", "231", "24"]),
@@ -835,6 +895,21 @@ class TestSimpleNodeMethods(TestNonEmptyTree):
             max_queries = 3 if issubclass(model, AL_Node) else 1
             with django_assert_max_num_queries(max_queries):
                 got = model.objects.get_descendant_count(parent)
+            assert got == expected
+
+    def test_get_descendant_count_max_depth(self, model, django_assert_max_num_queries):
+        data = [
+            ("2", 4),
+            ("23", 1),
+            ("231", 0),
+            ("1", 0),
+            ("4", 1),
+        ]
+        for desc, expected in data:
+            parent = model.objects.get(desc=desc)
+            max_queries = 3 if issubclass(model, AL_Node) else 1
+            with django_assert_max_num_queries(max_queries):
+                got = model.objects.get_descendant_count(parent, max_depth=1)
             assert got == expected
 
     def test_is_sibling_of(self, model, django_assert_max_num_queries):

--- a/treebeard/al_tree.py
+++ b/treebeard/al_tree.py
@@ -21,22 +21,33 @@ class AL_NodeManager(NodeManager):
             order_by = ["parent", "sib_order"]
         return super().get_queryset().order_by(*order_by)
 
-    def get_tree(self, parent=None):
+    def get_tree(self, parent=None, max_depth: int | None = None):
         """
-        :returns: A list of nodes ordered as DFS, including the parent. If
-                  no parent is given, the entire tree is returned.
+        :returns:
+
+            A list of nodes ordered as DFS, including the parent. If
+            no parent is given, the entire tree is returned.
+
+            If max_depth is set then the tree is limited to the specified depth, relative
+            to the parent (or the root if no parent is specified).
         """
         if parent:
             depth = parent.get_depth() + 1
             parent.node_has_children = self.get_children(parent).exists()
             results = [parent]
+            if max_depth:
+                max_depth += parent.get_depth()
         else:
             depth = 1
             results = []
-        self._get_tree_recursively(results, parent, depth)
+
+        self._get_tree_recursively(results, parent, depth, max_depth=max_depth)
         return results
 
-    def _get_tree_recursively(self, results, parent, depth):
+    def _get_tree_recursively(self, results, parent, depth, max_depth):
+        if max_depth and depth > max_depth:
+            return results
+
         if parent:
             qs = self.get_children(parent) if parent.node_has_children else self.none()
         else:
@@ -48,7 +59,7 @@ class AL_NodeManager(NodeManager):
         for node in qs:
             node._cached_depth = depth
             results.append(node)
-            self._get_tree_recursively(results, node, depth + 1)
+            self._get_tree_recursively(results, node, depth + 1, max_depth=max_depth)
 
     @transaction.atomic
     @check_create_args
@@ -193,17 +204,24 @@ class AL_NodeManager(NodeManager):
             return self.tree_model.objects.filter(parent_id=node.parent_id)
         return self.get_root_nodes()
 
-    def get_descendants(self, node, include_self=False):
+    def get_descendants(self, node, include_self=False, max_depth: int | None = None):
         """
         :returns: A *list* of all the node's descendants, doesn't
             include the node itself if `include_self` is False
+
+            If max_depth is set then the tree is limited to the specified depth relative
+            to the node.
         """
-        tree = self.tree_model.objects.get_tree(node)
+        tree = self.tree_model.objects.get_tree(node, max_depth=max_depth)
         return tree if include_self else tree[1:]
 
-    def get_descendant_count(self, node):
-        """:returns: the number of descendants of a node"""
-        return len(self.get_descendants(node))
+    def get_descendant_count(self, node, max_depth: int | None = None):
+        """:returns: the number of descendants of a node
+
+        If max_depth is set then the count is limited to the specified depth relative
+        to the node.
+        """
+        return len(self.get_descendants(node, max_depth=max_depth))
 
     def get_prev_sibling(self, node):
         return self.get_siblings(node).filter(sib_order__lt=node.sib_order).last()

--- a/treebeard/ltree/__init__.py
+++ b/treebeard/ltree/__init__.py
@@ -138,20 +138,26 @@ class LT_NodeManager(NodeManager):
         """Sets the custom queryset as the default."""
         return LT_NodeQuerySet(self.model, using=self._db).order_by("path")
 
-    def get_tree(self, parent=None):
+    def get_tree(self, parent=None, max_depth: int | None = None):
         """
         :returns:
 
-            A *queryset* of nodes ordered as DFS, including the parent.
-            If no parent is given, the entire tree is returned.
+            A queryset of nodes ordered as DFS, including the parent. If
+            no parent is given, the entire tree is returned.
+
+            If max_depth is set then the tree is limited to the specified depth, relative
+            to the parent (or the root if no parent is specified).
         """
         cls = self.tree_model
 
-        if parent is None:
-            # return the entire tree
-            return cls.objects.all()
+        filters = {}
+        if parent:
+            filters["path__descendants"] = parent.path
 
-        return cls.objects.filter(path__descendants=parent.path)
+        if max_depth:
+            filters["path__depth__lte"] = max_depth + (parent.get_depth() if parent else 0)
+
+        return cls.objects.filter(**filters)
 
     @transaction.atomic
     @check_create_args
@@ -506,16 +512,19 @@ class LT_NodeManager(NodeManager):
         """
         return self.get_siblings(node).filter(path__gt=node.path).first()
 
-    def get_descendants(self, node, include_self=False):
+    def get_descendants(self, node, include_self=False, max_depth: int | None = None):
         """
         :returns: A queryset of all the node's descendants as DFS, doesn't
             include the node itself if `include_self` is False
+
+            If max_depth is set then the tree is limited to the specified depth relative
+            to the node.
         """
         manager = self.tree_model.objects
         if include_self:
-            return manager.get_tree(node)
+            return manager.get_tree(node, max_depth=max_depth)
 
-        return manager.get_tree(node).exclude(pk=node.pk)
+        return manager.get_tree(node, max_depth=max_depth).exclude(pk=node.pk)
 
     def get_prev_sibling(self, node):
         """

--- a/treebeard/models.py
+++ b/treebeard/models.py
@@ -202,12 +202,15 @@ class NodeManager(models.Manager):
 
         return base_class
 
-    def get_tree(self, parent=None):  # pragma: no cover
+    def get_tree(self, parent=None, max_depth: int | None = None):  # pragma: no cover
         """
         :returns:
 
-            A list of nodes ordered as DFS, including the parent. If
+            A queryset of nodes ordered as DFS, including the parent. If
             no parent is given, the entire tree is returned.
+
+            If max_depth is set then the tree is limited to the specified depth, relative
+            to the parent (or the root if no parent is specified).
         """
         raise NotImplementedError
 
@@ -519,18 +522,25 @@ class NodeManager(models.Manager):
         """
         raise NotImplementedError
 
-    def get_descendants(self, node, include_self=False):
+    def get_descendants(self, node, include_self=False, max_depth: int | None = None):
         """
         :returns:
 
             A queryset of all the node's descendants, doesn't
             include the node itself if include_self is False.
+
+            If max_depth is set then the tree is limited to the specified depth relative
+            to the node.
         """
         raise NotImplementedError
 
-    def get_descendant_count(self, node):
-        """:returns: the number of descendants of a node."""
-        return self.get_descendants(node).count()
+    def get_descendant_count(self, node, max_depth: int | None = None):
+        """:returns: the number of descendants of a node
+
+        If max_depth is set then the count is limited to the specified depth relative
+        to the node.
+        """
+        return self.get_descendants(node, max_depth=max_depth).count()
 
     def get_first_child(self, node):
         """

--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -96,21 +96,31 @@ class MP_NodeManager(NodeManager):
         """Sets the custom queryset as the default."""
         return MP_NodeQuerySet(self.model, using=self._db).order_by("path")
 
-    def get_tree(self, parent=None):
+    def get_tree(self, parent=None, max_depth: int | None = None):
         """
         :returns:
 
-            A *queryset* of nodes ordered as DFS, including the parent.
-            If no parent is given, the entire tree is returned.
+            A queryset of nodes ordered as DFS, including the parent. If
+            no parent is given, the entire tree is returned.
+
+            If max_depth is set then the tree is limited to the specified depth, relative
+            to the parent (or the root if no parent is specified).
         """
         cls = self.tree_model
 
-        if parent is None:
-            # return the entire tree
-            return cls.objects.all()
-        if parent.is_leaf():
+        if parent and parent.is_leaf():
             return cls.objects.filter(pk=parent.pk)
-        return cls.objects.filter(path__startswith=parent.path, depth__gte=parent.depth).order_by("path")
+
+        filters = {}
+
+        if parent:
+            filters["path__startswith"] = parent.path
+            filters["depth__gte"] = parent.depth
+
+        if max_depth is not None:
+            filters["depth__lte"] = max_depth + (parent.depth if parent else 0)
+
+        return cls.objects.filter(**filters)
 
     def fix_tree(self, fix_paths=False, parent=None):
         """
@@ -855,6 +865,8 @@ class MP_NodeManager(NodeManager):
         """:returns: A queryset of all the node's children"""
         if node.is_leaf():
             return self.tree_model.objects.none()
+
+        # Using the path interval generates a more efficient database query than just specifying a path prefix
         return self.tree_model.objects.filter(
             depth=node.depth + 1, path__range=node._get_children_path_interval(node.path)
         ).order_by("path")
@@ -878,17 +890,20 @@ class MP_NodeManager(NodeManager):
             qset = qset.filter(path__range=node._get_children_path_interval(parentpath))
         return qset
 
-    def get_descendants(self, node, include_self=False):
+    def get_descendants(self, node, include_self=False, max_depth: int | None = None):
         """
         :returns: A queryset of all the node's descendants as DFS, doesn't
             include the node itself if `include_self` is False
+
+            If max_depth is set then the tree is limited to the specified depth relative
+            to the node.
         """
         manager = self.tree_model.objects
         if include_self:
-            return manager.get_tree(node)
+            return manager.get_tree(node, max_depth=max_depth)
         if node.is_leaf():
             return manager.none()
-        return manager.get_tree(node).exclude(pk=node.pk)
+        return manager.get_tree(node, max_depth=max_depth).exclude(pk=node.pk)
 
     def get_root(self, node):
         """:returns: the root node for the current node object."""

--- a/treebeard/ns_tree.py
+++ b/treebeard/ns_tree.py
@@ -83,21 +83,31 @@ class NS_NodeManager(NodeManager):
         """Sets the custom queryset as the default."""
         return NS_NodeQuerySet(self.model, using=self._db).order_by("tree_id", "lft")
 
-    def get_tree(self, parent=None):
+    def get_tree(self, parent=None, max_depth: int | None = None):
         """
         :returns:
 
-            A *queryset* of nodes ordered as DFS, including the parent.
-            If no parent is given, all trees are returned.
+            A queryset of nodes ordered as DFS, including the parent. If
+            no parent is given, the entire tree is returned.
+
+            If max_depth is set then the tree is limited to the specified depth, relative
+            to the parent (or the root if no parent is specified).
         """
         cls = self.tree_model
 
-        if parent is None:
-            # return the entire tree
-            return cls.objects.all()
-        if parent.is_leaf():
+        if parent and parent.is_leaf():
             return cls.objects.filter(pk=parent.pk)
-        return cls.objects.filter(tree_id=parent.tree_id, lft__range=(parent.lft, parent.rgt - 1))
+
+        filters = {}
+
+        if parent:
+            filters["tree_id"] = parent.tree_id
+            filters["lft__range"] = (parent.lft, parent.rgt - 1)
+
+        if max_depth:
+            filters["depth__lte"] = max_depth + (parent.depth if parent else 0)
+
+        return cls.objects.filter(**filters)
 
     @transaction.atomic
     @check_create_args
@@ -496,9 +506,16 @@ class NS_NodeManager(NodeManager):
             return self.get_root_nodes()
         return self.get_children(self.get_parent(node, True))
 
-    def get_descendant_count(self, node):
-        """:returns: the number of descendants of a node."""
-        return (node.rgt - node.lft - 1) / 2
+    def get_descendant_count(self, node, max_depth: int | None = None):
+        """:returns: the number of descendants of a node.
+
+        If max_depth is set then the count is limited to the specified depth relative
+        to the node.
+        """
+        if not max_depth:
+            return (node.rgt - node.lft - 1) / 2
+
+        return self.get_descendants(node, max_depth=max_depth).count()
 
     def get_root(self, node):
         """:returns: the root node for the supplied node object."""
@@ -533,17 +550,20 @@ class NS_NodeManager(NodeManager):
             return self.tree_model.objects.none()
         return self.tree_model.objects.filter(tree_id=node.tree_id, lft__lt=node.lft, rgt__gt=node.rgt)
 
-    def get_descendants(self, node, include_self=False):
+    def get_descendants(self, node, include_self=False, max_depth: int | None = None):
         """
         :returns: A queryset of all the node's descendants as DFS, doesn't
             include the node itself if `include_self` is `False`
+
+            If max_depth is set then the tree is limited to the specified depth relative
+            to the node.
         """
         manager = self.tree_model.objects
         if include_self:
-            return manager.get_tree(node)
+            return manager.get_tree(node, max_depth=max_depth)
         if node.is_leaf():
             return manager.none()
-        return manager.get_tree(node).exclude(pk=node.pk)
+        return manager.get_tree(node, max_depth=max_depth).exclude(pk=node.pk)
 
     def _alter_gap(self, tree_id, start_index, offset):
         """


### PR DESCRIPTION
Adds a `max_depth` argument to the following methods, that will limit the tree to that depth relative to the parent node:

- `get_tree()`
- `get_descendants()`
- `get_descendant_count()`

This allows efficiently fetching a shallow tree, .e.g for list views.