### PR TITLE
Fix silent no-op on sorted move across parents

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -17,7 +17,7 @@ Contributions made by:
     * Alexei Vlasov
     * moberley
     * czare1
-    * Fernando Gutierrez (xbito) 
+    * Fernando Gutierrez (xbito)
     * Jens Diemer
     * Jacob Rief
     * Maik Hoepfel
@@ -25,3 +25,4 @@ Contributions made by:
     * Johannes Wilm
     * Awais Qureshi
     * Julian Wachholz
+    * Dominique Barton

--- a/tests/test_treebeard.py
+++ b/tests/test_treebeard.py
@@ -3254,6 +3254,39 @@ class TestTreeSorted(TestTreeBase):
         ]
         assert self.got(sorted_model) == expected
 
+    def test_move_sorted_back_under_previous_parent(self, sorted_model):
+        # Regression test: a sorted move used to be silently skipped when the
+        # node's last path segment happened to match the computed target slot,
+        # even though the node lived under a different parent.
+        # For more information see:
+        # https://github.com/django-treebeard/django-treebeard/issues/414
+        root = sorted_model.objects.add_root({"val1": 1, "val2": 1, "desc": "rt"})
+        parent = sorted_model.objects.add_child(root, {"val1": 2, "val2": 1, "desc": "prt"})
+        for val1, desc in ((1, "ac1"), (2, "ac2"), (3, "ac3")):
+            parent = sorted_model.objects.get(pk=parent.pk)
+            sorted_model.objects.add_child(parent, {"val1": val1, "val2": 1, "desc": desc})
+
+        # Move ac1 up under the root: it sorts before its old parent, taking
+        # the position whose last path segment collides with the slot computed
+        # for the move back below.
+        ac1 = sorted_model.objects.get(desc="ac1")
+        root = sorted_model.objects.get(pk=root.pk)
+        sorted_model.objects.move(ac1, root, "sorted-child")
+
+        # ... and move it back under its old parent.
+        ac1 = sorted_model.objects.get(desc="ac1")
+        parent = sorted_model.objects.get(pk=parent.pk)
+        sorted_model.objects.move(ac1, parent, "sorted-child")
+
+        expected = [
+            (1, 1, "rt", 1, 1),
+            (2, 1, "prt", 2, 3),
+            (1, 1, "ac1", 3, 0),
+            (2, 1, "ac2", 3, 0),
+            (3, 1, "ac3", 3, 0),
+        ]
+        assert self.got(sorted_model) == expected
+
 
 @pytest.mark.django_db
 class TestInheritedModels(TestTreeBase):

--- a/treebeard/mp_tree.py
+++ b/treebeard/mp_tree.py
@@ -500,8 +500,11 @@ class MP_NodeManager(NodeManager):
             siblings = self.get_sorted_pos_queryset(self.get_siblings(target), node)
             if first := siblings.first():
                 newpos = first._get_lastpos_in_path()
-                if node._get_lastpos_in_path() == newpos - 1:
-                    # The node is already in the right place, nothing to do
+                node_parentpath = node._get_basepath(node.path, node.depth - 1)
+                first_parentpath = first._get_basepath(first.path, first.depth - 1)
+                if node_parentpath == first_parentpath and node._get_lastpos_in_path() == newpos - 1:
+                    # The node is already in the right place (same parent,
+                    # right before the computed sibling), nothing to do
                     return
             else:
                 newpos = None


### PR DESCRIPTION
The "already in the right place" shortcut in MP_NodeManager.move() only compared the node's last path segment against the computed target slot. When the segment matched (e.g. moving a node back under its previous parent), the move was silently skipped even though the node lived under a completely different parent.

Also require the node to share the parent path with the computed sibling before treating the move as a no-op.

Fixes #414 